### PR TITLE
Xbox Reprices Game Pass and Delays Day-One Call of Duty Access

### DIFF
--- a/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access.md
+++ b/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access.md
@@ -7,7 +7,7 @@ subject: "technology"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/73"
 image: "/images/news-banner.png"
 ---
 
@@ -35,4 +35,4 @@ For subscribers, lower monthly cost can improve affordability, but delayed first
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#73](https://github.com/thestamp/Static-ai-articles/pull/73)

--- a/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access.md
+++ b/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access.md
@@ -1,0 +1,38 @@
+---
+title: "Xbox Reprices Game Pass and Delays Day-One Call of Duty Access"
+author: "Adeline Park"
+author_id: "technology_lead"
+date: "2026-04-24"
+subject: "technology"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# Xbox Reprices Game Pass and Delays Day-One Call of Duty Access
+
+Microsoft is reducing pricing on select Xbox Game Pass tiers while changing launch access for new **Call of Duty** releases: instead of day-one inclusion, new entries are expected to arrive about a year later. The change pairs a consumer-price adjustment with a major content-timing shift in one of the service’s most important franchises.
+
+BBC reports the new policy and pricing shift as part of Microsoft’s Game Pass restructuring. The Verge separately reports internal framing that Game Pass had become too expensive, and The Game Business reports PC Game Pass pricing moving to **$13.99**.
+
+## Why this matters
+
+For subscribers, lower monthly cost can improve affordability, but delayed first-party blockbuster access changes the value proposition that historically differentiated Game Pass from traditional catalog subscriptions. For Microsoft, the move appears to balance subscription growth goals with premium release economics.
+
+## What to watch next
+
+- Whether Microsoft applies similar release-window delays to additional premium franchises.
+- Region-by-region pricing consistency and effective dates.
+- Any churn/retention signal in upcoming Xbox business disclosures.
+
+## Sources
+
+- BBC: [Xbox cuts prices for Game Pass but ends day-one Call of Duty access](https://www.bbc.com/news/articles/cgrlvvrn409o)
+- The Verge: [Xbox Game Pass ‘has become too expensive,’ says Microsoft’s gaming chief](https://www.theverge.com/tech/911182/microsoft-xbox-game-pass-too-expensive-leaked-memo)
+- The Game Business: [Xbox cuts Game Pass Ultimate price](https://www.thegamebusiness.com/p/xbox-cuts-game-pass-ultimate-price)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access",
+    "title": "Xbox Reprices Game Pass and Delays Day-One Call of Duty Access",
+    "date": "2026-04-24",
+    "author": "Adeline Park",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "subject": "technology",
+    "category": "technology",
+    "permalink": "/articles/2026-04-24-xbox-reprices-game-pass-delays-day-one-call-of-duty-access/",
+    "summary": "Microsoft is cutting select Xbox Game Pass prices while shifting new Call of Duty titles off day-one access to roughly a one-year window, according to concurrent reporting by BBC, The Verge, and The Game Business.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "title": "The international right has CPAC. Has the left finally found its answer? | Owen Jones",
     "date": "2026-04-24T03:37:39Z",
     "author": "Maya Sterling",


### PR DESCRIPTION
## Summary
Publishes one technology desk article on Xbox Game Pass pricing changes and delayed day-one Call of Duty availability.

## Desk fit rationale
- **Desk:** `technology`
- This story is a consumer-platform pricing and subscription-product change by Microsoft/Xbox, which is a direct technology/product-market development.

## Duplicate/update gate
- Checked `assets/data/articles.json` and `articles/*.md` for Xbox/Game Pass/Call of Duty overlap.
- Checked open PRs for same event overlap.
- Decision: **New** (no same-event duplicate found).

## Claim matrix
| Claim | Source | Evidence note |
|---|---|---|
| Xbox is cutting some Game Pass prices | BBC | Headline and body report subscription price cuts |
| New Call of Duty titles shift off day-one Game Pass access to ~1 year | BBC | OG description and article framing cite one-year delay |
| Internal Microsoft framing says Game Pass became too expensive | The Verge | Reported statement from gaming leadership context |
| PC Game Pass pricing listed at $13.99 | The Game Business | Outlet reports explicit PC Game Pass price point |

## Source discovery and bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | BBC Technology RSS | Fast desk-aligned detection of current item | Single-outlet framing | Required corroboration from additional outlets |
| 2 | Extract outbound links from BBC story HTML | Recover independent corroborating sources | Link selection may privilege cited outlets | Included both trade and general tech outlet |
| 3 | Verify direct fetch + metadata for Verge/Game Business | Confirm URLs reachable in runner | Paywall/partial context risk | Used only overlap facts consistent across sources |

## Image generation
- Requested OpenAI Images API (`gpt-image-1`) for topical editorial image.
- Fallback used: `/images/news-banner.png`.
- Reason: `OPENAI_API_KEY missing` in runner.
