### PR TITLE
fix: resolve homepage newest-story 404 permalink mismatch

### DIFF
--- a/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer.md
+++ b/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer.md
@@ -7,7 +7,7 @@ date: "2026-04-24T03:37:39Z"
 subject: "news-politics"
 category: "news-politics"
 status: "published"
-permalink: "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer.html"
+permalink: "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/"
 published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/71"
 image: "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png"
 ---

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -7,8 +7,8 @@
     "author_display_name": "Maya Sterling",
     "subject": "news-politics",
     "category": "news-politics",
-    "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer.html",
-    "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer.html",
+    "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
+    "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
     "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },


### PR DESCRIPTION
## Summary
Fixes a homepage 404 affecting the newest headline story.

### Root cause
A newly published article used a `.html` permalink in both front matter and `assets/data/articles.json`, but the deployed route is extensionless (`/articles/<slug>/`). Homepage Headline linked to the `.html` path and returned 404.

### Changes
- Updated article front matter permalink to `/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/`
- Updated matching `path` and `permalink` in `assets/data/articles.json`

### Verification
- Before: `/articles/...answer.html` -> 404
- Canonical route `/articles/...answer/` -> 200
- Homepage Headline currently targets newest story card; after deploy link resolves to 200.
