### PR TITLE
[technology] Meta adds teen AI topic visibility for parents

### DIFF
--- a/articles/2026-04-23-meta-teen-ai-topic-visibility-parents.md
+++ b/articles/2026-04-23-meta-teen-ai-topic-visibility-parents.md
@@ -1,0 +1,28 @@
+---
+title: "Meta Adds Teen AI Topic Visibility for Parents in Supervised Accounts"
+author: "Adeline Park"
+author_id: "technology_lead"
+date: "2026-04-23"
+subject: "technology"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-meta-teen-ai-topic-visibility-parents/"
+published_pr_url: "TBD"
+---
+
+# Meta Adds Teen AI Topic Visibility for Parents in Supervised Accounts
+
+Meta says it is rolling out new parental-supervision tools that let parents see the **topics** teens discuss with Meta AI, without exposing the full text of private chats.
+
+According to Meta's newsroom announcement, the feature is designed for supervised Teen Accounts and is aimed at giving parents better visibility into how teens are using AI while preserving conversation privacy. Engadget reports the change arrives as platforms face mounting pressure from policymakers and families to strengthen youth safety controls.
+
+The update positions Meta AI controls as part of the broader Teen Account safety framework, with the company emphasizing guardrails and parental awareness rather than full message monitoring.
+
+## Sources
+
+- Meta Newsroom: [Helping Parents Understand the Conversations Their Teens Are Having With AI](https://about.fb.com/news/2026/04/helping-parents-understand-conversations-their-teens-are-having-with-ai/)
+- Engadget: [Meta will show parents the topics of their teens' AI conversations](https://www.engadget.com/ai/meta-will-show-parents-the-topics-of-their-teens-ai-conversations-123119624.html)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/articles/2026-04-23-meta-teen-ai-topic-visibility-parents.md
+++ b/articles/2026-04-23-meta-teen-ai-topic-visibility-parents.md
@@ -7,7 +7,7 @@ subject: "technology"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-meta-teen-ai-topic-visibility-parents/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/27"
 ---
 
 # Meta Adds Teen AI Topic Visibility for Parents in Supervised Accounts
@@ -25,4 +25,4 @@ The update positions Meta AI controls as part of the broader Teen Account safety
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#27](https://github.com/thestamp/Static-ai-articles/pull/27)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Meta Adds Teen AI Topic Visibility for Parents in Supervised Accounts",
+    "summary": "Meta introduced new Teen Account supervision tools that show parents AI conversation topics while keeping full teen chat content private.",
+    "date": "2026-04-23",
+    "subject": "technology",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "author": "Adeline Park",
+    "path": "articles/2026-04-23-meta-teen-ai-topic-visibility-parents/"
+  },
+  {
     "title": "South African Court Orders Zambia to Return Edgar Lungu's Body in Burial Dispute",
     "summary": "A South African court ordered Zambia to return former President Edgar Lungu's body to a funeral home, escalating a dispute over burial arrangements.",
     "date": "2026-04-23",
@@ -61,7 +71,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",


### PR DESCRIPTION
## Summary
Publishes one technology desk article on Meta's new teen AI parental-topic visibility controls.

## Sources
- https://about.fb.com/news/2026/04/helping-parents-understand-conversations-their-teens-are-having-with-ai/
- https://www.engadget.com/ai/meta-will-show-parents-the-topics-of-their-teens-ai-conversations-123119624.html
