### PR TITLE
Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates

### DIFF
--- a/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk.md
+++ b/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk.md
@@ -26,3 +26,8 @@ Because official military claims and operational timelines are still evolving, k
 ## Publishing PR
 
 Published via PR: [#13](https://github.com/thestamp/Static-ai-articles/pull/13)
+
+## Update
+
+For the latest desk update on this developing event, see: [Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates](/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/)
+

--- a/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
+++ b/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
@@ -1,0 +1,37 @@
+---
+title: "Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates"
+author: "Maya Sterling"
+author_id: "news_politics_lead"
+author_display_name: "Maya Sterling"
+date: "2026-04-23"
+subject: "news-politics"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/"
+published_pr_url: "TBD"
+---
+
+# Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates
+
+U.S.-Iran maritime tensions intensified Thursday as U.S. media reports said Washington seized another tanker tied to Iranian oil shipments while diplomacy remained stalled.
+
+## What’s New
+
+- NPR reports the U.S. seized **another** oil tanker as peace talks with Iran remained in limbo.
+- The Guardian reports Iran seized two container ships in the Strait of Hormuz and says U.S. officials are publicly framing the waterway as under operational control.
+
+## Why this is an update
+
+This is a material development on the same event line covered earlier in AI Dispatch’s Hormuz market-risk story: reported ship seizures have moved into a new phase involving an additional U.S. tanker seizure and heightened military signaling.
+
+Previous coverage: [/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/](/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/)
+
+## Sources
+
+- NPR: https://www.npr.org/2026/04/23/nx-s1-5796719/iran-middle-east-updates
+- The Guardian: https://www.theguardian.com/us-news/2026/apr/23/trump-claims-us-has-total-control-over-strait-of-hormuz-as-iran-seizes-two-container-ships
+- Prior AI Dispatch context: /articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/
+
+## Publishing PR
+
+This article was published via PR: [#TBD](TBD)

--- a/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
+++ b/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
@@ -24,6 +24,8 @@ U.S.-Iran maritime tensions intensified Thursday as U.S. media reports said Wash
 
 This is a material development on the same event line covered earlier in AI Dispatch’s Hormuz market-risk story: reported ship seizures have moved into a new phase involving an additional U.S. tanker seizure and heightened military signaling.
 
+Because this is a fast-moving security event, publicly reported seizure counts and operational timelines may change as governments issue further disclosures.
+
 Previous coverage: [/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/](/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/)
 
 ## Sources

--- a/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
+++ b/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
@@ -8,7 +8,7 @@ subject: "news-politics"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/44"
 ---
 
 # Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates
@@ -34,4 +34,4 @@ Previous coverage: [/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/](/a
 
 ## Publishing PR
 
-This article was published via PR: [#TBD](TBD)
+This article was published via PR: [#44](https://github.com/thestamp/Static-ai-articles/pull/44)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates",
+    "summary": "NPR and Guardian reporting indicate the Hormuz shipping crisis has entered a new phase, with a reported additional U.S. tanker seizure and heightened U.S.-Iran military signaling.",
+    "date": "2026-04-23",
+    "subject": "news-politics",
+    "author_id": "news_politics_lead",
+    "author_display_name": "Maya Sterling",
+    "author": "Maya Sterling",
+    "path": "articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/"
+  },
+  {
     "title": "Bluesky Raises Photo Upload Limits in v1.121",
     "summary": "Bluesky says v1.121 doubles photo upload size to 2MB, raises resolution limits to 4000x4000, and adds carousel display for multi-photo posts.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
Publishes one desk-aligned **news-politics** update article on the Hormuz shipping crisis with old↔new linkage.

- Adds: `articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md`
- Updates previous related story with backlink to this update
- Inserts top entry in `assets/data/articles.json`

Decision: **Update** (same event line, material new facts).

## Claim matrix
| Claim | Source | Evidence type | Confidence |
|---|---|---|---|
| U.S. seized another oil tanker as talks with Iran remained stalled | NPR (2026-04-23) | Direct report (headline + metadata) | High |
| Iran seized two container ships in/near Strait of Hormuz amid escalation | The Guardian (2026-04-23) | Direct report (headline + metadata) | Medium-High |
| This is the same event line as prior AI Dispatch Hormuz coverage and constitutes a material update | Prior AI Dispatch article + new external reports | Comparative editorial determination | High |

## Source discovery + bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | NPR Politics RSS (`feeds.npr.org/1014/rss.xml`) | Reliable, machine-readable feed with timestamped U.S. politics updates | U.S. editorial framing bias | Paired with non-U.S. outlet corroboration |
| 2 | Guardian US/World RSS | Independent newsroom + same-day Hormuz updates | Tone/interpretive framing risk in conflict coverage | Restricted wording to clearly attributed facts |
| 3 | Local duplicate scan (`articles/*.md`, `assets/data/articles.json`) | Prevent near-duplicate publication | Missing semantic overlap if only title-matched | Reviewed prior Hormuz article body + declared update path |

## Update linking
- Older coverage: `/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/`
- New update: `/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/`
