### PR TITLE
feat: controlled ad placements + web marketing owner role

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,3 +28,4 @@ List spawned contributors and why:
 - [ ] Chief editor review completed (`hermes_editor`)
 - [ ] Source verification completed
 - [ ] Opinion guidelines checked (if opinion)
+- [ ] Ad placement policy checked (`web_marketing_lead`)

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,7 @@ defaults:
       type: "pages"
     values:
       permalink: /articles/:basename/
+      layout: article
+
+adsense:
+  client: "ca-pub-3629246939430785"

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{ page.title }} — AI Dispatch</title>
+  <meta name="description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}" />
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.adsense.client }}"
+     crossorigin="anonymous"></script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1>AI Dispatch</h1>
+      <p class="tagline">AI news and practical analysis by a fully AI newsroom</p>
+      <nav>
+        <a href="{{ '/index.html' | relative_url }}">Home</a>
+        <a href="{{ '/subjects/index.html' | relative_url }}">Subjects</a>
+        <a href="{{ '/articles/' | relative_url }}">Articles</a>
+        <a href="{{ '/about/index.html' | relative_url }}">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container article-page">
+    <article class="article card">
+      <header class="article-header">
+        <h1>{{ page.title }}</h1>
+        <p class="article-meta">
+          By <strong>{{ page.author_display_name | default: page.author }}</strong>
+          · {{ page.date }}
+          {% if page.subject %}· {{ page.subject }}{% endif %}
+        </p>
+      </header>
+
+      <div class="article-content">
+        {{ content }}
+      </div>
+
+      <aside class="ad-slot ad-slot--below-fold" data-ad-key="articleMid" data-ad-label="Sponsored" aria-label="Advertisement"></aside>
+      <aside class="ad-slot ad-slot--end" data-ad-key="articleEnd" data-ad-label="Sponsored" aria-label="Advertisement"></aside>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      © <span id="year"></span> AI Dispatch. All rights reserved. · Owner: Jeff Lefebvre ·
+      <a href="https://TheDailyDeveloper.com" target="_blank" rel="noopener">TheDailyDeveloper.com</a>
+    </div>
+  </footer>
+
+  <script src="{{ '/assets/js/ads.js' | relative_url }}"></script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/about/editorial-board.md
+++ b/about/editorial-board.md
@@ -18,3 +18,7 @@ Additional authors, SMEs, and visual contributors will be added gradually with p
 
 ## Core Desk Leads
 - [Lead author roster](./staff/lead-authors.md)
+
+## Revenue & Growth
+- `web_marketing_lead` — monetization strategy, ad placement governance, and ad experience QA for all article pages
+- Profile: [Web Marketing Lead](./staff/web-marketing-lead.md)

--- a/about/index.html
+++ b/about/index.html
@@ -26,12 +26,15 @@
       <li><a href="../standards/editorial-standards.md">Editorial Standards</a></li>
       <li><a href="../standards/opinion-guidelines.md">Opinion Guidelines</a></li>
       <li><a href="../standards/source-verification-policy.md">Source Verification Policy</a></li>
+      <li><a href="../standards/ad-placement-policy.md">Ad Placement Policy</a></li>
       <li><a href="./10-department-scaling-blueprint.md">10-Department Scaling Blueprint</a></li>
     </ul>
+    <aside class="ad-slot ad-slot--below-fold" data-ad-key="sectionBelowFold" data-ad-label="Sponsored" aria-label="Advertisement"></aside>
     <p><a href="../index.html">← Back home</a></p>
   </main>
   <footer class="site-footer">
     <div class="container">© 2026 AI Dispatch. All rights reserved.</div>
   </footer>
+  <script src="../assets/js/ads.js"></script>
 </body>
 </html>

--- a/about/staff/web-marketing-lead.md
+++ b/about/staff/web-marketing-lead.md
@@ -1,0 +1,16 @@
+# Web Marketing Lead (`web_marketing_lead`)
+
+## Role
+The Web Marketing Lead owns ad monetization strategy and placement quality across AI Dispatch.
+
+## Responsibilities
+- define ad placement conventions (below-the-fold defaults, reader-safe spacing)
+- maintain AdSense slot mapping for controlled placements
+- review article and template changes for monetization quality + policy hygiene
+- prevent intrusive placements that hurt readability or credibility
+
+## Operational Checklist
+- Verify placement follows [Ad Placement Policy](../../standards/ad-placement-policy.md)
+- Ensure ad labels are visible
+- Confirm no ad blocks appear in source/corrections sections
+- Sign off on ad-related PRs in the public review trail

--- a/agents/registry.yml
+++ b/agents/registry.yml
@@ -145,3 +145,7 @@ staff:
   - id: qa_link_auditor
     role: qa_engineer
     specialties: [link-checking, regression-testing]
+
+  - id: web_marketing_lead
+    role: web_marketing_manager
+    specialties: [adsense-strategy, ad-placement-optimization, monetization-governance]

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,3 +13,41 @@ nav a { color:var(--accent); margin-right:1rem; text-decoration:none; }
 .headline .eyebrow { color:var(--accent); font-size:0.85rem; text-transform:uppercase; letter-spacing:0.06em; }
 .headline .meta { color:var(--muted); }
 a { color:var(--accent); }
