### PR TITLE
fix: resolve homepage runtime 404s for root-relative images

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,10 +4,21 @@
 
   const isSubjectsPage = window.location.pathname.includes('/subjects/');
   const basePrefix = isSubjectsPage ? '..' : '.';
+  const pathParts = window.location.pathname.split('/').filter(Boolean);
+  const firstSegment = pathParts[0] || '';
+  const githubProjectBase = /github\.io$/i.test(window.location.hostname)
+    && firstSegment
+    && !firstSegment.includes('.')
+    ? `/${firstSegment}`
+    : '';
 
   const withBase = (path) => {
     if (!path) return path;
-    if (/^(https?:)?\/\//.test(path) || path.startsWith('/')) return path;
+    if (/^(https?:)?\/\//.test(path)) return path;
+    if (path.startsWith('/')) {
+      if (!githubProjectBase || path.startsWith(`${githubProjectBase}/`) || path === githubProjectBase) return path;
+      return `${githubProjectBase}${path}`;
+    }
     return `${basePrefix}/${path}`.replace('././', './').replace('.././', '../');
   };
 


### PR DESCRIPTION
## Summary
This fixes homepage/runtime resource 404s on GitHub Pages project paths (`/Static-ai-articles/...`).

## Root cause
`assets/js/main.js` treated root-relative asset paths (e.g. `/images/news-banner.png`) as site-root absolute URLs.
On a project site, those resolved to `https://thestamp.github.io/images/...` instead of `https://thestamp.github.io/Static-ai-articles/images/...`, producing 404s and broken card images.

## Fix
- Detect GitHub Pages project base (`/<repo>`) from `window.location.pathname`.
- In `withBase()`, prefix root-relative in-site paths with the detected project base.
- Preserve external URLs and already-prefixed paths.

## Verification
- Homepage Headline + Category briefings populate.
- Broken image URL no longer points to `https://thestamp.github.io/images/...`.
- Key routes return 200: `/`, `/about/index.html`, `/subjects/index.html`, `/articles/`.
- Newest-3 article URLs (date-sorted) return 200.