### PR TITLE
policy: domain SME approvals + feedback loop + source discovery log

### DIFF
--- a/agents/delegation-protocol.md
+++ b/agents/delegation-protocol.md
@@ -27,9 +27,14 @@ hey, can [steph_crypto](cryptocurrency research specialist) do some research on 
    - post a comment tagging `@thestamp` for manual staffing review.
 6. Temporary merge gate policy (until Copilot loop is re-enabled):
    - Copilot review is optional/disabled for gating.
-   - Required approvals are: webdev + regular approvers (SME and `hermes_editor`).
+   - Required approvals are: webdev + regular approvers (subject-matched SME and `hermes_editor`).
+   - SME must match the article subject domain (examples: policy→`policy_sme`, markets/business-economy→`markets_sme`, technology/model releases→`models_sme`, products→`products_sme`, science-health→`research_sme`, security→`security_sme`, infrastructure/chips/cloud→`infra_sme`).
    - webdev approval command: `/webdev-approved` (legacy `/webdev-reviewed-copilot` is accepted).
    - Once required approvals are present, automation enables auto-merge.
 7. Duplicate handling policy:
    - If editor determines a PR duplicates existing coverage without material new facts, label/comment as duplicate, tag `@thestamp`, and close the PR.
    - If material new facts exist, continue as an update article (`Update:` title + cross-links old↔new).
+8. Discussion quality policy:
+   - PR discussion must include meaningful author↔delegate exchange, not one-way status drops.
+   - Require at least one explicit feedback loop: delegate critique/request → author revision response → delegate/editor acknowledgment.
+   - Include substantive rationale for editorial choices (angle, exclusions, uncertainty treatment), not only approval commands.

--- a/standards/source-verification-policy.md
+++ b/standards/source-verification-policy.md
@@ -8,11 +8,24 @@ Before merge, editors validate that:
 - High-impact claims have independent corroboration.
 - Uncertainty is explicitly labeled.
 
-## Required PR Section
+## Required PR Sections
 
-Use a claim matrix:
+### 1) Claim matrix
 
 | Claim | Source URL | Verified by | Status |
 |---|---|---|---|
 
-Merge is blocked if the matrix is missing for factual stories.
+### 2) Source discovery and bias-check log
+
+Document **how** sources were found so editors can audit selection bias:
+
+| Step | Query / feed / method | Why selected | Potential bias risk | Mitigation |
+|---|---|---|---|---|
+
+Minimum expectations:
+- Include at least 3 discovery steps (e.g., wire feed, search query, direct outlet check).
+- Include at least 2 distinct outlet types (for example: wire/public broadcaster + commercial outlet).
+- State at least one excluded source and why it was excluded.
+- Explicitly note known uncertainty or unresolved conflicts across sources.
+
+Merge is blocked if either required section is missing for factual stories.


### PR DESCRIPTION
## Summary
- require subject-matched SME approvers (not models_sme by default)
- require meaningful author↔delegate discussion with at least one explicit feedback loop
- require source discovery + bias-check log in PRs so editor can audit source selection bias

## Files
- agents/delegation-protocol.md
- standards/source-verification-policy.md
