### PR TITLE
World: South African court orders Zambia to return Edgar Lungu body amid burial dispute

### DIFF
--- a/articles/2026-04-23-zambia-lungu-body-return-dispute.md
+++ b/articles/2026-04-23-zambia-lungu-body-return-dispute.md
@@ -1,0 +1,28 @@
+---
+title: "South African Court Orders Zambia to Return Edgar Lungu's Body in Burial Dispute"
+author: "Elias Navarro"
+author_id: "world_lead"
+date: "2026-04-23"
+subject: "world"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-zambia-lungu-body-return-dispute/"
+published_pr_url: "TBD"
+---
+
+# South African Court Orders Zambia to Return Edgar Lungu's Body in Burial Dispute
+
+A South African court has ordered Zambian authorities to return former President Edgar Lungu's body to a funeral home, intensifying an extended dispute between the government and Lungu's family over burial arrangements.
+
+AP reported that Zambian officials had taken custody of the remains before the court order required the body to be returned. BBC reported the conflict is centered on where and how Lungu should be buried.
+
+The standoff has become a politically sensitive dispute in Zambia, with both legal and family claims shaping the next steps.
+
+## Sources
+
+- BBC: [South African court orders Zambia to return former president's body](https://www.bbc.com/news/articles/cdj7vgwwzgdo)
+- AP: [Court orders Zambia to return body of ex-president Lungu to a funeral home](https://apnews.com/article/zambia-former-president-body-lungu-hichilema-14c66bdc24015f43bb3310c6d1338c7e)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/articles/2026-04-23-zambia-lungu-body-return-dispute.md
+++ b/articles/2026-04-23-zambia-lungu-body-return-dispute.md
@@ -7,7 +7,7 @@ subject: "world"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-zambia-lungu-body-return-dispute/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/26"
 ---
 
 # South African Court Orders Zambia to Return Edgar Lungu's Body in Burial Dispute
@@ -25,4 +25,4 @@ The standoff has become a politically sensitive dispute in Zambia, with both leg
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#26](https://github.com/thestamp/Static-ai-articles/pull/26)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "South African Court Orders Zambia to Return Edgar Lungu's Body in Burial Dispute",
+    "summary": "A South African court ordered Zambia to return former President Edgar Lungu's body to a funeral home, escalating a dispute over burial arrangements.",
+    "date": "2026-04-23",
+    "subject": "world",
+    "author_id": "world_lead",
+    "author_display_name": "Elias Navarro",
+    "author": "Elias Navarro",
+    "path": "articles/2026-04-23-zambia-lungu-body-return-dispute/"
+  },
+  {
     "title": "Warner Bros. Discovery Shareholders Vote on Paramount Deal",
     "summary": "Warner Bros. Discovery shareholders are voting on Paramount's proposed takeover, a major media consolidation move with integration and regulatory details still to be finalized.",
     "date": "2026-04-23",
@@ -51,7 +61,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",


### PR DESCRIPTION
## Article Metadata
- Author persona: `world_lead`
- Beat/Subject: `world`
- Type: `news`
- Proposed article path: `articles/2026-04-23-zambia-lungu-body-return-dispute.md`
- Published PR URL field added in article frontmatter/body: `published_pr_url`

## Summary
Adds a breaking world-desk article on a South African court order requiring Zambia to return former President Edgar Lungu's body to a funeral home during an ongoing burial dispute.

## Source links
- https://www.bbc.com/news/articles/cdj7vgwwzgdo
- https://apnews.com/article/zambia-former-president-body-lungu-hichilema-14c66bdc24015f43bb3310c6d1338c7e

## Review Gates
- [x] Copilot gate is temporarily disabled
- [ ] Web developer approved (`/webdev-approved`)
- [ ] Domain SME review completed (`*_sme`)
- [ ] Chief editor review completed (`hermes_editor`)
- [x] Source verification completed
