### PR TITLE
fix: front page newest-first tie-breaker when timestamps are missing

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -39,6 +39,12 @@
   const sortNewestFirst = (items) => [...items].sort((a, b) => {
     const tsDiff = parseTimestamp(b) - parseTimestamp(a);
     if (tsDiff !== 0) return tsDiff;
+
+    // If timestamps are identical/missing, prefer original feed order with newer entries first.
+    // We treat higher source index as newer so array order bugs don't show oldest-first.
+    const sourceIndexDiff = (b.__sourceIndex ?? -1) - (a.__sourceIndex ?? -1);
+    if (sourceIndexDiff !== 0) return sourceIndexDiff;
+
     return (b.path || '').localeCompare(a.path || '');
   });
 
@@ -186,7 +192,10 @@
   try {
     const res = await fetch(withBase('assets/data/articles.json'));
     const rawItems = await res.json();
-    const items = Array.isArray(rawItems) ? sortNewestFirst(rawItems) : [];
+    const normalized = Array.isArray(rawItems)
+      ? rawItems.map((item, idx) => ({ ...item, __sourceIndex: idx }))
+      : [];
+    const items = sortNewestFirst(normalized);
 
     renderHome(items);
     renderSubjects(items);


### PR DESCRIPTION
## Summary
- fix homepage/story sort fallback when many items only have YYYY-MM-DD
- use source index as secondary tie-breaker so latest entries appear first
- preserve timestamp-first behavior when explicit timestamps exist

## Why
Front page was showing older items first for same-day posts due to alphabetical path tie-break.

## Test
- `node --check assets/js/main.js`
- verified sort output with `assets/data/articles.json` places latest entries first
