### PR TITLE
Publish: Business desk — Warner Bros. Discovery shareholders vote on Paramount deal

### DIFF
--- a/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal.md
+++ b/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal.md
@@ -7,7 +7,7 @@ subject: "business-economy"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/25"
 ---
 
 # Warner Bros. Discovery Shareholders Vote on Paramount Deal
@@ -26,4 +26,4 @@ Even with the vote underway, key execution details remain unsettled, including f
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#25](https://github.com/thestamp/Static-ai-articles/pull/25)

--- a/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal.md
+++ b/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal.md
@@ -1,0 +1,29 @@
+---
+title: "Warner Bros. Discovery Shareholders Vote on Paramount Deal"
+author: "Priya Desai"
+author_id: "business_economy_lead"
+date: "2026-04-23"
+subject: "business-economy"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal/"
+published_pr_url: "TBD"
+---
+
+# Warner Bros. Discovery Shareholders Vote on Paramount Deal
+
+Warner Bros. Discovery shareholders are voting Thursday on Paramount’s proposed acquisition of the company, a blockbuster media transaction that outlets describe as one of the largest consolidation moves in the sector this year.
+
+AP reports the proposal at about $81 billion and frames the vote as a pivotal step that could reshape Hollywood ownership and distribution power. CNBC separately reports that Warner Bros. Discovery scheduled a special shareholder meeting for the vote on Paramount’s bid.
+
+Even with the vote underway, key execution details remain unsettled, including final integration structure, regulatory sequencing, and timing for any post-vote closing milestones.
+
+## Sources
+
+- AP News: [Warner Bros shareholders to vote on Paramount's $81 billion takeover of the Hollywood giant](https://apnews.com/article/warner-brothers-paramount-skydance-netflix-david-ellison-d52e8730ba894adf2ebb9a69646d323b)
+- CNBC: [Warner Bros. Discovery shareholders to vote on Paramount deal](https://www.cnbc.com/2026/04/23/warner-bros-discovery-shareholder-vote-paramount-deal.html)
+- ABC News: [Warner Bros shareholders to vote on Paramount's $81B takeover of the Hollywood giant](https://abcnews.com/Business/wireStory/warner-bros-shareholders-vote-paramounts-81-billion-takeover-132298964)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Warner Bros. Discovery Shareholders Vote on Paramount Deal",
+    "summary": "Warner Bros. Discovery shareholders are voting on Paramount's proposed takeover, a major media consolidation move with integration and regulatory details still to be finalized.",
+    "date": "2026-04-23",
+    "subject": "business-economy",
+    "author_id": "business_economy_lead",
+    "author_display_name": "Priya Desai",
+    "author": "Priya Desai",
+    "path": "articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal/"
+  },
+  {
     "title": "NBA Rewind: How the trade deadline shook up the playoff (and tanking) picture",
     "summary": "NBA Rewind: How the trade deadline shook up the playoff (and tanking) picture remains a developing story with key details still being confirmed across early reports.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
Publishes one business-economy breaking item on Warner Bros. Discovery shareholders voting on Paramount’s proposed acquisition.

## Sources
- AP News: https://apnews.com/article/warner-brothers-paramount-skydance-netflix-david-ellison-d52e8730ba894adf2ebb9a69646d323b
- CNBC: https://www.cnbc.com/2026/04/23/warner-bros-discovery-shareholder-vote-paramount-deal.html
- ABC News: https://abcnews.com/Business/wireStory/warner-bros-shareholders-vote-paramounts-81-billion-takeover-132298964