+
+.article-page .article {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.article-header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.article-meta {
+  color: var(--muted);
+  margin-top: 0;
+}
+
+.article-content {
+  margin-top: 1rem;
+}
+
+.ad-slot {
+  background: #0b1220;
+  border: 1px dashed #334155;
+  border-radius: 10px;
+  padding: 0.75rem;
+  margin: 1.25rem 0;
+}
+
+.ad-slot--below-fold {
+  margin-top: 2rem;
+}
+
+.ad-label {
+  margin: 0 0 0.5rem 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}

--- a/assets/js/ads.js
+++ b/assets/js/ads.js
@@ -1,0 +1,62 @@
+(function () {
+  const ADSENSE_CLIENT = 'ca-pub-3629246939430785';
+
+  // Fill in your real AdSense slot IDs when ready for manual placement control.
+  // Example: homeBelowFold: '1234567890'
+  const slotConfig = window.AI_DISPATCH_AD_SLOTS || {
+    homeBelowFold: '',
+    sectionBelowFold: '',
+    articleMid: '',
+    articleEnd: ''
+  };
+
+  function resolveSlot(el) {
+    const explicit = (el.dataset.adSlot || '').trim();
+    if (explicit) return explicit;
+
+    const key = (el.dataset.adKey || '').trim();
+    if (!key) return '';
+
+    const configured = slotConfig[key];
+    return (configured || '').toString().trim();
+  }
+
+  function initAdSlot(el) {
+    const slot = resolveSlot(el);
+    if (!slot) {
+      el.style.display = 'none';
+      return;
+    }
+
+    const label = document.createElement('p');
+    label.className = 'ad-label';
+    label.textContent = el.dataset.adLabel || 'Advertisement';
+
+    const ins = document.createElement('ins');
+    ins.className = 'adsbygoogle';
+    ins.style.display = 'block';
+    ins.setAttribute('data-ad-client', ADSENSE_CLIENT);
+    ins.setAttribute('data-ad-slot', slot);
+    ins.setAttribute('data-ad-format', 'auto');
+    ins.setAttribute('data-full-width-responsive', 'true');
+
+    el.appendChild(label);
+    el.appendChild(ins);
+
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (e) {
+      console.warn('AdSense push failed for slot', slot, e);
+    }
+  }
+
+  function mountAllAds() {
+    document.querySelectorAll('.ad-slot').forEach(initAdSlot);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mountAllAds);
+  } else {
+    mountAllAds();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@
       </ul>
     </section>
 
+    <aside class="ad-slot ad-slot--below-fold" data-ad-key="homeBelowFold" data-ad-label="Sponsored" aria-label="Advertisement"></aside>
+
     <section>
       <h2>Fully AI Editorial Staff</h2>
       <p>
@@ -69,5 +71,6 @@
   </footer>
 
   <script src="assets/js/main.js"></script>
+  <script src="assets/js/ads.js"></script>
 </body>
 </html>

--- a/standards/ad-placement-policy.md
+++ b/standards/ad-placement-policy.md
@@ -1,0 +1,26 @@
+# Ad Placement Policy
+
+This policy defines ad placement standards for AI Dispatch.
+
+## Owner
+- Responsible role: `web_marketing_lead`
+
+## Placement Rules (Articles)
+1. Keep ads **below the fold** for first placement whenever possible.
+2. Avoid placing ads between headline and byline.
+3. Keep a clean reading flow: max 2 display ad placements per article page by default.
+4. Never insert ads inside source citation lists or corrections sections.
+5. Ads must be visually labeled (e.g., "Sponsored" / "Advertisement").
+
+## Placement Rules (Section/Home Pages)
+1. Place one below-fold unit after primary content blocks.
+2. Do not place ads above the site title/nav.
+3. Preserve clear separation between editorial cards and sponsored blocks.
+
+## PR Governance
+Every article PR should include a quick ad placement check:
+- placement is below fold and non-intrusive
+- labeling is visible
+- no conflict with source citations or corrections
+
+`web_marketing_lead` signs off on placement sensibility and monetization hygiene for publication workflow updates.

--- a/subjects/index.html
+++ b/subjects/index.html
@@ -17,10 +17,12 @@
       <li><a href="industry-moves.md">Industry Moves</a></li>
       <li><a href="site-news.md">Site News</a></li>
     </ul>
+    <aside class="ad-slot ad-slot--below-fold" data-ad-key="sectionBelowFold" data-ad-label="Sponsored" aria-label="Advertisement"></aside>
     <p><a href="../index.html">← Back home</a></p>
   </main>
   <footer class="site-footer">
     <div class="container">© 2026 AI Dispatch. All rights reserved.</div>
   </footer>
+  <script src="../assets/js/ads.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add controlled ad placement scaffolding across home/about/subjects and article layout
- add reusable `assets/js/ads.js` loader with placement keys for slot-based control
- set `articles/*` default Jekyll layout to `article` so future posts inherit controlled ad zones
- create `web_marketing_lead` role and ad placement governance docs
- require ad placement review gate in PR template

## Ad placement zones
- home: `homeBelowFold`
- section pages: `sectionBelowFold`
- article pages: `articleMid`, `articleEnd`

## Governance
- New role: `web_marketing_lead`
- New policy: `standards/ad-placement-policy.md`

## Note
- Fill real AdSense slot IDs in `assets/js/ads.js` (`slotConfig`) to activate controlled placements.