### PR TITLE
style: mobile-first polish for homepage and category UX

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -200,6 +200,109 @@ a:hover { text-decoration: underline; }
 .author-card p { margin: 0; color: var(--muted); }
 
 @media (max-width: 760px) {
-  .masthead-row { flex-direction: column; align-items: flex-start; }
-  .masthead-cta { width: 100%; text-align: center; }
+  .container {
+    width: min(1120px, 94vw);
+    padding: 0.85rem;
+  }
+
+  .site-header--pro h1 {
+    font-size: clamp(1.8rem, 8vw, 2.3rem);
+  }
+
+  .tagline,
+  .owner-line {
+    font-size: 0.98rem;
+    line-height: 1.55;
+  }
+
+  .masthead-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .masthead-cta {
+    width: 100%;
+    text-align: center;
+  }
+
+  .main-nav,
+  .subject-nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.2rem;
+    scrollbar-width: thin;
+  }
+
+  .main-nav a,
+  .subject-nav a {
+    flex: 0 0 auto;
+    font-size: 0.88rem;
+    padding: 0.42rem 0.68rem;
+  }
+
+  .hero-banner {
+    margin-top: 0.8rem;
+  }
+
+  .hero-banner__image {
+    max-height: 230px;
+  }
+
+  .hero-banner__content {
+    padding: 0.9rem;
+  }
+
+  .hero-banner__content h2 {
+    font-size: 1.2rem;
+    line-height: 1.3;
+  }
+
+  .section-title {
+    margin-top: 1.2rem;
+  }
+
+  .card-grid,
+  .subject-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .card,
+  .subject-card {
+    padding: 0.85rem;
+    border-radius: 10px;
+  }
+
+  .card p,
+  .subject-card span {
+    font-size: 0.96rem;
+    line-height: 1.55;
+  }
+
+  .site-footer .container {
+    font-size: 0.9rem;
+    line-height: 1.45;
+  }
+}
+
+@media (max-width: 420px) {
+  .site-header--pro h1 {
+    font-size: 1.72rem;
+  }
+
+  .tagline {
+    font-size: 0.95rem;
+  }
+
+  .main-nav a,
+  .subject-nav a {
+    font-size: 0.84rem;
+    padding: 0.38rem 0.62rem;
+  }
+
+  .hero-banner__content h2 {
+    font-size: 1.1rem;
+  }
 }


### PR DESCRIPTION
## Summary
Mobile polish pass for professional news UX:
- improved mobile typography scale and line-height for masthead/body/footer
- added horizontal scroll behavior for nav pills on small screens
- tuned hero image height and content spacing on mobile
- converted cards/subject grid to single-column on mobile for readability
- tightened card padding and spacing rhythm for phones

## File
- `assets/css/style.css`
