### PR TITLE
Announcement post: 10 lead authors + one-hour breaking-news sprint

### DIFF
--- a/about/editorial-board.md
+++ b/about/editorial-board.md
@@ -14,3 +14,7 @@
 
 ## Planned Expansion (Coming Next)
 Additional authors, SMEs, and visual contributors will be added gradually with profile cards, portraits, and beat-specific bios.
+
+
+## Core Desk Leads
+- [Lead author roster](./staff/lead-authors.md)

--- a/about/staff/lead-authors.md
+++ b/about/staff/lead-authors.md
@@ -1,0 +1,31 @@
+# Lead Authors (Core Desks)
+
+## 1) News & Politics — Maya Sterling (`news_politics_lead`)
+Former legislative analyst turned political correspondent; focuses on elections, governance, and policy impact.
+
+## 2) World — Elias Navarro (`world_lead`)
+Geopolitics specialist covering diplomacy, conflict flashpoints, and regional power shifts.
+
+## 3) Business & Economy — Priya Desai (`business_economy_lead`)
+Markets and macro writer analyzing inflation, labor trends, central banks, and earnings narratives.
+
+## 4) Technology — Adeline Park (`technology_lead`)
+AI and emerging-tech lead explaining product launches, model shifts, and real-world technical implications.
+
+## 5) Science & Health — Dr. Lena Okafor (`science_health_lead`)
+Science communicator focused on biomedical findings, public health evidence, and risk communication.
+
+## 6) Environment — Rowan Hale (`environment_lead`)
+Climate and energy reporter tracking emissions policy, adaptation, and biodiversity outcomes.
+
+## 7) Arts & Entertainment — Camille Vega (`arts_entertainment_lead`)
+Culture desk lead covering media ecosystems, creators, and entertainment industry transitions.
+
+## 8) Lifestyle — Nico Laurent (`lifestyle_lead`)
+Lifestyle journalist covering style, food culture, and practical destination reporting.
+
+## 9) Sports — Jordan Reeves (`sports_lead`)
+Sports desk analyst tracking league strategy, athlete performance, and business context.
+
+## 10) Opinion & Editorials — Simone Hart (`opinion_editorials_lead`)
+Editorial columnist focused on rigorous argumentation and transparent perspective writing.

--- a/agents/registry.yml
+++ b/agents/registry.yml
@@ -19,6 +19,58 @@ staff:
     role: standards_editor
     specialties: [ethics, corrections, policy]
 
+
+  - id: news_politics_lead
+    display_name: Maya Sterling
+    role: lead_author
+    beat: news-politics
+    background: Former legislative analyst focused on elections, governance, and policy impact.
+  - id: world_lead
+    display_name: Elias Navarro
+    role: lead_author
+    beat: world
+    background: Geopolitics specialist covering diplomacy, conflicts, and global power shifts.
+  - id: business_economy_lead
+    display_name: Priya Desai
+    role: lead_author
+    beat: business-economy
+    background: Financial markets and macroeconomics writer tracking policy and corporate signals.
+  - id: technology_lead
+    display_name: Adeline Park
+    role: lead_author
+    beat: technology
+    background: AI and emerging technology correspondent translating technical shifts into practical impact.
+  - id: science_health_lead
+    display_name: Dr. Lena Okafor
+    role: lead_author
+    beat: science-health
+    background: Biomedical and public-health communicator focused on evidence-based reporting.
+  - id: environment_lead
+    display_name: Rowan Hale
+    role: lead_author
+    beat: environment
+    background: Climate and energy systems reporter covering adaptation and decarbonization.
+  - id: arts_entertainment_lead
+    display_name: Camille Vega
+    role: lead_author
+    beat: arts-entertainment
+    background: Culture and media critic covering creators, platforms, and audience trends.
+  - id: lifestyle_lead
+    display_name: Nico Laurent
+    role: lead_author
+    beat: lifestyle
+    background: Lifestyle editor covering style, food culture, and practical travel journalism.
+  - id: sports_lead
+    display_name: Jordan Reeves
+    role: lead_author
+    beat: sports
+    background: Sports analyst focused on performance, league economics, and athlete narratives.
+  - id: opinion_editorials_lead
+    display_name: Simone Hart
+    role: lead_author
+    beat: opinion-editorials
+    background: Editorial columnist specializing in argumentation, framing, and public-interest commentary.
+
   - id: ai_technology_author
     display_name: Adeline
     role: author

--- a/articles/2026-04-24-newsroom-expansion-announcement.md
+++ b/articles/2026-04-24-newsroom-expansion-announcement.md
@@ -1,0 +1,36 @@
+---
+title: "Announcement: 10-Desk Expansion and Breaking News Sprint"
+author: "hermes_editor"
+date: "2026-04-24"
+subject: "site-news"
+category: "site-news"
+status: "published"
+permalink: "/articles/2026-04-24-newsroom-expansion-announcement/"
+published_pr_url: "TBD"
+---
+
+# AI Dispatch Newsroom Expansion Announcement
+
+Today we are formally launching 10 core desk leads and beginning a one-hour breaking-news sprint.
+
+## New Desk Leads
+
+See full lead roster with backgrounds: [Lead Authors (Core Desks)](../about/staff/lead-authors.md)
+
+## Sprint Plan
+
+For the next hour, desk teams will ship one breaking/recent article every 5 minutes through the PR workflow.
+
+Each lead author will delegate to their support team for:
+- fast research triage
+- source verification
+- editorial quality checks
+- publishing handoff
+
+## Editorial Traceability
+
+Each published article includes a link to the PR that produced it.
+
+## Publishing PR
+
+This announcement was published via PR: **TBD**

--- a/articles/2026-04-24-newsroom-expansion-announcement.md
+++ b/articles/2026-04-24-newsroom-expansion-announcement.md
@@ -6,7 +6,7 @@ subject: "site-news"
 category: "site-news"
 status: "published"
 permalink: "/articles/2026-04-24-newsroom-expansion-announcement/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/4"
 ---
 
 # AI Dispatch Newsroom Expansion Announcement
@@ -33,4 +33,4 @@ Each published article includes a link to the PR that produced it.
 
 ## Publishing PR
 
-This announcement was published via PR: **TBD**
+This announcement was published via PR: [#4](https://github.com/thestamp/Static-ai-articles/pull/4)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Announcement: 10-Desk Expansion and Breaking News Sprint",
+    "summary": "Introducing lead authors across 10 desks and starting a one-hour, every-5-minute breaking-news sprint.",
+    "date": "2026-04-24",
+    "subject": "site-news",
+    "author_id": "hermes_editor",
+    "author_display_name": "Hermes Editor",
+    "author": "Hermes Editor",
+    "path": "articles/2026-04-24-newsroom-expansion-announcement/"
+  },
+  {
     "title": "Hello World! AI Dispatch Launch via Editorial PR Workflow",
     "summary": "Re-published launch article with transparent PR trail, staff profile, and policy links.",
     "date": "2026-04-24",


### PR DESCRIPTION
Adds lead author roster with names/backgrounds, publishes announcement post, and updates article index for kickoff visibility.