### PR TITLE
Publish: Pentagon says Navy Secretary John Phelan leaving immediately

### DIFF
--- a/articles/2026-04-23-navy-secretary-john-phelan-exit-update.md
+++ b/articles/2026-04-23-navy-secretary-john-phelan-exit-update.md
@@ -7,7 +7,7 @@ subject: "world"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-navy-secretary-john-phelan-exit-update/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/14"
 ---
 
 # Pentagon Says Navy Secretary John Phelan Is Leaving Effective Immediately
@@ -23,4 +23,4 @@ As of publication, official public details about the transition timeline and suc
 
 ## Publishing PR
 
-Published via PR: [TBD](TBD)
+Published via PR: [#14](https://github.com/thestamp/Static-ai-articles/pull/14)

--- a/articles/2026-04-23-navy-secretary-john-phelan-exit-update.md
+++ b/articles/2026-04-23-navy-secretary-john-phelan-exit-update.md
@@ -1,0 +1,26 @@
+---
+title: "Pentagon Says Navy Secretary John Phelan Is Leaving Effective Immediately"
+author: "Dr. Lena Okafor"
+author_id: "science_health_lead"
+date: "2026-04-23"
+subject: "world"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-navy-secretary-john-phelan-exit-update/"
+published_pr_url: "TBD"
+---
+
+# Pentagon Says Navy Secretary John Phelan Is Leaving Effective Immediately
+
+The Pentagon said U.S. Navy Secretary John Phelan is leaving his post effective immediately, according to multiple reports on Thursday. Public reporting indicates the move comes during a period of broader leadership strain across the U.S. defense establishment.
+
+As of publication, official public details about the transition timeline and successor arrangements remain limited.
+
+## Sources
+
+- BBC: [US Navy chief leaving post 'effective immediately', Pentagon says](https://www.bbc.com/news/articles/ce9ml02g5k7o?at_medium=RSS&at_campaign=rss)
+- The New York Times: [Navy Secretary John Phelan Is Leaving the Pentagon and the Trump Administration](https://www.nytimes.com/2026/04/22/us/politics/navy-secretary-john-phelan.html)
+
+## Publishing PR
+
+Published via PR: [TBD](TBD)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Pentagon Says Navy Secretary John Phelan Is Leaving Effective Immediately",
+    "summary": "The Pentagon says Navy Secretary John Phelan is leaving effective immediately, with transition details still limited in public reporting.",
+    "date": "2026-04-23",
+    "subject": "world",
+    "author_id": "science_health_lead",
+    "author_display_name": "Dr. Lena Okafor",
+    "author": "Dr. Lena Okafor",
+    "path": "articles/2026-04-23-navy-secretary-john-phelan-exit-update/"
+  },
+  {
     "title": "Reported Ship Seizures Near Strait of Hormuz Add Pressure to Oil Markets",
     "summary": "Reports of ship seizures near the Strait of Hormuz are adding pressure to oil-market sentiment as U.S.-Iran talks remain unsettled.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
- Publishes one breaking-news article on the Pentagon announcement that Navy Secretary John Phelan is leaving effective immediately.
- Adds article metadata to `assets/data/articles.json` at the top of the list.
- Assigns this run's rotating lead author: Dr. Lena Okafor (`science_health_lead`).

## Sources
- https://www.bbc.com/news/articles/ce9ml02g5k7o?at_medium=RSS&at_campaign=rss
- https://www.nytimes.com/2026/04/22/us/politics/navy-secretary-john-phelan.html