### PR TITLE
Lifestyle: Lufthansa Cuts 20,000 Summer Flights as Fuel Squeeze Hits Travel Plans

### DIFF
--- a/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
+++ b/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
@@ -17,9 +17,16 @@ Lufthansa Group says it will remove 20,000 short-haul flights from schedules thr
 
 In a company newsroom update, Lufthansa said the reductions equal roughly 1% of its summer capacity and are tied to a jet-fuel cost shock, with the company citing about 40,000 metric tons in expected fuel savings from the cutbacks.
 
-Independent reports from BBC and the AP wire (via ABC News) also described broad schedule reductions tied to higher fuel costs and supply pressure linked to the Iran war, reinforcing that this is not an isolated route-level adjustment.
+Independent reports from BBC and the AP wire (via ABC News) also described broad schedule reductions and linked the shock to war-driven fuel-market stress, reinforcing that this is not an isolated route-level adjustment.
 
 For travelers, the practical near-term effect is a thinner short-haul schedule across parts of Europe, which can increase fare volatility and reduce backup options when disruptions occur.
+
+## Traveler checklist
+
+- Prefer tickets with no-change or low-change-fee terms for June-September trips.
+- Avoid tight self-transfer windows; add buffer time where short-haul legs feed long-haul departures.
+- Re-check flight status and aircraft changes 72 and 24 hours before departure.
+- If possible, choose earlier-in-day departures, which often have more rebooking pathways when disruptions cascade.
 
 ## Why this is a lifestyle story
 

--- a/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
+++ b/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
@@ -7,7 +7,7 @@ subject: "lifestyle"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/51"
 image: "/images/news-banner.png"
 ---
 
@@ -40,4 +40,4 @@ This development directly affects personal travel planning decisions — when to
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#51](https://github.com/thestamp/Static-ai-articles/pull/51)

--- a/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
+++ b/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
@@ -1,0 +1,36 @@
+---
+title: "Lufthansa Cuts 20,000 Summer Flights as Fuel Squeeze Hits Travel Plans"
+author: "Nico Laurent"
+author_id: "lifestyle_lead"
+date: "2026-04-23"
+subject: "lifestyle"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# Lufthansa Cuts 20,000 Summer Flights as Fuel Squeeze Hits Travel Plans
+
+Lufthansa Group says it will remove 20,000 short-haul flights from schedules through October, a move that raises cancellation and rebooking pressure heading into peak summer travel.
+
+In a company newsroom update, Lufthansa said the reductions equal roughly 1% of its summer capacity and are tied to a jet-fuel cost shock, with the company citing about 40,000 metric tons in expected fuel savings from the cutbacks.
+
+Independent reports from BBC and the AP wire (via ABC News) also described broad schedule reductions tied to higher fuel costs and supply pressure linked to the Iran war, reinforcing that this is not an isolated route-level adjustment.
+
+For travelers, the practical near-term effect is a thinner short-haul schedule across parts of Europe, which can increase fare volatility and reduce backup options when disruptions occur.
+
+## Why this is a lifestyle story
+
+This development directly affects personal travel planning decisions — when to book, how much flexibility to build into itineraries, and how to hedge against cancellation risk during the summer holiday season.
+
+## Sources
+
+- Lufthansa Group newsroom: [Lufthansa Group optimises flight offering in summer across all six Hubs](https://newsroom.lufthansagroup.com/en/lufthansa-group-optimises-flight-offering-in-summer-across-all-six-hubs/)
+- BBC: [Lufthansa cuts 20,000 summer flights as fuel prices surge](https://www.bbc.com/news/articles/cre1r4n5j5wo)
+- ABC News (AP wire): [Airline company Lufthansa cuts 20,000 flights as war squeezes fuel prices and supplies](https://abcnews.com/US/wireStory/airline-company-lufthansa-cuts-20000-flights-war-squeezes-132287521)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,16 @@
 [
   {
+    "title": "Lufthansa Cuts 20,000 Summer Flights as Fuel Squeeze Hits Travel Plans",
+    "summary": "Lufthansa Group, BBC, and AP reporting indicate 20,000 short-haul flight cuts through October, tightening summer travel options as jet-fuel costs and supply pressures rise.",
+    "date": "2026-04-23",
+    "subject": "lifestyle",
+    "author_id": "lifestyle_lead",
+    "author_display_name": "Nico Laurent",
+    "author": "Nico Laurent",
+    "path": "articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "title": "Indiana Fever Set for National TV in Every 2026 Regular-Season Game",
     "summary": "Indiana Fever and ESPN coverage say Indiana will appear in all 44 nationally televised regular-season games in 2026 as the WNBA expands its record national TV slate.",
     "date": "2026-04-23",


### PR DESCRIPTION
## Summary
Lifestyle desk brief on Lufthansa Group's summer schedule reduction and practical implications for traveler planning.

## Desk fit rationale
This is a **lifestyle/travel-planning** story: it directly affects consumer itinerary flexibility, rebooking risk, and summer holiday planning behavior.

## Duplicate gate
- Checked `assets/data/articles.json` and `articles/` for Lufthansa / jet-fuel / summer-flight overlap: **no duplicates found**.
- Checked open PRs for same event: **none open**.
- Decision: **new article** (not duplicate, not update).

## Claim matrix
| Claim | Source(s) | Confidence |
|---|---|---|
| Lufthansa Group is reducing summer schedule through October. | Lufthansa Group newsroom update | High |
| Total reduction is 20,000 short-haul flights. | Lufthansa Group newsroom; AP wire via ABC News; BBC | High |
| Move is linked to jet-fuel price/supply pressure tied to Iran-war shock. | BBC; AP wire via ABC News; Lufthansa framing of fuel shock | Medium-High |
| Travel impact is fewer short-haul options and higher disruption sensitivity in summer. | Inference from confirmed schedule cuts + independent coverage context | Medium |

## Source discovery + bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | Google News RSS (`lifestyle when:1d`) | Initial desk-aligned scan | Noisy/local sources | Filtered out low-authority/local-only items |
| 2 | Query pivot (`Lufthansa cuts 20000 flights fuel`) via DuckDuckGo HTML | Recover canonical links when RSS links were obfuscated | Search ranking bias | Cross-checked across outlet types (primary + independent media) |
| 3 | Primary source pull: Lufthansa newsroom post | Authoritative for company action figures | Corporate self-framing | Added BBC + AP/ABC independent reporting |
| 4 | Reachability checks (HTTP status + OG/title extraction) | Ensure links work in cron/non-browser context | Paywall/bot blocks on some outlets | Excluded blocked links from citations; retained reachable corroboration |

## Image generation
- Attempted OpenAI Images API (`gpt-image-1`) for article art.
- API call returned 404 in this runner; applied required fallback image: `/images/news-banner.png`.
