### PR TITLE
[technology] Vercel says expanded breach probe found additional customer data exposure

### DIFF
--- a/articles/2026-04-23-vercel-second-compromise-customer-data.md
+++ b/articles/2026-04-23-vercel-second-compromise-customer-data.md
@@ -7,7 +7,7 @@ subject: "technology"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-vercel-second-compromise-customer-data/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/40"
 ---
 
 # Vercel Reports Additional Customer Data Exposure During Expanded April Breach Probe
@@ -28,4 +28,4 @@ What this means for developers and security teams: if your organization uses Ver
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#40](https://github.com/thestamp/Static-ai-articles/pull/40)

--- a/articles/2026-04-23-vercel-second-compromise-customer-data.md
+++ b/articles/2026-04-23-vercel-second-compromise-customer-data.md
@@ -1,0 +1,31 @@
+---
+title: "Vercel Reports Additional Customer Data Exposure During Expanded April Breach Probe"
+author: "Adeline Park"
+author_id: "technology_lead"
+date: "2026-04-23"
+subject: "technology"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-vercel-second-compromise-customer-data/"
+published_pr_url: "TBD"
+---
+
+# Vercel Reports Additional Customer Data Exposure During Expanded April Breach Probe
+
+Vercel says its expanded April 2026 incident investigation found evidence of an **additional compromise affecting some customer data**, broadening the scope beyond the first disclosures made earlier this month.
+
+In an updated security bulletin, Vercel says it identified unauthorized access to certain internal systems and published new indicators of compromise as the investigation continued. Context, the vendor tied to Vercel's prior incident disclosures, also posted an updated security statement describing impact to its legacy consumer product and response steps.
+
+Third-party reporting on April 23 says Vercel informed customers that a second compromise was discovered during follow-up analysis, with additional customer-account exposure under review.
+
+What this means for developers and security teams: if your organization uses Vercel or connected third-party tooling, review incident notices, rotate credentials/tokens tied to impacted services, and monitor access logs for unusual account activity in the affected window.
+
+## Sources
+
+- Vercel Knowledge Base: [Vercel April 2026 security incident](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident)
+- Context: [Security Incident Response Statement](https://context.ai/security-update)
+- TechCrunch: [Vercel says some of its customers' data was stolen prior to its recent hack](https://techcrunch.com/2026/04/23/vercel-says-some-of-its-customers-data-was-stolen-prior-to-its-recent-hack/)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Vercel Reports Additional Customer Data Exposure During Expanded April Breach Probe",
+    "summary": "Vercel says expanded April incident investigation uncovered additional customer data exposure, with Context and third-party reporting providing updated scope details.",
+    "date": "2026-04-23",
+    "subject": "technology",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "author": "Adeline Park",
+    "path": "articles/2026-04-23-vercel-second-compromise-customer-data/"
+  },
+  {
     "title": "UN Agencies Warn Extreme Heat Is Pushing Global Agrifood Systems to the Brink",
     "summary": "UN and FAO reporting says extreme heat is increasingly straining agrifood systems worldwide, with risks to farm livelihoods, productivity, and food security.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
This PR publishes one technology desk article on Vercel's expanded April 2026 security-incident investigation and reported additional customer-data exposure.

- Desk: `technology`
- Author: `Adeline Park` (`technology_lead`)
- Decision: `new` (no same-event open PR or published duplicate found)

## Claim matrix
| Claim | Source | Confidence |
|---|---|---|
| Vercel published an April 2026 incident bulletin describing unauthorized access to certain internal systems and ongoing investigation updates. | https://vercel.com/kb/bulletin/vercel-april-2026-security-incident | High |
| Context published an incident-response statement with updated timeline and impacted-product scope. | https://context.ai/security-update | High |
| Reporting says Vercel later identified evidence of a second compromise affecting some customer data during expanded investigation. | https://techcrunch.com/2026/04/23/vercel-says-some-of-its-customers-data-was-stolen-prior-to-its-recent-hack/ | Medium-High |

## Source discovery + bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | TechCrunch RSS (`https://techcrunch.com/feed/`) | Reliable automation-friendly feed for current tech events | Single-outlet framing risk | Required corroboration with primary sources |
| 2 | Extracted outbound links from TechCrunch article HTML | Recover primary disclosures tied to same event | Link context could be selective | Kept only canonical incident disclosures |
| 3 | Verified primary pages via direct fetch + metadata (`vercel.com`, `context.ai`) | Confirm source reachability and official statements | Vendor self-reporting may understate impact | Labeled vendor claims and avoided overclaiming beyond disclosures |

## Duplicate gate
Checked:
- `assets/data/articles.json`
- `articles/*.md` headline/body overlap for Vercel/Context incident
- Open PRs (`state=open`)

Result: no same-event duplicate found; publishing as new article.
