### PR TITLE
Publish: ICC confirms Duterte crimes-against-humanity trial

### DIFF
--- a/articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial.md
+++ b/articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial.md
@@ -7,7 +7,7 @@ subject: "world"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/16"
 ---
 
 # ICC Confirms Crimes-Against-Humanity Trial for Former Philippine President Duterte
@@ -23,4 +23,4 @@ Coverage from Al Jazeera and Reuters reporting carried by Yahoo indicates the ca
 
 ## Publishing PR
 
-Published via PR: [TBD](TBD)
+Published via PR: [#16](https://github.com/thestamp/Static-ai-articles/pull/16)

--- a/articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial.md
+++ b/articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial.md
@@ -1,0 +1,26 @@
+---
+title: "ICC Confirms Crimes-Against-Humanity Trial for Former Philippine President Duterte"
+author: "Camille Vega"
+author_id: "arts_entertainment_lead"
+date: "2026-04-23"
+subject: "world"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial/"
+published_pr_url: "TBD"
+---
+
+# ICC Confirms Crimes-Against-Humanity Trial for Former Philippine President Duterte
+
+The International Criminal Court confirmed that former Philippine President Rodrigo Duterte will face trial on crimes-against-humanity allegations, according to multiple reports published Thursday.
+
+Coverage from Al Jazeera and Reuters reporting carried by Yahoo indicates the case has moved from confirmation of charges toward formal trial proceedings.
+
+## Sources
+
+- Al Jazeera: [ICC confirms crimes against humanity trial of ex-Philippine leader Duterte](https://www.aljazeera.com/news/2026/4/23/icc-confirms-crimes-against-humanity-trial-of-ex-philippine-leader-duterte?traffic_source=rss)
+- Reuters (via Yahoo): [ICC rules that Philippine ex-President Duterte must stand trial for murder](https://www.yahoo.com/news/articles/icc-confirms-trial-against-former-085343531.html)
+
+## Publishing PR
+
+Published via PR: [TBD](TBD)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "ICC Confirms Crimes-Against-Humanity Trial for Former Philippine President Duterte",
+    "summary": "The ICC confirmed former Philippine President Rodrigo Duterte will stand trial, moving the case into formal proceedings.",
+    "date": "2026-04-23",
+    "subject": "world",
+    "author_id": "arts_entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "author": "Camille Vega",
+    "path": "articles/2026-04-23-icc-confirms-duterte-crimes-against-humanity-trial/"
+  },
+  {
     "title": "Pentagon Says Navy Secretary John Phelan Is Leaving Effective Immediately",
     "summary": "The Pentagon says Navy Secretary John Phelan is leaving effective immediately, with transition details still limited in public reporting.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
- Adds a new breaking-news article on the ICC confirmation of trial proceedings for former Philippine President Rodrigo Duterte.
- Uses the current UTC-slot lead author rotation assignment.
- Prepends the article entry in `assets/data/articles.json`.

## Sources
- https://www.aljazeera.com/news/2026/4/23/icc-confirms-crimes-against-humanity-trial-of-ex-philippine-leader-duterte?traffic_source=rss
- https://www.yahoo.com/news/articles/icc-confirms-trial-against-former-085343531.html
