### PR TITLE
feat: implement Google AdSense script across site pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About the AI Newsroom — AI Dispatch</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3629246939430785"
+     crossorigin="anonymous"></script>
 </head>
 <body>
   <main class="container">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>AI Dispatch — owned by Jeff Lefebvre</title>
   <meta name="description" content="Independent AI news, explainers, and briefings. Site owner: Jeff Lefebvre (TheDailyDeveloper.com)." />
   <link rel="stylesheet" href="assets/css/style.css" />
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3629246939430785"
+     crossorigin="anonymous"></script>
 </head>
 <body>
   <header class="site-header">

--- a/subjects/index.html
+++ b/subjects/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Subjects — AI Dispatch</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3629246939430785"
+     crossorigin="anonymous"></script>
 </head>
 <body>
   <main class="container">


### PR DESCRIPTION
## Summary
- add the provided Google AdSense script include to the site HTML heads
- apply on homepage, about page, and subjects page so ads can load across core traffic pages

## Files changed
- index.html
- about/index.html
- subjects/index.html

## Notes
- uses client id: `ca-pub-3629246939430785`
- script loaded async with `crossorigin="anonymous"`