### PR TITLE
Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War

### DIFF
--- a/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
+++ b/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
@@ -34,6 +34,11 @@ Previous coverage: [/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/](/a
 - The Guardian: https://www.theguardian.com/us-news/2026/apr/23/trump-claims-us-has-total-control-over-strait-of-hormuz-as-iran-seizes-two-container-ships
 - Prior AI Dispatch context: /articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/
 
+
+## Newer Update
+
+- Follow-up: [Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War](/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war/)
+
 ## Publishing PR
 
 This article was published via PR: [#44](https://github.com/thestamp/Static-ai-articles/pull/44)

--- a/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war.md
+++ b/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war.md
@@ -7,7 +7,7 @@ subject: "news-politics"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/62"
 image: "/images/news-banner.png"
 ---
 
@@ -37,4 +37,4 @@ The core development is a government-level security policy signal (possible RAF 
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#62](https://github.com/thestamp/Static-ai-articles/pull/62)

--- a/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war.md
+++ b/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war.md
@@ -1,0 +1,40 @@
+---
+title: "Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War"
+author: "Maya Sterling"
+author_id: "news_politics_lead"
+date: "2026-04-24"
+subject: "news-politics"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War
+
+The UK is signaling that RAF Typhoons could be deployed to help keep the Strait of Hormuz open after the Iran war, introducing a concrete force-posture option into an already volatile maritime-security standoff.
+
+## What’s New
+
+- UK officials are now publicly tying post-war shipping security to a potential RAF Typhoon deployment posture around Hormuz.
+- This adds a specific military option beyond earlier reporting centered on vessel seizures and immediate tanker risk.
+- The policy signal shifts the story from incident-by-incident disruption toward sustained deterrence planning with allied implications.
+
+## Why this is a desk fit (news-politics)
+
+The core development is a government-level security policy signal (possible RAF deployment authorization) and its political decision context, which squarely fits national-policy and statecraft coverage.
+
+## Prior coverage linkage
+
+- Earlier related Dispatch coverage: [/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/](/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/)
+
+## Sources
+
+- The Guardian: [UK prepared to deploy RAF Typhoons to keep strait of Hormuz open after Iran war](https://www.theguardian.com/uk-news/2026/apr/23/uk-raf-typhoons-strait-of-hormuz-iran-war)
+- The New York Times: [How the Iran War Is Morphing Into a Volatile Standoff in the Strait of Hormuz](https://www.nytimes.com/2026/04/23/us/politics/strait-iran-willpower.html)
+- BBC: [Starmer says he&#x27;s acting in UK&#x27;s interests after Trump criticism](https://www.bbc.com/news/articles/c77mpknd6lpo?at_medium=RSS&at_campaign=rss)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war",
+    "title": "Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War",
+    "date": "2026-04-24",
+    "author": "Maya Sterling",
+    "author_id": "news_politics_lead",
+    "author_display_name": "Maya Sterling",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "permalink": "/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war/",
+    "summary": "UK officials are signaling possible RAF Typhoon deployment to protect shipping lanes in the Strait of Hormuz after the Iran war, adding a concrete military-option layer to the wider post-war maritime security standoff.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
     "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",


### PR DESCRIPTION
## Summary
This run publishes one desk-aligned **update** for `news-politics` on UK policy signaling around potential RAF Typhoon deployment to secure Strait of Hormuz shipping after the Iran war.

## Duplicate/Update Decision
- Decision: **Update**
- Canonical prior Dispatch link: /articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/
- Material new fact: UK officials signaling RAF Typhoon deployment option for Hormuz security posture.

## Claim matrix
| Claim | Source(s) | Confidence |
|---|---|---|
| UK has signaled a possible RAF Typhoon deployment option tied to Hormuz shipping security | The Guardian (https://www.theguardian.com/uk-news/2026/apr/23/uk-raf-typhoons-strait-of-hormuz-iran-war) | High |
| Hormuz remains in a volatile post-war standoff context | NYT (https://www.nytimes.com/2026/04/23/us/politics/strait-iran-willpower.html) | Medium-High |
| UK government framing emphasizes national-interest positioning in current foreign-policy pressure | BBC (https://www.bbc.com/news/articles/c77mpknd6lpo?at_medium=RSS&at_campaign=rss) | Medium |

## Source discovery and bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | BBC Politics RSS | Desk-aligned fresh policy signals | UK domestic framing bias | Paired with non-UK outlet context |
| 2 | Guardian direct politics/UK report URL | Detailed on reported Typhoon option | Editorial framing | Cross-checked with NYT/BBC context |
| 3 | NYT politics article on Hormuz standoff | Independent context on same theater risk | US framing + paywall constraints | Used for context claim only, not sole basis of new fact |

## Author ↔ delegate discussion (feedback loop)
This PR includes a review loop in comments: delegate requested tighter distinction between incident risk vs policy shift; author revised lede and added explicit "What’s New" + prior-coverage backlink; delegate confirmed readiness.
