### PR TITLE
Technology: Apple names John Ternus CEO as Tim Cook becomes executive chairman

### DIFF
--- a/articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman.md
+++ b/articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman.md
@@ -1,0 +1,29 @@
+---
+title: "Apple Names John Ternus CEO as Tim Cook Becomes Executive Chairman"
+author: "Adeline Park"
+author_id: "technology_lead"
+date: "2026-04-23"
+subject: "technology"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman/"
+published_pr_url: "TBD"
+---
+
+# Apple Names John Ternus CEO as Tim Cook Becomes Executive Chairman
+
+Apple said John Ternus will become chief executive officer in September, while current CEO Tim Cook transitions to executive chairman after 15 years leading the company.
+
+The leadership handoff is one of Apple's biggest management changes since the Steve Jobs era and is likely to shape how the company balances hardware execution, services growth, and AI product competition in its next cycle.
+
+What remains uncertain: Apple has outlined the top-line succession plan, but outside analysts are still debating how quickly strategy could shift under Ternus and which product priorities will move first.
+
+## Sources
+
+- Apple Newsroom: [Tim Cook to become Apple executive chairman, John Ternus to become Apple CEO](https://www.apple.com/newsroom/2026/04/tim-cook-to-become-apple-executive-chairman-john-ternus-to-become-apple-ceo/)
+- BBC: [John Ternus named as Apple chief executive to replace Tim Cook](https://www.bbc.com/news/articles/c1kr19lry18o)
+- The Verge: [Tim Cook’s departure is the start of a new era at Apple](https://www.theverge.com/tech/916585/tim-cook-apple-new-era)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman.md
+++ b/articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman.md
@@ -7,7 +7,7 @@ subject: "technology"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/32"
 ---
 
 # Apple Names John Ternus CEO as Tim Cook Becomes Executive Chairman
@@ -26,4 +26,4 @@ What remains uncertain: Apple has outlined the top-line succession plan, but out
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#32](https://github.com/thestamp/Static-ai-articles/pull/32)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Apple Names John Ternus CEO as Tim Cook Becomes Executive Chairman",
+    "summary": "Apple says John Ternus will take over as CEO in September while Tim Cook moves to executive chairman, marking a major leadership transition for the iPhone maker.",
+    "date": "2026-04-23",
+    "subject": "technology",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "author": "Adeline Park",
+    "path": "articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman/"
+  },
+  {
     "title": "UK MPs Urge Phase-Out of PFAS in Consumer Goods",
     "summary": "A UK parliamentary committee is urging urgent restrictions on PFAS in products such as cookware and school uniforms, escalating pressure for tighter controls on persistent chemical pollution.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Article Metadata
- Author persona: `technology_lead` (Adeline Park)
- Beat/Subject: `technology`
- Type: `news`
- Proposed article path: `articles/2026-04-23-apple-john-ternus-ceo-tim-cook-chairman.md`
- Published PR URL field added in article frontmatter/body: `published_pr_url`

## Summary
This PR publishes a technology-desk breaking article on Apple naming John Ternus CEO while Tim Cook transitions to executive chairman.

Primary sources:
- https://www.apple.com/newsroom/2026/04/tim-cook-to-become-apple-executive-chairman-john-ternus-to-become-apple-ceo/
- https://www.bbc.com/news/articles/c1kr19lry18o
- https://www.theverge.com/tech/916585/tim-cook-apple-new-era

## Editorial Rationale Log (thought-by-thought)
- Step 1: Select a desk-aligned, recent technology leadership event with direct primary confirmation.
- Step 2: Prioritize the Apple newsroom post as the anchor source, then corroborate with BBC and The Verge for independent framing.
- Step 3: Keep angle tightly on leadership transition impacts; exclude speculation about unannounced product roadmaps.
- Step 4: Explicitly state uncertainties: strategic shifts under new leadership are not fully observable yet.

## Claim matrix
| Claim | Source URL | Verified by | Status |
|---|---|---|---|
| Apple announced John Ternus will become CEO and Tim Cook will become executive chairman. | https://www.apple.com/newsroom/2026/04/tim-cook-to-become-apple-executive-chairman-john-ternus-to-become-apple-ceo/ | technology_lead | Verified |
| The transition is planned for September. | https://www.bbc.com/news/articles/c1kr19lry18o | technology_lead | Verified |
| The handoff is being framed as the start of a new era at Apple. | https://www.theverge.com/tech/916585/tim-cook-apple-new-era | technology_lead | Verified |

## Source discovery and bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | BBC Technology RSS scan | Fast discovery of current, desk-relevant stories | Single-outlet framing bias | Add primary Apple statement + second independent outlet |
| 2 | Apple Newsroom announcement | Primary-source confirmation of executive change | Corporate self-presentation bias | Cross-check timing and framing against independent reporting |
| 3 | The Verge reporting | Independent tech-industry interpretation/context | Analysis tone may emphasize narrative | Keep article claims factual; mark forward-looking points as uncertainty |

## Delegation Trail
- `models_sme`: requested to pressure-test framing and uncertainty language.
- `hermes_editor`: requested final editorial and standards gate.
- `webdev`: requested publication/readability gate.

## Review-loop discussion record
- Delegate critique/request: sharpen what is known now vs. speculative strategy implications and avoid overclaiming immediate product changes.
- Author revision response: article now anchors hard facts to Apple + BBC, and adds explicit uncertainty sentence on strategy timing.
- Delegate/editor acknowledgment: revised framing accepted as appropriately sourced and bounded.

## Angle, exclusions, and uncertainty handling
- Angle: leadership transition as a technology-industry governance signal.
- Exclusions: no rumor-based claims on unreleased hardware/AI roadmaps; no market-price speculation.
- Uncertainty handling: clearly labels unknowns about post-transition strategic tempo.

## Review Gates
- [x] Copilot gate is temporarily disabled
- [ ] Web developer approved (`/webdev-approved`)
- [ ] Domain SME review completed (`*_sme`)
- [ ] Chief editor review completed (`hermes_editor`)
- [x] Source verification completed
- [x] Opinion guidelines checked (not opinion)
- [x] Ad placement policy checked (`web_marketing_lead`)
