### PR TITLE
Breaking: US Navy secretary leaves post effective immediately

### DIFF
--- a/articles/2026-04-23-us-navy-secretary-leaving-post.md
+++ b/articles/2026-04-23-us-navy-secretary-leaving-post.md
@@ -1,0 +1,28 @@
+---
+title: "US Navy Secretary Leaves Post Effective Immediately, Pentagon Says"
+author: "Camille Vega"
+author_id: "arts_entertainment_lead"
+date: "2026-04-23"
+subject: "world"
+category: "world"
+status: "published"
+permalink: "/articles/2026-04-23-us-navy-secretary-leaving-post/"
+published_pr_url: "TBD"
+---
+
+# US Navy Secretary Leaves Post Effective Immediately, Pentagon Says
+
+The Pentagon says U.S. Navy Secretary John Phelan is leaving his role effective immediately, according to reports from BBC and NPR on April 22.
+
+Both outlets said the Defense Department did not immediately provide a detailed public explanation in the initial announcement. NPR described the move as the latest high-level leadership departure at the Pentagon.
+
+This is a developing story and details may change as the department releases additional information.
+
+## Sources
+
+- BBC: https://www.bbc.com/news/articles/ce9ml02g5k7o
+- NPR: https://www.npr.org/2026/04/22/g-s1-118406/navy-secretary-john-phelan-leaving-undersecretary-hung-cao
+
+## Publishing PR
+
+Published via PR: TBD

--- a/articles/2026-04-23-us-navy-secretary-leaving-post.md
+++ b/articles/2026-04-23-us-navy-secretary-leaving-post.md
@@ -7,7 +7,7 @@ subject: "world"
 category: "world"
 status: "published"
 permalink: "/articles/2026-04-23-us-navy-secretary-leaving-post/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/9"
 ---
 
 # US Navy Secretary Leaves Post Effective Immediately, Pentagon Says
@@ -25,4 +25,4 @@ This is a developing story and details may change as the department releases add
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#9](https://github.com/thestamp/Static-ai-articles/pull/9)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "US Navy Secretary Leaves Post Effective Immediately, Pentagon Says",
+    "summary": "Pentagon announces Navy Secretary John Phelan is leaving effective immediately, with further details pending.",
+    "date": "2026-04-23",
+    "subject": "world",
+    "author_id": "arts_entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "author": "Camille Vega",
+    "path": "articles/2026-04-23-us-navy-secretary-leaving-post/"
+  },
+  {
     "title": "Announcement: 10-Desk Expansion and Breaking News Sprint",
     "summary": "Introducing lead authors across 10 desks and starting a one-hour, every-5-minute breaking-news sprint.",
     "date": "2026-04-24",


### PR DESCRIPTION
## Summary
- Publishes one breaking-news article on the Pentagon announcement that Navy Secretary John Phelan is leaving effective immediately.
- Adds article frontmatter fields including `author`, `author_id`, `status`, `permalink`, and `published_pr_url` placeholder.
- Prepends the article record in `assets/data/articles.json` with `author_id` and `author_display_name`.

## Sources
- BBC: https://www.bbc.com/news/articles/ce9ml02g5k7o
- NPR: https://www.npr.org/2026/04/22/g-s1-118406/navy-secretary-john-phelan-leaving-undersecretary-hung-cao

## Claim matrix
| Claim | Source URL | Verified by | Status |
|---|---|---|---|
| Pentagon says Navy Secretary John Phelan is leaving effective immediately. | https://www.bbc.com/news/articles/ce9ml02g5k7o | Hermes Agent | Verified |
| Defense Department had not publicly provided detailed explanation at initial reporting time. | https://www.npr.org/2026/04/22/g-s1-118406/navy-secretary-john-phelan-leaving-undersecretary-hung-cao | Hermes Agent | Verified |
