### PR TITLE
arts-entertainment: 'Storage Wars' star Darrell Sheets dies at 67

### DIFF
--- a/articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67.md
+++ b/articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67.md
@@ -1,0 +1,31 @@
+---
+title: "'Storage Wars' Star Darrell Sheets Dies at 67"
+author: "Camille Vega"
+author_id: "arts_entertainment_lead"
+date: "2026-04-23"
+subject: "arts-entertainment"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67/"
+published_pr_url: "TBD"
+---
+
+# 'Storage Wars' Star Darrell Sheets Dies at 67
+
+Darrell Sheets, one of the best-known personalities from A&E's *Storage Wars*, has died at age 67, according to multiple U.S. media reports published Wednesday.
+
+Variety reported that Sheets appeared in 163 episodes of the series and was found dead in Lake Havasu City, Arizona. The *Los Angeles Times* also reported his death and said local police described the case as under investigation.
+
+Coverage from the BBC said former colleagues had raised concerns publicly and called for authorities to examine online harassment allegations surrounding the case.
+
+This remains a developing story, and officials have not yet released a full investigative account.
+
+## Sources
+
+- Variety: ['Storage Wars' Star Darrell Sheets Dead at 67](https://variety.com/2026/tv/news/darrell-sheets-dead-storage-wars-1236728128/)
+- Los Angeles Times: [Darrell Sheets dead: 'Storage Wars' star was 67](https://www.latimes.com/entertainment-arts/story/2026-04-22/storage-wars-star-darrell-sheets-died-at-67)
+- BBC: ['Storage Wars' star Darrell Sheets dies age 67 - reports](https://www.bbc.com/news/articles/cx29vx4xy0ko)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67.md
+++ b/articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67.md
@@ -7,7 +7,7 @@ subject: "arts-entertainment"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/22"
 ---
 
 # 'Storage Wars' Star Darrell Sheets Dies at 67
@@ -28,4 +28,4 @@ This remains a developing story, and officials have not yet released a full inve
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#22](https://github.com/thestamp/Static-ai-articles/pull/22)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "'Storage Wars' Star Darrell Sheets Dies at 67",
+    "summary": "Darrell Sheets, a prominent Storage Wars cast member known as \"The Gambler,\" has died at 67, with authorities in Arizona still investigating the circumstances.",
+    "date": "2026-04-23",
+    "subject": "arts-entertainment",
+    "author_id": "arts_entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "author": "Camille Vega",
+    "path": "articles/2026-04-23-storage-wars-star-darrell-sheets-dies-at-67/"
+  },
+  {
     "title": "Senate Republicans Advance Reconciliation Path for ICE and Border Funding",
     "summary": "Senate Republicans advanced a budget resolution that opens a reconciliation path for ICE and Border Patrol funding, with detailed spending language still ahead.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
- Publishes one new arts-entertainment breaking article on Darrell Sheets' death
- Adds article markdown with sources and developing-story framing
- Inserts article metadata at top of assets/data/articles.json

## Source links
- https://variety.com/2026/tv/news/darrell-sheets-dead-storage-wars-1236728128/
- https://www.latimes.com/entertainment-arts/story/2026-04-22/storage-wars-star-darrell-sheets-died-at-67
- https://www.bbc.com/news/articles/cx29vx4xy0ko
