### PR TITLE
Technology Desk: Android 17 QPR1 Beta 1 lands for Pixel

### DIFF
--- a/articles/2026-04-23-android-17-qpr1-beta-1-pixel.md
+++ b/articles/2026-04-23-android-17-qpr1-beta-1-pixel.md
@@ -7,7 +7,7 @@ subject: "technology"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-android-17-qpr1-beta-1-pixel/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/29"
 ---
 
 # Google Rolls Out Android 17 QPR1 Beta 1 for Pixel Devices
@@ -26,4 +26,4 @@ What this means for users: Pixel owners already on the Android beta track can te
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#29](https://github.com/thestamp/Static-ai-articles/pull/29)

--- a/articles/2026-04-23-android-17-qpr1-beta-1-pixel.md
+++ b/articles/2026-04-23-android-17-qpr1-beta-1-pixel.md
@@ -1,0 +1,29 @@
+---
+title: "Google Rolls Out Android 17 QPR1 Beta 1 for Pixel Devices"
+author: "Adeline Park"
+author_id: "technology_lead"
+date: "2026-04-23"
+subject: "technology"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-android-17-qpr1-beta-1-pixel/"
+published_pr_url: "TBD"
+---
+
+# Google Rolls Out Android 17 QPR1 Beta 1 for Pixel Devices
+
+Google has started shipping **Android 17 QPR1 Beta 1** to eligible Pixel devices, beginning the first Quarterly Platform Release cycle after Android 17 Beta 4.
+
+Early coverage from Android-focused outlets says the build is now live for enrolled Beta Program users, with updates expected to focus on platform stability, bug fixes, and feature polishing ahead of a later stable drop. Google's Android release-notes hub also now exposes QPR1 Beta navigation under Android 17, signaling the transition into the next beta phase.
+
+What this means for users: Pixel owners already on the Android beta track can test QPR1 changes now, while app developers and QA teams get an early compatibility window before broader rollout.
+
+## Sources
+
+- 9to5Google: [Google releases Android 17 QPR1 Beta 1 for Pixel](https://9to5google.com/2026/04/22/android-17-qpr1-beta-1-pixel/)
+- Droid Life: [Google Releases Android 17 QPR1 Beta 1 for Pixel](https://www.droid-life.com/2026/04/22/google-releases-android-17-qpr1-beta-1-for-pixel/)
+- Android Developers: [Android 17 release notes](https://developer.android.com/about/versions/17/release-notes)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Google Rolls Out Android 17 QPR1 Beta 1 for Pixel Devices",
+    "summary": "Google has released Android 17 QPR1 Beta 1 to eligible Pixel devices, opening the next quarterly beta cycle for testing and early compatibility checks.",
+    "date": "2026-04-23",
+    "subject": "technology",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "author": "Adeline Park",
+    "path": "articles/2026-04-23-android-17-qpr1-beta-1-pixel/"
+  },
+  {
     "title": "Meta Adds Teen AI Topic Visibility for Parents in Supervised Accounts",
     "summary": "Meta introduced new Teen Account supervision tools that show parents AI conversation topics while keeping full teen chat content private.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
This PR publishes one technology-desk breaking article on Google shipping Android 17 QPR1 Beta 1 for Pixel devices.

- Adds article: `articles/2026-04-23-android-17-qpr1-beta-1-pixel.md`
- Updates index: `assets/data/articles.json` (new entry inserted at top)
- Subject alignment: `technology` with `technology_lead` (Adeline Park)

## Why this angle
- **Angle:** immediate product-and-platform availability signal (QPR1 Beta 1 now live for Pixel beta users).
- **Exclusions:** no unverified performance claims, no speculative rollout timelines beyond cited reporting.
- **Uncertainty handling:** language constrained to what sources directly confirm (availability + release-cycle context).

## Source links
1. https://9to5google.com/2026/04/22/android-17-qpr1-beta-1-pixel/
2. https://www.droid-life.com/2026/04/22/google-releases-android-17-qpr1-beta-1-for-pixel/
3. https://developer.android.com/about/versions/17/release-notes

## Claim matrix
| Claim | Evidence URL | Source type | Confidence |
|---|---|---|---|
| Android 17 QPR1 Beta 1 is rolling out to Pixel beta users | https://9to5google.com/2026/04/22/android-17-qpr1-beta-1-pixel/ | Independent tech outlet | High |
| Same rollout is independently reported by another outlet | https://www.droid-life.com/2026/04/22/google-releases-android-17-qpr1-beta-1-for-pixel/ | Independent tech outlet | High |
| Android 17 release-notes surface now includes QPR1 beta navigation/context | https://developer.android.com/about/versions/17/release-notes | Official platform documentation | Medium-High |

## Source discovery and bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | Tech desk RSS scan (`techcrunch`, `theverge`, Android-focused feeds) | Fast discovery of same-day technology items | Outlet editorial skew | Cross-check event in multiple independent outlets |
| 2 | `droid-life` + `9to5google` headline match on QPR1 Beta 1 | Confirms same event across separate publications | Ecosystem fan-site bias | Require agreement on only factual availability claims |
| 3 | Android Developers release-notes page verification | Anchor to primary platform source | Official source may omit operational caveats | Keep claims narrow and avoid over-inference |
