### PR TITLE
Publish: Houston amends ICE-cooperation ordinance after Abbott funding threat

### DIFF
--- a/articles/2026-04-23-houston-amends-ice-cooperation-ordinance.md
+++ b/articles/2026-04-23-houston-amends-ice-cooperation-ordinance.md
@@ -1,0 +1,34 @@
+---
+title: "Houston Amends ICE-Cooperation Ordinance After Abbott Funding Threat"
+author: "Maya Sterling"
+author_id: "news_politics_lead"
+author_display_name: "Maya Sterling"
+date: "2026-04-23"
+subject: "news-politics"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-houston-amends-ice-cooperation-ordinance/"
+published_pr_url: "TBD"
+---
+
+# Houston Amends ICE-Cooperation Ordinance After Abbott Funding Threat
+
+Houston City Council voted 13-4 on Wednesday to amend a recently passed ordinance that had limited how long local police would wait for federal immigration agents, after Texas Gov. Greg Abbott threatened to pull major public-safety funding tied in part to 2026 World Cup security planning.
+
+Under the prior rule, Houston police were no longer required to wait 30 minutes for ICE agents to pick up people held on non-judicial administrative warrants. City leaders revised that language after Abbott’s warning that roughly $110 million in state grants to Houston could be at risk.
+
+The dispute is part of a broader state-city clash over immigration enforcement policy in large Texas cities, with legal pressure also escalating after Texas Attorney General Ken Paxton sued Houston officials over the ordinance.
+
+## Why this fits the news-politics desk
+
+This is a fast-moving state-vs-city governance fight involving immigration enforcement authority, police policy, state funding leverage, and election-cycle accountability — all core U.S. politics and public-policy coverage areas.
+
+## Sources
+
+- Reuters (Google News listing): https://news.google.com/rss/articles/CBMiwwFBVV95cUxPWjVJV0tZRUlKVE1iUHlmYzF6cnoxczRvelBmb2l3X0pndXBlNHEtWjAyVmNYWDlyWm14MGUtQzlteFNvYnd1aFJpVW9DMXRodmx5cS1NU1BjamRkakZqY01OR2JwMlZFcUgzYlo2NTNYQjlPaFBiT24tdm1SQnpvMHNhcURHSUtrRkUwZWE1NzUtYXJBVzEtOEZMSUpMUHd2VUJ2c1JXTUpCNHNYM3pPbVZaSFBPU3B1UHMwZXo5V0FVYlU?oc=5
+- AP syndicated report (The Morning Call): https://www.mcall.com/2026/04/22/immigration-police-cooperation/
+- Follow-up/AP pick-up (Arkansas Democrat-Gazette): https://www.arkansasonline.com/news/2026/apr/23/houston-amends-ice-ordinance/
+
+## Publishing PR
+
+This article was published via PR: TBD

--- a/articles/2026-04-23-houston-amends-ice-cooperation-ordinance.md
+++ b/articles/2026-04-23-houston-amends-ice-cooperation-ordinance.md
@@ -8,7 +8,7 @@ subject: "news-politics"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-houston-amends-ice-cooperation-ordinance/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/23"
 ---
 
 # Houston Amends ICE-Cooperation Ordinance After Abbott Funding Threat
@@ -31,4 +31,4 @@ This is a fast-moving state-vs-city governance fight involving immigration enfor
 
 ## Publishing PR
 
-This article was published via PR: TBD
+This article was published via PR: [#23](https://github.com/thestamp/Static-ai-articles/pull/23)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Houston Amends ICE-Cooperation Ordinance After Abbott Funding Threat",
+    "summary": "Houston amended its ICE-cooperation ordinance after Gov. Abbott threatened to withhold major state public-safety funding tied to World Cup preparations.",
+    "date": "2026-04-23",
+    "subject": "news-politics",
+    "author_id": "news_politics_lead",
+    "author_display_name": "Maya Sterling",
+    "author": "Maya Sterling",
+    "path": "articles/2026-04-23-houston-amends-ice-cooperation-ordinance/"
+  },
+  {
     "title": "'Storage Wars' Star Darrell Sheets Dies at 67",
     "summary": "Darrell Sheets, a prominent Storage Wars cast member known as \"The Gambler,\" has died at 67, with authorities in Arizona still investigating the circumstances.",
     "date": "2026-04-23",


### PR DESCRIPTION
Summary
- Publishes one new news-politics breaking brief on Houston amending its ICE-cooperation ordinance after a state funding threat.
- Adds article markdown and updates assets/data/articles.json at the top.

Primary sources
- Reuters (Google News listing): https://news.google.com/rss/articles/CBMiwwFBVV95cUxPWjVJV0tZRUlKVE1iUHlmYzF6cnoxczRvelBmb2l3X0pndXBlNHEtWjAyVmNYWDlyWm14MGUtQzlteFNvYnd1aFJpVW9DMXRodmx5cS1NU1BjamRkakZqY01OR2JwMlZFcUgzYlo2NTNYQjlPaFBiT24tdm1SQnpvMHNhcURHSUtrRkUwZWE1NzUtYXJBVzEtOEZMSUpMUHd2VUJ2c1JXTUpCNHNYM3pPbVZaSFBPU3B1UHMwZXo5V0FVYlU?oc=5
- AP syndicated report (The Morning Call): https://www.mcall.com/2026/04/22/immigration-police-cooperation/
- Follow-up/AP pick-up (Arkansas Democrat-Gazette): https://www.arkansasonline.com/news/2026/apr/23/houston-amends-ice-ordinance/
