### PR TITLE
feat: category-grouped homepage + latest-first subject feeds

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -132,6 +132,106 @@ a:hover { text-decoration: underline; }
   box-shadow: 0 0 0 1px rgba(73, 166, 255, 0.3) inset;
 }
 
+.headline-layout {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.headline-media img {
+  width: 100%;
+  height: 100%;
+  min-height: 240px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+.headline-copy h3 {
+  margin: 0.25rem 0 0.55rem;
+  font-size: clamp(1.2rem, 2vw, 1.6rem);
+}
+
+.category-tiles {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.category-tile__hero {
+  display: grid;
+  grid-template-columns: 116px 1fr;
+  gap: 0.8rem;
+  align-items: start;
+}
+
+.category-tile__hero img {
+  width: 116px;
+  height: 116px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+.category-tile__hero h3 {
+  margin: 0.2rem 0 0.35rem;
+  font-size: 1.02rem;
+}
+
+.category-tile__list {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+}
+
+.category-tile__list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px dashed rgba(159, 176, 199, 0.25);
+}
+
+.category-tile__list li:last-child {
+  border-bottom: 0;
+}
+
+.category-tile__list small,
+.muted {
+  color: var(--muted);
+}
+
+.subject-feed {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 0.6rem;
+}
+
+.feed-card {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 0.9rem;
+  align-items: start;
+}
+
+.feed-card__media img {
+  width: 220px;
+  height: 138px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+.feed-card h3 {
+  margin: 0.05rem 0 0.45rem;
+}
+
+.subject-nav a.is-active {
+  border-color: var(--accent-2);
+  box-shadow: 0 0 0 1px rgba(94, 200, 255, 0.35) inset;
+  color: #ecf8ff;
+}
+
 .headline .eyebrow { color: var(--accent-2); }
 .headline .meta { color: var(--muted); }
 
@@ -269,6 +369,38 @@ a:hover { text-decoration: underline; }
     gap: 0.75rem;
   }
 
+  .headline-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .headline-media img {
+    min-height: 190px;
+  }
+
+  .category-tiles {
+    grid-template-columns: 1fr;
+  }
+
+  .category-tile__hero {
+    grid-template-columns: 88px 1fr;
+    gap: 0.65rem;
+  }
+
+  .category-tile__hero img {
+    width: 88px;
+    height: 88px;
+  }
+
+  .feed-card {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .feed-card__media img {
+    width: 100%;
+    height: 180px;
+  }
+
   .card,
   .subject-card {
     padding: 0.85rem;
@@ -304,5 +436,9 @@ a:hover { text-decoration: underline; }
 
   .hero-banner__content h2 {
     font-size: 1.1rem;
+  }
+
+  .feed-card__media img {
+    height: 156px;
   }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,75 +1,202 @@
 (async function () {
-  document.getElementById('year').textContent = new Date().getFullYear();
+  const yearEl = document.getElementById('year');
+  if (yearEl) yearEl.textContent = new Date().getFullYear();
 
-  const headlineEl = document.getElementById('headline-story');
-  const container = document.getElementById('latest-articles');
-  if (!container) return;
+  const isSubjectsPage = window.location.pathname.includes('/subjects/');
+  const basePrefix = isSubjectsPage ? '..' : '.';
 
-  try {
-    const res = await fetch('assets/data/articles.json');
-    const items = await res.json();
+  const withBase = (path) => {
+    if (!path) return path;
+    if (/^(https?:)?\/\//.test(path) || path.startsWith('/')) return path;
+    return `${basePrefix}/${path}`.replace('././', './').replace('.././', '../');
+  };
 
-    if (!Array.isArray(items) || items.length === 0) {
-      if (headlineEl) headlineEl.innerHTML = '<p>No headline available yet.</p>';
-      container.innerHTML = '<p>Articles index is not available yet.</p>';
+  const articleHref = (item) => withBase(item.path || 'articles/');
+  const articleImage = (item) => withBase(item.image || item.image_url || 'images/news-banner.png');
+  const displayAuthor = (item) => item.author_display_name || item.author || item.author_id || 'Unknown';
+
+  const parseTimestamp = (item) => {
+    const explicit = item.published_at || item.datetime || item.timestamp;
+    if (explicit) {
+      const t = Date.parse(explicit);
+      if (!Number.isNaN(t)) return t;
+    }
+
+    if (item.date) {
+      const t = Date.parse(item.date);
+      if (!Number.isNaN(t)) return t;
+    }
+
+    const pathDateMatch = (item.path || '').match(/(\d{4}-\d{2}-\d{2})/);
+    if (pathDateMatch) {
+      const t = Date.parse(pathDateMatch[1]);
+      if (!Number.isNaN(t)) return t;
+    }
+
+    return 0;
+  };
+
+  const sortNewestFirst = (items) => [...items].sort((a, b) => {
+    const tsDiff = parseTimestamp(b) - parseTimestamp(a);
+    if (tsDiff !== 0) return tsDiff;
+    return (b.path || '').localeCompare(a.path || '');
+  });
+
+  const subjectLabel = (slug) => ({
+    'news-politics': 'News & Politics',
+    world: 'World',
+    'business-economy': 'Business & Economy',
+    technology: 'Technology',
+    'science-health': 'Science & Health',
+    environment: 'Environment',
+    'arts-entertainment': 'Arts & Entertainment',
+    lifestyle: 'Lifestyle',
+    sports: 'Sports',
+    'opinion-editorials': 'Opinion & Editorials',
+    'site-news': 'Site News',
+    editorial: 'Editorial'
+  }[slug] || slug);
+
+  const renderHome = (items) => {
+    const headlineEl = document.getElementById('headline-story');
+    const categoryTilesEl = document.getElementById('category-tiles');
+
+    if (!headlineEl || !categoryTilesEl) return;
+
+    if (!items.length) {
+      headlineEl.innerHTML = '<p>No headline available yet.</p>';
+      categoryTilesEl.innerHTML = '<p>No category briefings available yet.</p>';
       return;
     }
 
-    const displayAuthor = (item) => item.author_display_name || item.author || item.author_id || 'Unknown';
+    const headline = items[0];
+    headlineEl.innerHTML = `
+      <a class="headline-media" href="${articleHref(headline)}">
+        <img src="${articleImage(headline)}" alt="Headline image for ${headline.title}" loading="lazy" />
+      </a>
+      <div class="headline-copy">
+        <p class="eyebrow">Latest headline</p>
+        <h3><a href="${articleHref(headline)}">${headline.title}</a></h3>
+        <p>${headline.summary || ''}</p>
+        <p class="meta">${headline.date || ''} · ${subjectLabel(headline.subject)} · ${displayAuthor(headline)}</p>
+      </div>
+    `;
 
-    const parseTimestamp = (item) => {
-      const explicit = item.published_at || item.datetime || item.timestamp;
-      if (explicit) {
-        const t = Date.parse(explicit);
-        if (!Number.isNaN(t)) return t;
-      }
+    const grouped = new Map();
+    for (const item of items) {
+      const key = item.subject || 'general';
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key).push(item);
+    }
 
-      if (item.date) {
-        const t = Date.parse(item.date);
-        if (!Number.isNaN(t)) return t;
-      }
+    const tiles = [];
+    for (const [subject, stories] of grouped.entries()) {
+      const newest = stories[0];
+      const older = stories.slice(1, 4);
+      const subjectLink = withBase(`subjects/index.html#${subject}`);
 
-      const pathDateMatch = (item.path || '').match(/(\d{4}-\d{2}-\d{2})/);
-      if (pathDateMatch) {
-        const t = Date.parse(pathDateMatch[1]);
-        if (!Number.isNaN(t)) return t;
-      }
+      tiles.push(`
+        <article class="card category-tile">
+          <a class="category-tile__hero" href="${subjectLink}">
+            <img src="${articleImage(newest)}" alt="${subjectLabel(subject)} coverage image" loading="lazy" />
+            <div>
+              <p class="eyebrow">${subjectLabel(subject)}</p>
+              <h3>${newest.title}</h3>
+              <p class="meta">${newest.date || ''} · ${displayAuthor(newest)}</p>
+            </div>
+          </a>
+          ${older.length ? `
+            <ul class="category-tile__list">
+              ${older.map(s => `
+                <li>
+                  <a href="${articleHref(s)}">${s.title}</a>
+                  <small>${s.date || ''}</small>
+                </li>
+              `).join('')}
+            </ul>
+          ` : '<p class="muted">No older stories in this category yet.</p>'}
+        </article>
+      `);
+    }
 
-      return 0;
+    categoryTilesEl.innerHTML = tiles.join('');
+  };
+
+  const renderSubjects = (items) => {
+    const feedTitleEl = document.getElementById('subject-feed-title');
+    const feedEl = document.getElementById('subject-feed');
+    const buttonEls = Array.from(document.querySelectorAll('[data-subject]'));
+    if (!feedTitleEl || !feedEl || !buttonEls.length) return;
+
+    const subjectsInData = new Set(items.map((i) => i.subject).filter(Boolean));
+
+    const getSelectedSubject = () => {
+      const fromHash = decodeURIComponent((window.location.hash || '').replace('#', '').trim());
+      if (fromHash && subjectsInData.has(fromHash)) return fromHash;
+      return buttonEls.find((b) => subjectsInData.has(b.dataset.subject))?.dataset.subject || buttonEls[0].dataset.subject;
     };
 
-    const sortedItems = [...items].sort((a, b) => {
-      const tsDiff = parseTimestamp(b) - parseTimestamp(a);
-      if (tsDiff !== 0) return tsDiff;
-      return (b.path || '').localeCompare(a.path || '');
+    const renderSubjectFeed = (subject) => {
+      const filtered = items.filter((i) => i.subject === subject);
+      feedTitleEl.textContent = `${subjectLabel(subject)} — Latest stories`;
+
+      buttonEls.forEach((btn) => {
+        btn.classList.toggle('is-active', btn.dataset.subject === subject);
+      });
+
+      if (!filtered.length) {
+        feedEl.innerHTML = '<p>No stories in this category yet.</p>';
+        return;
+      }
+
+      feedEl.innerHTML = filtered.map((a) => `
+        <article class="card feed-card">
+          <a class="feed-card__media" href="${articleHref(a)}">
+            <img src="${articleImage(a)}" alt="${a.title}" loading="lazy" />
+          </a>
+          <div>
+            <h3><a href="${articleHref(a)}">${a.title}</a></h3>
+            <p>${a.summary || ''}</p>
+            <small>${a.date || ''} · ${subjectLabel(a.subject)} · ${displayAuthor(a)}</small>
+          </div>
+        </article>
+      `).join('');
+    };
+
+    const applySubject = (subject) => {
+      if (!subject) return;
+      history.replaceState(null, '', `#${subject}`);
+      renderSubjectFeed(subject);
+    };
+
+    buttonEls.forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        applySubject(btn.dataset.subject);
+      });
     });
 
-    const headline = sortedItems[0];
+    window.addEventListener('hashchange', () => {
+      renderSubjectFeed(getSelectedSubject());
+    });
 
-    if (headlineEl) {
-      headlineEl.innerHTML = `
-        <p class="eyebrow">Headline story</p>
-        <h3><a href="${headline.path}">${headline.title}</a></h3>
-        <p>${headline.summary}</p>
-        <p class="meta">${headline.date} · ${headline.subject} · ${displayAuthor(headline)}</p>
-      `;
-    }
+    renderSubjectFeed(getSelectedSubject());
+  };
 
-    const latest = sortedItems.slice(1);
-    if (latest.length === 0) {
-      container.innerHTML = '<p>No additional briefings yet.</p>';
-      return;
-    }
+  try {
+    const res = await fetch(withBase('assets/data/articles.json'));
+    const rawItems = await res.json();
+    const items = Array.isArray(rawItems) ? sortNewestFirst(rawItems) : [];
 
-    container.innerHTML = latest.map(a => `
-      <article class="card">
-        <h3><a href="${a.path}">${a.title}</a></h3>
-        <p>${a.summary}</p>
-        <small>${a.date} · ${a.subject} · ${displayAuthor(a)}</small>
-      </article>
-    `).join('');
-  } catch {
+    renderHome(items);
+    renderSubjects(items);
+  } catch (err) {
+    const headlineEl = document.getElementById('headline-story');
+    const categoryTilesEl = document.getElementById('category-tiles');
+    const feedEl = document.getElementById('subject-feed');
+
     if (headlineEl) headlineEl.innerHTML = '<p>No headline available yet.</p>';
-    container.innerHTML = '<p>Articles index is not available yet.</p>';
+    if (categoryTilesEl) categoryTilesEl.innerHTML = '<p>Category briefings are not available yet.</p>';
+    if (feedEl) feedEl.innerHTML = '<p>Subject feed is not available yet.</p>';
   }
 })();

--- a/index.html
+++ b/index.html
@@ -53,13 +53,13 @@
     </section>
 
     <section>
-      <h2 class="section-title">Headline</h2>
-      <article id="headline-story" class="headline card"></article>
+      <h2 class="section-title">Top story</h2>
+      <article id="headline-story" class="headline card headline-layout"></article>
     </section>
 
     <section>
-      <h2 class="section-title">Latest Briefings</h2>
-      <div id="latest-articles" class="card-grid"></div>
+      <h2 class="section-title">Category briefings</h2>
+      <div id="category-tiles" class="card-grid category-tiles"></div>
     </section>
 
     <aside class="ad-slot ad-slot--below-fold" data-ad-key="homeBelowFold" data-ad-label="Sponsored" aria-label="Advertisement"></aside>

--- a/subjects/index.html
+++ b/subjects/index.html
@@ -11,31 +11,33 @@
   <header class="site-header site-header--pro">
     <div class="container">
       <h1>Subject Categories</h1>
-      <p class="tagline">Navigate coverage by desk and beat.</p>
+      <p class="tagline">Browse each desk with latest stories first.</p>
       <nav class="main-nav" aria-label="Primary">
         <a href="../index.html">Home</a>
         <a href="index.html">Subjects</a>
         <a href="../articles/">Articles</a>
         <a href="../about/index.html">About</a>
       </nav>
+
+      <nav class="subject-nav" aria-label="Subject categories">
+        <a href="#news-politics" data-subject="news-politics">News & Politics</a>
+        <a href="#world" data-subject="world">World</a>
+        <a href="#business-economy" data-subject="business-economy">Business & Economy</a>
+        <a href="#technology" data-subject="technology">Technology</a>
+        <a href="#science-health" data-subject="science-health">Science & Health</a>
+        <a href="#environment" data-subject="environment">Environment</a>
+        <a href="#arts-entertainment" data-subject="arts-entertainment">Arts & Entertainment</a>
+        <a href="#lifestyle" data-subject="lifestyle">Lifestyle</a>
+        <a href="#sports" data-subject="sports">Sports</a>
+        <a href="#opinion-editorials" data-subject="opinion-editorials">Opinion & Editorials</a>
+      </nav>
     </div>
   </header>
 
   <main class="container">
     <section class="card">
-      <h2>All Desks</h2>
-      <div class="subject-grid">
-        <a id="news-politics" class="subject-card" href="../articles/"><strong>News & Politics</strong><span>Legislation, elections, governance</span></a>
-        <a id="world" class="subject-card" href="../articles/"><strong>World</strong><span>Diplomacy, conflict, global affairs</span></a>
-        <a id="business-economy" class="subject-card" href="../articles/"><strong>Business & Economy</strong><span>Markets, companies, macro trends</span></a>
-        <a id="technology" class="subject-card" href="../articles/"><strong>Technology</strong><span>AI platforms, product releases, innovation</span></a>
-        <a id="science-health" class="subject-card" href="../articles/"><strong>Science & Health</strong><span>Research, medicine, public health</span></a>
-        <a id="environment" class="subject-card" href="../articles/"><strong>Environment</strong><span>Climate, energy, sustainability</span></a>
-        <a id="arts-entertainment" class="subject-card" href="../articles/"><strong>Arts & Entertainment</strong><span>Culture, creators, media business</span></a>
-        <a id="lifestyle" class="subject-card" href="../articles/"><strong>Lifestyle</strong><span>Consumer trends, travel, food, style</span></a>
-        <a id="sports" class="subject-card" href="../articles/"><strong>Sports</strong><span>Leagues, performance, economics</span></a>
-        <a id="opinion-editorials" class="subject-card" href="../articles/"><strong>Opinion & Editorials</strong><span>Arguments, analysis, perspective</span></a>
-      </div>
+      <h2 id="subject-feed-title">Latest stories</h2>
+      <div id="subject-feed" class="subject-feed"></div>
     </section>
 
     <aside class="ad-slot ad-slot--below-fold" data-ad-key="sectionBelowFold" data-ad-label="Sponsored" aria-label="Advertisement"></aside>


### PR DESCRIPTION
## Summary
Implements front-page and category-feed behavior requested:
- homepage now groups stories by category tiles
- each category tile shows latest headline + up to 3 older headlines beneath it
- top story section is newest overall with image
- category clicks go to subject feed pages that render newest-first
- subject feed supports hash-based category selection and updates dynamically
- homepage ordering is always computed in JS (not dependent on JSON raw order)

## Files
- index.html
- subjects/index.html
- assets/js/main.js
- assets/css/style.css
