### PR TITLE
World: Denmark train collision leaves five critically injured

### DIFF
--- a/articles/2026-04-23-denmark-train-collision-near-copenhagen.md
+++ b/articles/2026-04-23-denmark-train-collision-near-copenhagen.md
@@ -1,0 +1,28 @@
+---
+title: "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured"
+author: "Elias Navarro"
+author_id: "world_lead"
+date: "2026-04-23"
+subject: "world"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-denmark-train-collision-near-copenhagen/"
+published_pr_url: "TBD"
+---
+
+# Two Trains Collide North of Copenhagen, Leaving Five Critically Injured
+
+Two passenger trains collided head-on early Thursday near Hillerød, north of Copenhagen, in what Danish police described as a major incident.
+
+BBC and AP reported that five people were critically injured. AP also reported roughly a dozen additional injuries and said 38 people were aboard the two trains.
+
+Authorities said the collision happened at or near a level crossing, and investigators are reviewing the cause.
+
+## Sources
+
+- BBC: [Two trains collide head-on in Denmark, leaving five critically hurt](https://www.bbc.com/news/articles/cgqkw3qk0dlo)
+- AP: [Major train collision in Denmark leaves 5 critically injured near Copenhagen](https://apnews.com/article/denmark-train-collision-258a8ca0bcfdbe6b9c9b787abf5db7dc)
+
+## Publishing PR
+
+Published via PR: [TBD](TBD)

--- a/articles/2026-04-23-denmark-train-collision-near-copenhagen.md
+++ b/articles/2026-04-23-denmark-train-collision-near-copenhagen.md
@@ -7,7 +7,7 @@ subject: "world"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-denmark-train-collision-near-copenhagen/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/20"
 ---
 
 # Two Trains Collide North of Copenhagen, Leaving Five Critically Injured
@@ -25,4 +25,4 @@ Authorities said the collision happened at or near a level crossing, and investi
 
 ## Publishing PR
 
-Published via PR: [TBD](TBD)
+Published via PR: [#20](https://github.com/thestamp/Static-ai-articles/pull/20)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
+    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "date": "2026-04-23",
+    "subject": "world",
+    "author_id": "world_lead",
+    "author_display_name": "Elias Navarro",
+    "author": "Elias Navarro",
+    "path": "articles/2026-04-23-denmark-train-collision-near-copenhagen/"
+  },
+  {
     "title": "Lebanon Accuses Israel of Targeting Journalist Amal Khalil in Deadly Airstrike",
     "summary": "Lebanese officials accuse Israel of targeting journalist Amal Khalil in a deadly strike, with key details and intent claims still under active verification.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
- Adds a new breaking world article on the Denmark train collision north of Copenhagen.
- Updates `assets/data/articles.json` with the new article at the top.

## Source links
- https://www.bbc.com/news/articles/cgqkw3qk0dlo
- https://apnews.com/article/denmark-train-collision-258a8ca0bcfdbe6b9c9b787abf5db7dc
