### PR TITLE
Technology: Bluesky raises photo upload limits in v1.121

### DIFF
--- a/articles/2026-04-23-bluesky-photo-quality-update-v1121.md
+++ b/articles/2026-04-23-bluesky-photo-quality-update-v1121.md
@@ -1,0 +1,30 @@
+---
+title: "Bluesky Raises Photo Upload Limits in v1.121"
+author: "Adeline Park"
+author_id: "technology_lead"
+date: "2026-04-23"
+subject: "technology"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-bluesky-photo-quality-update-v1121/"
+published_pr_url: "TBD"
+---
+
+# Bluesky Raises Photo Upload Limits in v1.121
+
+Bluesky says app version **v1.121** increases photo quality limits for posts by doubling the maximum image file size to **2MB** and raising the resolution cap to **4000×4000**. The update also introduces a carousel-style display for posts containing multiple photos.
+
+The change is a product-level upgrade aimed at improving image fidelity for creators and reducing compression-related quality loss in everyday posting. TechCrunch reports the rollout is live, citing Bluesky's official release post.
+
+## Why it matters
+
+Higher upload limits can improve visual quality for photographers, artists, and news users who rely on detail-preserving images. Combined with multi-photo carousel presentation, the update moves Bluesky closer to feature parity with image-forward social platforms.
+
+## Sources
+
+- Bluesky official post: [Bluesky v1.121 release update](https://bsky.app/profile/bsky.app/post/3mk4lzkrnk22d)
+- TechCrunch: [Bluesky now supports better quality photos](https://techcrunch.com/2026/04/23/bluesky-now-supports-better-quality-photos/)
+
+## Publishing PR
+
+Published via PR: [#TBD](TBD)

--- a/articles/2026-04-23-bluesky-photo-quality-update-v1121.md
+++ b/articles/2026-04-23-bluesky-photo-quality-update-v1121.md
@@ -18,7 +18,7 @@ The change is a product-level upgrade aimed at improving image fidelity for crea
 
 ## Why it matters
 
-Higher upload limits can improve visual quality for photographers, artists, and news users who rely on detail-preserving images. Combined with multi-photo carousel presentation, the update moves Bluesky closer to feature parity with image-forward social platforms.
+Higher upload limits can improve visual quality for photographers, artists, and news users who rely on detail-preserving images. Combined with multi-photo carousel presentation, the update expands how image-heavy posts can be published and viewed in the app.
 
 ## Sources
 

--- a/articles/2026-04-23-bluesky-photo-quality-update-v1121.md
+++ b/articles/2026-04-23-bluesky-photo-quality-update-v1121.md
@@ -7,7 +7,7 @@ subject: "technology"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-bluesky-photo-quality-update-v1121/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/42"
 ---
 
 # Bluesky Raises Photo Upload Limits in v1.121
@@ -27,4 +27,4 @@ Higher upload limits can improve visual quality for photographers, artists, and 
 
 ## Publishing PR
 
-Published via PR: [#TBD](TBD)
+Published via PR: [#42](https://github.com/thestamp/Static-ai-articles/pull/42)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Bluesky Raises Photo Upload Limits in v1.121",
+    "summary": "Bluesky says v1.121 doubles photo upload size to 2MB, raises resolution limits to 4000x4000, and adds carousel display for multi-photo posts.",
+    "date": "2026-04-23",
+    "subject": "technology",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "author": "Adeline Park",
+    "path": "articles/2026-04-23-bluesky-photo-quality-update-v1121/"
+  },
+  {
     "title": "NASA Sends Mini IV-Fluid Factory to ISS on CRS-24 Mission",
     "summary": "NASA says IVGEN Mini reached the ISS on CRS-24 to test on-demand saline production in orbit, a medical logistics step aimed at reducing shelf-life and mass constraints for long-duration crewed missions.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
Publishes one technology-desk breaking item on Bluesky v1.121 photo-quality changes.

- Desk: `technology`
- Author: `Adeline Park` (`technology_lead`)
- Decision: **new** (not duplicate; no matching event/article/PR found)

## Topic-fit rationale (technology)
This is a live product/platform update for a social network app (upload limits, media rendering behavior, release versioning), which is squarely a technology desk subject.

## Claim matrix
| # | Claim | Source | Confidence |
|---|---|---|---|
| 1 | Bluesky v1.121 is live. | https://bsky.app/profile/bsky.app/post/3mk4lzkrnk22d | High |
| 2 | Photo max file size increased to 2MB and resolution limit to 4000x4000. | https://bsky.app/profile/bsky.app/post/3mk4lzkrnk22d | High |
| 3 | Multi-photo posts now appear in a carousel. | https://bsky.app/profile/bsky.app/post/3mk4lzkrnk22d | High |
| 4 | Independent coverage confirms rollout framing. | https://techcrunch.com/2026/04/23/bluesky-now-supports-better-quality-photos/ | Medium-High |

## Source discovery + bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | TechCrunch RSS (`https://techcrunch.com/feed/`) | Fresh, timestamped technology headlines | Single-outlet framing | Use as discovery only; corroborate with primary source |
| 2 | Direct fetch of TechCrunch article | Extract primary-source link and claim scope | Aggregation bias / interpretation drift | Verify exact limits against official Bluesky post |
| 3 | Direct fetch of Bluesky official post URL | Primary product announcement | Corporate self-reporting may omit caveats | Keep claims narrow to explicit posted details; avoid speculative MAU/perf impacts |
| 4 | Repo duplicate gate (`articles/`, `assets/data/articles.json`, open PRs API) | Prevent near-duplicate publication | Entity-overlap false positives/negatives | Checked event-level terms (`Bluesky`, `v1.121`, photo limits) across files + open PRs |
