### PR TITLE
Lebanon accuses Israel of targeting journalist Amal Khalil in deadly airstrike

### DIFF
--- a/articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil.md
+++ b/articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil.md
@@ -7,7 +7,7 @@ subject: "world"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/18"
 ---
 
 # Lebanon Accuses Israel of Targeting Journalist Amal Khalil in Deadly Airstrike
@@ -25,4 +25,4 @@ At publication time, no independently verified public record has resolved the ce
 
 ## Publishing PR
 
-Published via PR: [TBD](TBD)
+Published via PR: [#18](https://github.com/thestamp/Static-ai-articles/pull/18)

--- a/articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil.md
+++ b/articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil.md
@@ -1,0 +1,28 @@
+---
+title: "Lebanon Accuses Israel of Targeting Journalist Amal Khalil in Deadly Airstrike"
+author: "Simone Hart"
+author_id: "opinion_editorials_lead"
+date: "2026-04-23"
+subject: "world"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil/"
+published_pr_url: "TBD"
+---
+
+# Lebanon Accuses Israel of Targeting Journalist Amal Khalil in Deadly Airstrike
+
+Lebanese officials have accused Israel of deliberately targeting journalist Amal Khalil in an airstrike, an allegation that raises immediate questions over protections for media workers in active conflict zones.
+
+Public details remain contested and are still developing. Early reporting indicates Khalil was killed in the strike, while officials and news organizations are continuing to gather evidence about the strike location, sequence of events, and whether clear press identification was present.
+
+At publication time, no independently verified public record has resolved the central dispute over intent. Coverage is therefore being framed around verified claims, attribution, and known facts from multiple outlets.
+
+## Sources
+
+- BBC: [Lebanon accuses Israel of targeting journalist killed in air strike](https://www.bbc.com/news/articles/c5yvn036evlo)
+- Al Jazeera: [What we know about Israel killing Lebanese journalist Amal Khalil](https://www.aljazeera.com/news/2026/4/23/what-we-know-about-israel-killing-lebanese-journalist-amal-khalil?traffic_source=rss)
+
+## Publishing PR
+
+Published via PR: [TBD](TBD)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Lebanon Accuses Israel of Targeting Journalist Amal Khalil in Deadly Airstrike",
+    "summary": "Lebanese officials accuse Israel of targeting journalist Amal Khalil in a deadly strike, with key details and intent claims still under active verification.",
+    "date": "2026-04-23",
+    "subject": "world",
+    "author_id": "opinion_editorials_lead",
+    "author_display_name": "Simone Hart",
+    "author": "Simone Hart",
+    "path": "articles/2026-04-23-lebanon-accuses-israel-targeting-journalist-amal-khalil/"
+  },
+  {
     "title": "ICC Confirms Crimes-Against-Humanity Trial for Former Philippine President Duterte",
     "summary": "The ICC confirmed former Philippine President Rodrigo Duterte will stand trial, moving the case into formal proceedings.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
- Adds one breaking-news article on allegations surrounding the death of Lebanese journalist Amal Khalil.
- Uses attributed, developing-language framing where intent remains disputed.
- Updates `assets/data/articles.json` with the new item at the top.

## Sources
- https://www.bbc.com/news/articles/c5yvn036evlo
- https://www.aljazeera.com/news/2026/4/23/what-we-know-about-israel-killing-lebanese-journalist-amal-khalil?traffic_source=rss
