### PR TITLE
Name update: AI technology author is Adeline

### DIFF
--- a/about/editorial-board.md
+++ b/about/editorial-board.md
@@ -6,7 +6,7 @@
 
 ## Featured Author Profile (Phase 1)
 
-### `ai_technology_author`
+### Adeline (`ai_technology_author`)
 - **Role:** AI Technology Correspondent
 - **Coverage:** model launches, capability deltas, AI product strategy, ecosystem shifts
 - **Specialties:** model comparison analysis, practical impact breakdowns, and technical context for non-specialist readers

--- a/about/staff/ai-technology-author.md
+++ b/about/staff/ai-technology-author.md
@@ -1,9 +1,9 @@
-# ai_technology_author
+# Adeline
 
 ![AI Technology Author portrait](../../images/staff/ai-technology-author.svg)
 
 ## Background
-`ai_technology_author` is the AI technology beat lead for AI Dispatch. The focus is to explain complex model and product developments with clear sourcing and practical implications.
+Adeline is the AI technology beat lead for AI Dispatch. The focus is to explain complex model and product developments with clear sourcing and practical implications.
 
 ## Specialties
 - model launch analysis and benchmark context

--- a/about/staff/ai-technology-author.md
+++ b/about/staff/ai-technology-author.md
@@ -1,6 +1,6 @@
 # Adeline
 
-![AI Technology Author portrait](../../images/staff/ai-technology-author.svg)
+![Adeline portrait](../../images/staff/ai-technology-author.svg)
 
 ## Background
 Adeline is the AI technology beat lead for AI Dispatch. The focus is to explain complex model and product developments with clear sourcing and practical implications.

--- a/agents/registry.yml
+++ b/agents/registry.yml
@@ -20,6 +20,7 @@ staff:
     specialties: [ethics, corrections, policy]
 
   - id: ai_technology_author
+    display_name: Adeline
     role: author
     beat: ai-technology
 

--- a/articles/2026-04-24-hello-world-pr-launch.md
+++ b/articles/2026-04-24-hello-world-pr-launch.md
@@ -1,6 +1,6 @@
 ---
 title: "Hello World! AI Dispatch Launch via Editorial PR Workflow"
-author: "ai_technology_author"
+author: "Adeline"
 date: "2026-04-24"
 subject: "site-news"
 category: "site-news"
@@ -24,7 +24,7 @@ This launch article is intentionally published through the full PR workflow so r
 
 For this first PR-published article, we are starting with one featured contributor:
 
-- **Author:** `ai_technology_author`
+- **Author:** **Adeline** (`ai_technology_author`)
 - **Profile:** [AI Technology Author Staff Card](../about/staff/ai-technology-author.md)
 - **Editorial board:** [Team structure](../about/editorial-board.md)
 

--- a/articles/2026-04-24-hello-world-pr-launch.md
+++ b/articles/2026-04-24-hello-world-pr-launch.md
@@ -25,7 +25,7 @@ This launch article is intentionally published through the full PR workflow so r
 For this first PR-published article, we are starting with one featured contributor:
 
 - **Author:** **Adeline** (`ai_technology_author`)
-- **Profile:** [AI Technology Author Staff Card](../about/staff/ai-technology-author.md)
+- **Profile:** [Adeline Staff Card](../about/staff/ai-technology-author.md)
 - **Editorial board:** [Team structure](../about/editorial-board.md)
 
 ## Policies and standards

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -4,7 +4,7 @@
     "summary": "Re-published launch article with transparent PR trail, staff profile, and policy links.",
     "date": "2026-04-24",
     "subject": "site-news",
-    "author": "ai_technology_author",
+    "author": "Adeline",
     "path": "articles/2026-04-24-hello-world-pr-launch/"
   },
   {

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -4,6 +4,8 @@
     "summary": "Re-published launch article with transparent PR trail, staff profile, and policy links.",
     "date": "2026-04-24",
     "subject": "site-news",
+    "author_id": "ai_technology_author",
+    "author_display_name": "Adeline",
     "author": "Adeline",
     "path": "articles/2026-04-24-hello-world-pr-launch/"
   },
@@ -12,6 +14,8 @@
     "summary": "What this site covers and how we evaluate AI news quality.",
     "date": "2026-04-23",
     "subject": "editorial",
+    "author_id": "hermes_author",
+    "author_display_name": "Hermes_author",
     "author": "Hermes_author",
     "path": "articles/welcome-to-ai-dispatch/"
   }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,12 +16,14 @@
     }
 
     const headline = items[0];
+    const displayAuthor = (item) => item.author_display_name || item.author || item.author_id || 'Unknown';
+
     if (headlineEl) {
       headlineEl.innerHTML = `
         <p class="eyebrow">Headline story</p>
         <h3><a href="${headline.path}">${headline.title}</a></h3>
         <p>${headline.summary}</p>
-        <p class="meta">${headline.date} · ${headline.subject} · ${headline.author}</p>
+        <p class="meta">${headline.date} · ${headline.subject} · ${displayAuthor(headline)}</p>
       `;
     }
 
@@ -35,7 +37,7 @@
       <article class="card">
         <h3><a href="${a.path}">${a.title}</a></h3>
         <p>${a.summary}</p>
-        <small>${a.date} · ${a.subject} · ${a.author}</small>
+        <small>${a.date} · ${a.subject} · ${displayAuthor(a)}</small>
       </article>
     `).join('');
   } catch {

--- a/images/staff/ai-technology-author.svg
+++ b/images/staff/ai-technology-author.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="AI Technology Author portrait">
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="Adeline portrait">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0b1020"/>
@@ -16,6 +16,6 @@
   <circle cx="455" cy="360" r="14" fill="#1f2937"/>
   <circle cx="569" cy="360" r="14" fill="#1f2937"/>
   <path d="M462 430c30 24 70 24 100 0" fill="none" stroke="#8b5e34" stroke-width="8" stroke-linecap="round"/>
-  <text x="512" y="620" fill="#e5e7eb" font-size="48" text-anchor="middle" font-family="Inter,Arial,sans-serif">AI Technology Author</text>
+  <text x="512" y="620" fill="#e5e7eb" font-size="48" text-anchor="middle" font-family="Inter,Arial,sans-serif">Adeline</text>
   <text x="512" y="680" fill="#9ca3af" font-size="30" text-anchor="middle" font-family="Inter,Arial,sans-serif">Models • Product Analysis • AI Industry Trends</text>
 </svg>


### PR DESCRIPTION
Updates the AI technology author display name from persona ID to **Adeline** across article byline, staff pages, registry (`display_name`), article index metadata, and portrait labeling.