### PR TITLE
fix: repair broken internal article links on GitHub Pages project site

### DIFF
--- a/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk.md
+++ b/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk.md
@@ -29,5 +29,5 @@ Published via PR: [#13](https://github.com/thestamp/Static-ai-articles/pull/13)
 
 ## Update
 
-For the latest desk update on this developing event, see: [Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates](/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/)
+For the latest desk update on this developing event, see: [Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates](../2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/)
 

--- a/articles/2026-04-23-senate-gop-budget-reconciliation-ice-funding.md
+++ b/articles/2026-04-23-senate-gop-budget-reconciliation-ice-funding.md
@@ -26,7 +26,7 @@ Because reconciliation is a process tool rather than final enactment, exact spen
 
 ## Update
 
-- Follow-up coverage: [Update: Senate Advances ICE and Border Funding Path in Reconciliation Vote](/articles/2026-04-23-update-senate-ice-border-funding-reconciliation/)
+- Follow-up coverage: [Update: Senate Advances ICE and Border Funding Path in Reconciliation Vote](../2026-04-23-update-senate-ice-border-funding-reconciliation/)
 
 ## Publishing PR
 

--- a/articles/2026-04-23-update-senate-ice-border-funding-reconciliation.md
+++ b/articles/2026-04-23-update-senate-ice-border-funding-reconciliation.md
@@ -33,4 +33,4 @@ This is a procedural-but-consequential congressional action: it changes the legi
 
 ## Earlier coverage
 
-- Previous AI Dispatch report: [Senate Republicans Advance Reconciliation Path for ICE and Border Funding](/articles/2026-04-23-senate-gop-budget-reconciliation-ice-funding/)
+- Previous AI Dispatch report: [Senate Republicans Advance Reconciliation Path for ICE and Border Funding](../2026-04-23-senate-gop-budget-reconciliation-ice-funding/)

--- a/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
+++ b/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz.md
@@ -26,7 +26,7 @@ This is a material development on the same event line covered earlier in AI Disp
 
 Because this is a fast-moving security event, publicly reported seizure counts and operational timelines may change as governments issue further disclosures.
 
-Previous coverage: [/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/](/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/)
+Previous coverage: [Iran Ship Seizures Near Strait of Hormuz Raise Oil-Risk Fears](../2026-04-23-iran-ship-seizures-hormuz-oil-risk/)
 
 ## Sources
 
@@ -37,7 +37,7 @@ Previous coverage: [/articles/2026-04-23-iran-ship-seizures-hormuz-oil-risk/](/a
 
 ## Newer Update
 
-- Follow-up: [Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War](/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war/)
+- Follow-up: [Update: UK Signals RAF Typhoon Option to Keep Strait of Hormuz Open After Iran War](../2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war/)
 
 ## Publishing PR
 

--- a/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war.md
+++ b/articles/2026-04-24-uk-raf-typhoon-option-strait-of-hormuz-iran-war.md
@@ -27,7 +27,7 @@ The core development is a government-level security policy signal (possible RAF 
 
 ## Prior coverage linkage
 
-- Earlier related Dispatch coverage: [/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/](/articles/2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/)
+- Earlier related Dispatch coverage: [Update: U.S. Seizes Another Oil Tanker as Hormuz Crisis Escalates](../2026-04-23-update-us-seizure-iran-oil-tanker-hormuz/)
 
 ## Sources
 


### PR DESCRIPTION
## Summary
- fixed broken cross-article links that used root-relative `/articles/...` paths
- converted to sibling-relative links (`../<slug>/`) so project-site base path is preserved
- includes the reported RAF Typhoon update article and related update chain links

## Why
On `thestamp.github.io/Static-ai-articles`, root-relative links resolve to `https://thestamp.github.io/articles/...` and 404.

## Verification
- searched for remaining markdown links matching `](/articles/` under `articles/` and found 0 matches after this change
