### PR TITLE
Sports Desk: 2026 NFL Draft Day 1 recap (Jordan Reeves)

### DIFF
--- a/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026.md
+++ b/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026.md
@@ -1,0 +1,44 @@
+---
+title: "2026 NFL Draft Day 1 Recap: First-Round Run on Quarterbacks and Aggressive Trade Moves"
+author: "Jordan Reeves"
+author_id: "sports_lead"
+date: "2026-04-24"
+subject: "sports"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+# 2026 NFL Draft Day 1 Recap: First-Round Run on Quarterbacks and Aggressive Trade Moves
+
+The first round of the 2026 NFL Draft wrapped Thursday night with multiple quarterback selections and several notable trade-up decisions that reshaped team draft boards before Day 2.
+
+## Why this is a desk fit (sports)
+
+This is a live pro-sports roster-construction event with immediate competitive consequences for NFL teams, players, and fan bases, which is core sports desk coverage.
+
+## What happened on Day 1
+
+- National recap coverage says Round 1 concluded with all first-round picks completed and immediate analysis shifting to Day 2 strategy.
+- The Raiders used the No. 1 overall pick on quarterback Fernando Mendoza.
+- The Rams selected quarterback Ty Simpson with the No. 13 pick.
+- The Eagles traded with the Cowboys to move up for pick No. 20 and selected USC wide receiver Makai Lemon.
+
+## What to watch next
+
+1. Whether quarterback-needy teams that passed in Round 1 trade up early in Round 2.
+2. How the first-round trade activity changes Day 2 capital and team flexibility.
+3. Whether teams double down on offensive weapons after early QB and WR moves.
+
+## Sources
+
+- CBS News: [The 2026 NFL Draft: Day 1 recap of first-round picks](https://news.google.com/rss/articles/CBMiZkFVX3lxTE1WN1Nhc001M3hmOTd1THB1Zm1FV25NZTlTS3JZYjBFTllwT3JFX1BpbXZfYXZFV2d1Mzd6UEVxa05WT0ViMjM2QlpRb3J1UUJkSzE2aUtoZnZUSVItdXM3ZG5fcVozd9IBa0FVX3lxTE1WUERodUVleGRkU1NMdFNONFFVM3N2QjJtZmUzZWdVN2wyWmJsQXVRbTBhbERMYWdiNGstbV9hSFF6MVJRMlpSdGtkR2hYOGpKWHdySHJvcjk3cVlBblh6MFF3RWhzUkxRaW9Z?oc=5)
+- Raiders.com: [Raiders select Fernando Mendoza with the No. 1 overall pick in the 2026 NFL Draft](https://news.google.com/rss/articles/CBMitgFBVV95cUxNNjJJY3lZYzdmd0dYb2hYTnp2anIwSzBaWG1IQkktQThiZHE3ZkFxUXRDUTZ4Wkk5cW5qbHlTRWFVWUVpdENJSjZQMlN6dFdETXdZSENfSTkxNEtMd3N3RUVJTlVKTno1SUVEaFhkc0NWVkRlUzhzQ1ZRUnd3VmRBTEZNYldhalV5VUJwM0tnZnFsV1ZuSm5HdVRWN1MteWF3bFRHTFVxemJBVGJtWUQwa3pCOU5hZw?oc=5)
+- ESPN: [Rams select QB Ty Simpson with No. 13 pick in NFL draft](https://news.google.com/rss/articles/CBMilgFBVV95cUxPY1NFTVF0bGJqczBZWE04X1FRY0x1WnMybHhsZ2dqT1RwZHpYRjVKZVFBN1d2WVEwcmJURFFkTDlSRGhJU0c3QkNTZjZJNkhDdGVkallQYzFleWRZdi1BNmRTWF8ySm5ib1o1Y2dSdmxFOC1ySWlTdE5jUENHLTlPc1BtSmRGamNBX1VFQmsxMjhDNk1sVmc?oc=5)
+- NBC Sports: [Eagles trade with Cowboys to select USC WR Makai Lemon 20th](https://news.google.com/rss/articles/CBMivgFBVV95cUxPd1drTUlxbVlsUTZVTGVqdThMWk1tWGgtVjYyOVY1WnJ0NHZ5RUE1clBXcFk0UDNDT0lfTUQ4TzJRa1ZseVZ1bzBBNVFNZWZNOURRa1JDbDNBUWUtLTJCOHRtU1FDbUIzcV81c1JNdUJTNXBCRGI2dDlPUEdkaUYzQTNEQ3lyZVpqZ29VM1NHR2k3UXFKUlo2UVBYNVctVXAxRC1iQXFhT3BVMUNaQW9DUUlFdWxYNDA0WlFveV9n?oc=5)
+
+## Publishing PR
+
+Published via PR: Pending

--- a/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026.md
+++ b/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026.md
@@ -7,7 +7,7 @@ subject: "sports"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/70"
 image: "/images/news-banner.png"
 ---
 
@@ -41,4 +41,4 @@ This is a live pro-sports roster-construction event with immediate competitive c
 
 ## Publishing PR
 
-Published via PR: Pending
+Published via PR: [#70](https://github.com/thestamp/Static-ai-articles/pull/70)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
+    "title": "2026 NFL Draft Day 1 Recap: First-Round Run on Quarterbacks and Aggressive Trade Moves",
+    "date": "2026-04-24",
+    "author": "Jordan Reeves",
+    "author_id": "sports_lead",
+    "author_display_name": "Jordan Reeves",
+    "subject": "sports",
+    "category": "sports",
+    "permalink": "/articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026/",
+    "summary": "Round 1 of the 2026 NFL Draft closed with a notable quarterback run and major trade-up moves, including the Eagles' move to No. 20 and the Rams selecting Ty Simpson at No. 13.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-24-turner-prize-2026-shortlist-mima-middlesbrough",
     "title": "Turner Prize 2026 Shortlist Names Four Artists, With Exhibition Set for MIMA in Middlesbrough",
     "date": "2026-04-24",


### PR DESCRIPTION
## Article Metadata
- Author persona: `sports_lead` (Jordan Reeves)
- Beat/Subject: `sports`
- Type: `news`
- Proposed article path: `articles/2026-04-24-nfl-draft-day-1-first-round-recap-2026.md`
- Published PR URL field: present in frontmatter/body (to be backfilled after PR creation)

## Duplicate/Update Gate Decision
- Decision: **New standalone story**
- Duplicate check performed against:
  - `articles/` corpus (no existing 2026 NFL Draft Day 1 first-round recap found)
  - open PRs in repo (no related open PR on this event)
- Material-new-facts update path not required this run.

## Editorial Rationale Log (thought-by-thought)
- Step 1: Constrained topic to sports desk assignment and selected a live, high-signal event (2026 NFL Draft Day 1).
- Step 2: Chose claims that can be corroborated across mixed outlet types (national recap + league/team + major sports outlet).
- Step 3: Limited copy to verifiable first-round facts and clearly labeled next-step watch items as forward-looking.

## Claim → Source Verification Matrix
| Claim | Source URL | Verified by | Status |
|---|---|---|---|
| Round 1 of the 2026 NFL Draft completed and recap coverage shifted to Day 2 framing. | https://news.google.com/rss/articles/CBMiZkFVX3lxTE1WN1Nhc001M3hmOTd1THB1Zm1FV25NZTlTS3JZYjBFTllwT3JFX1BpbXZfYXZFV2d1Mzd6UEVxa05WT0ViMjM2QlpRb3J1UUJkSzE2aUtoZnZUSVItdXM3ZG5fcVozd9IBa0FVX3lxTE1WUERodUVleGRkU1NMdFNONFFVM3N2QjJtZmUzZWdVN2wyWmJsQXVRbTBhbERMYWdiNGstbV9hSFF6MVJRMlpSdGtkR2hYOGpKWHdySHJvcjk3cVlBblh6MFF3RWhzUkxRaW9Z?oc=5 | hermes | ✅ |
| Raiders selected QB Fernando Mendoza with the No. 1 overall pick. | https://news.google.com/rss/articles/CBMitgFBVV95cUxNNjJJY3lZYzdmd0dYb2hYTnp2anIwSzBaWG1IQkktQThiZHE3ZkFxUXRDUTZ4Wkk5cW5qbHlTRWFVWUVpdENJSjZQMlN6dFdETXdZSENfSTkxNEtMd3N3RUVJTlVKTno1SUVEaFhkc0NWVkRlUzhzQ1ZRUnd3VmRBTEZNYldhalV5VUJwM0tnZnFsV1ZuSm5HdVRWN1MteWF3bFRHTFVxemJBVGJtWUQwa3pCOU5hZw?oc=5 | hermes | ✅ |
| Rams selected QB Ty Simpson at No. 13. | https://news.google.com/rss/articles/CBMilgFBVV95cUxPY1NFTVF0bGJqczBZWE04X1FRY0x1WnMybHhsZ2dqT1RwZHpYRjVKZVFBN1d2WVEwcmJURFFkTDlSRGhJU0c3QkNTZjZJNkhDdGVkallQYzFleWRZdi1BNmRTWF8ySm5ib1o1Y2dSdmxFOC1ySWlTdE5jUENHLTlPc1BtSmRGamNBX1VFQmsxMjhDNk1sVmc?oc=5 | hermes | ✅ |
| Eagles traded with Cowboys to move to No. 20 and selected WR Makai Lemon. | https://news.google.com/rss/articles/CBMivgFBVV95cUxPd1drTUlxbVlsUTZVTGVqdThMWk1tWGgtVjYyOVY1WnJ0NHZ5RUE1clBXcFk0UDNDT0lfTUQ4TzJRa1ZseVZ1bzBBNVFNZWZNOURRa1JDbDNBUWUtLTJCOHRtU1FDbUIzcV81c1JNdUJTNXBCRGI2dDlPUEdkaUYzQTNEQ3lyZVpqZ29VM1NHR2k3UXFKUlo2UVBYNVctVXAxRC1iQXFhT3BVMUNaQW9DUUlFdWxYNDA0WlFveV9n?oc=5 | hermes | ✅ |

## Source discovery and bias-check log
| Step | Query / feed / method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | Google News SPORTS RSS headline feed | Fast, current signal for breaking sports events | Aggregator ranking bias | Cross-checked specific claims against additional outlets, not single-feed narrative |
| 2 | Focused query: `2026 NFL Draft Day 1 recap` in Google News RSS search | Isolate recap-oriented reporting vs speculation | Search-term framing may over-prioritize recap takes | Added direct pick/trade claim sources from outlets with event-specific reports |
| 3 | Outlet-type balancing (CBS national outlet, ESPN major sports outlet, Raiders team site, NBC Sports) | Ensure at least two outlet types and reduce monoculture sourcing | Team sites can be self-promotional | Team-site claim used only for direct pick fact; corroborative context taken from independent outlets |
| 4 | Exclusion decision: fan blogs/open threads (e.g., discussion-only threads) | Avoid unsourced commentary and rumor amplification | Excluding community sources may miss color | Kept article narrowly factual; left interpretive analysis out |

Known uncertainty: pick-grade narratives and long-term impact assessments vary by analyst; article intentionally avoids grade claims and sticks to first-round factual outcomes.

## Delegation Trail
- `[products_sme](sports/product-impact reviewer):` asked to review whether article over-claimed Day 2 implications.
- Feedback loop:
  - `products_sme` feedback: “Keep the Day 2 section as watch items, not predictions; avoid asserting downstream roster outcomes as settled.”
  - `sports_lead` revision: Reframed section to “What to watch next” bullets and removed deterministic language.

## Image Attribution
- Source URL: Generated internally via OpenAI Images API (`gpt-image-1`) attempt
- License: N/A (generation failed in runner due missing API key)
- Attribution text: Fallback image used: `/images/news-banner.png`

## Review Gates
- [x] Copilot gate is temporarily disabled
- [x] Web developer approved (`/webdev-approved`)
- [x] Domain SME review completed (`products_sme`)
- [x] Chief editor review completed (`hermes_editor`)
- [x] Source verification completed
- [x] Opinion guidelines checked (not applicable; this is news)
- [x] Ad placement policy checked (`web_marketing_lead`)
