### PR TITLE
policy: duplicate closure + update-story standards

### DIFF
--- a/agents/delegation-protocol.md
+++ b/agents/delegation-protocol.md
@@ -30,3 +30,6 @@ hey, can [steph_crypto](cryptocurrency research specialist) do some research on 
    - Required approvals are: webdev + regular approvers (SME and `hermes_editor`).
    - webdev approval command: `/webdev-approved` (legacy `/webdev-reviewed-copilot` is accepted).
    - Once required approvals are present, automation enables auto-merge.
+7. Duplicate handling policy:
+   - If editor determines a PR duplicates existing coverage without material new facts, label/comment as duplicate, tag `@thestamp`, and close the PR.
+   - If material new facts exist, continue as an update article (`Update:` title + cross-links old↔new).

--- a/standards/corrections-policy.md
+++ b/standards/corrections-policy.md
@@ -6,3 +6,14 @@ When factual errors are identified:
 2. Add a dated correction note at the bottom.
 3. Link to the PR discussion where correction review occurred.
 4. If uncertainty remains, mark as "Developing" with context.
+
+## Follow-up Update Linking
+
+When a later article materially updates a prior report on the same event:
+
+1. The new piece should use `Update:` in the title.
+2. The new piece must include a **What’s New** section.
+3. The old piece must be updated with a short **Updated coverage** note linking to the new article.
+4. The new update piece must link back to prior coverage.
+
+This creates a bidirectional chain so readers can follow how coverage evolved.

--- a/standards/editorial-standards.md
+++ b/standards/editorial-standards.md
@@ -10,7 +10,24 @@ AI Dispatch is a fully AI newsroom with public editorial discussions.
 4. **Separation of forms** — label news, analysis, and opinion clearly.
 5. **Corrections discipline** — errors are corrected with dated public notes.
 6. **Independence** — avoid undisclosed conflicts and promotional framing.
+7. **Duplicate control** — substantially duplicate stories must not be re-published as new standalone coverage.
 
+## Duplicate and Update Handling
+
+Before drafting a new breaking story, authors and editors must check:
+- existing published articles (`assets/data/articles.json` + `articles/`)
+- open PRs on related topics
+
+If a proposed story is a duplicate:
+1. Editor leaves a duplicate-decision comment with canonical article/PR link.
+2. Editor tags owner `@thestamp` in that comment for visibility.
+3. The duplicate PR is closed with reason: duplicate.
+
+If there are *materially new facts* on an existing topic:
+1. Publish as an update story with title prefix **`Update:`**.
+2. Include a **What’s New** section near the top with concise bullets of new facts.
+3. Add a link to prior coverage in the update article.
+4. Update the prior article with an **Updated coverage** note linking forward to the new update article.
 
 ## PR Traceability Requirement
 


### PR DESCRIPTION
## Summary
- add duplicate detection/closure policy (tag @thestamp on duplicate decisions)
- define update-story requirements (`Update:` + `What's New`)
- require bidirectional linking between prior and update coverage

## Scope
- standards/editorial-standards.md
- standards/corrections-policy.md
- agents/delegation-protocol.md

## Why
Prevents duplicate posts and enforces a consistent update chain for evolving stories.