### PR TITLE
fix: restore direct newest-article links in homepage category briefings

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -103,7 +103,7 @@
 
       tiles.push(`
         <article class="card category-tile">
-          <a class="category-tile__hero" href="${subjectLink}">
+          <a class="category-tile__hero" href="${articleHref(newest)}">
             <img src="${articleImage(newest)}" alt="${subjectLabel(subject)} coverage image" loading="lazy" />
             <div>
               <p class="eyebrow">${subjectLabel(subject)}</p>
@@ -111,6 +111,7 @@
               <p class="meta">${newest.date || ''} · ${displayAuthor(newest)}</p>
             </div>
           </a>
+          <p class="category-tile__subject-link"><a href="${subjectLink}">More from ${subjectLabel(subject)} →</a></p>
           ${older.length ? `
             <ul class="category-tile__list">
               ${older.map(s => `


### PR DESCRIPTION
## Summary
- Fix homepage category briefing lead-card routing so the hero/title links go to the newest article URL (not only the subject anchor).
- Add an explicit "More from <subject>" link to preserve subject navigation.

## Root cause
Homepage category lead cards were anchored to `subjects/index.html#<subject>`, so newest stories in those cards were not directly reachable as article links from homepage. This caused freshness/link monitors to miss newest entries in rendered homepage article-link comparisons.

## Verification
- Live pre-fix checks: all key routes and article URLs returned 200, but homepage rendered newest story titles without direct article links in category lead cards.
- Post-change code behavior: category lead card hero now uses `articleHref(newest)`; subject navigation remains available via explicit "More from <subject>" link.

## Risk
Low; single JS template change in homepage renderer.