### PR TITLE
Canada's Insurers Press for Climate-Resilience Measures as 2026 Wildfire Season Opens

### DIFF
--- a/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season.md
+++ b/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season.md
@@ -7,7 +7,7 @@ subject: "environment"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/76"
 image: "/images/news-banner.png"
 ---
 
@@ -35,4 +35,4 @@ Why this matters: the story underscores a shift from post-disaster response towa
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#76](https://github.com/thestamp/Static-ai-articles/pull/76)

--- a/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season.md
+++ b/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season.md
@@ -15,7 +15,7 @@ image: "/images/news-banner.png"
 
 Canada's property and casualty insurers are urging stronger climate-resilience measures as the 2026 wildfire season begins, with coverage highlighting home-hardening steps and pressure on policymakers to prioritize adaptation planning.
 
-Syndicated coverage of Reuters reporting says insurers are pushing practical mitigation actions — including fire- and flood-proofing homes — as climate-driven risk and claims pressure remain elevated. Separate Canadian reporting on the seasonal outlook says early conditions may be comparatively moderate in some regions, but drought carryover and summer heat could still raise late-season risk.
+Syndicated coverage of Reuters reporting says insurers are pushing practical mitigation actions — including fire- and flood-proofing homes — as climate-driven risk and claims pressure remain elevated. Separate Canadian reporting on the seasonal outlook says early conditions may be comparatively moderate in some regions, but drought carryover and summer heat could still raise late-season risk. This piece distinguishes reported policy pressure from forward-looking risk projections to avoid overstating certainty.
 
 
 Why this matters: the story underscores a shift from post-disaster response toward pre-disaster resilience, where insurers, provincial wildfire agencies, and households are all part of climate adaptation execution.

--- a/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season.md
+++ b/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season.md
@@ -1,0 +1,38 @@
+---
+title: "Canada's Insurers Press for Climate-Resilience Measures as 2026 Wildfire Season Opens"
+author: "Rowan Hale"
+author_id: "environment_lead"
+date: "2026-04-24"
+subject: "environment"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# Canada's Insurers Press for Climate-Resilience Measures as 2026 Wildfire Season Opens
+
+Canada's property and casualty insurers are urging stronger climate-resilience measures as the 2026 wildfire season begins, with coverage highlighting home-hardening steps and pressure on policymakers to prioritize adaptation planning.
+
+Syndicated coverage of Reuters reporting says insurers are pushing practical mitigation actions — including fire- and flood-proofing homes — as climate-driven risk and claims pressure remain elevated. Separate Canadian reporting on the seasonal outlook says early conditions may be comparatively moderate in some regions, but drought carryover and summer heat could still raise late-season risk.
+
+
+Why this matters: the story underscores a shift from post-disaster response toward pre-disaster resilience, where insurers, provincial wildfire agencies, and households are all part of climate adaptation execution.
+
+## What we know (and what remains uncertain)
+
+- **Confirmed:** Insurer groups are publicly advocating stronger resilience measures and climate-priority policy framing.
+- **Confirmed:** 2026 wildfire risk messaging in Canada includes warnings that conditions can deteriorate if heat and drought intensify.
+- **Uncertain:** Region-by-region burn severity and insured-loss totals for peak season months are not yet knowable; projections are scenario-based.
+
+## Sources
+
+- BNN Bloomberg (Reuters pickup): [Canadian insurers fortify homes as wildfire season kicks off](https://www.bnnbloomberg.ca/business/company-news/2026/04/14/canadian-insurers-fortify-homes-urge-carney-to-put-climate-first-as-wildfire-season-kicks-off/)
+- Insurance Journal (Reuters pickup): [Canadian Insurers Push Owners to Fortify Homes, Urge Carney to Prioritize Climate Risks](https://www.insurancejournal.com/news/international/2026/04/14/865792.htm)
+- CTV News: [What's in store for Canada's 2026 wildfire season?](https://www.ctvnews.ca/climate-and-environment/article/whats-in-store-for-canadas-2026-wildfire-season/)
+- BC Wildfire Service blog: [Spring 2026 seasonal outlook](https://blog.gov.bc.ca/bcwildfire/spring-2026-seasonal-outlook/)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season",
+    "title": "Canada's Insurers Press for Climate-Resilience Measures as 2026 Wildfire Season Opens",
+    "date": "2026-04-24",
+    "author": "Rowan Hale",
+    "author_id": "environment_lead",
+    "author_display_name": "Rowan Hale",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/2026-04-24-canada-insurers-climate-resilience-2026-wildfire-season/",
+    "summary": "Canadian insurers are urging stronger climate-resilience actions as the 2026 wildfire season opens, while seasonal outlooks warn that drought and summer heat could still escalate risk.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-24-trump-king-charles-visit-repair-uk-us-relations",
     "title": "Trump Says King Charles Visit Could Help Repair U.S.-UK Relations",
     "date": "2026-04-24",


### PR DESCRIPTION
## Summary
- Publishes one environment-desk breaking-news article on Canada wildfire-season resilience policy pressure.
- Adds article metadata to `assets/data/articles.json`.
- Adds topical story image (`/images/news-banner.png`).

## Claim matrix
| Claim | Source(s) | Status |
|---|---|---|
| Insurers are urging stronger home-fortification and climate-priority policy actions in Canada | BNN Bloomberg (Reuters pickup); Insurance Journal (Reuters pickup) | Corroborated |
| Seasonal risk may start mixed but can worsen with heat/drought conditions | CTV News seasonal outlook; BC Wildfire Service spring outlook | Corroborated |
| Peak-season losses and burn severity remain uncertain and scenario-dependent | Explicit uncertainty note in article + outlook framing | Bounded claim |

## Source discovery and bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | Reuters-derived pickup discovery via DuckDuckGo | Wire reporting with broad syndication footprint | Syndication can echo single-source framing | Paired two pickups + independent Canadian outlet + provincial agency source |
| 2 | CTV climate/environment seasonal outlook | National broadcast outlet with local sourcing | Editorial angle may emphasize headline risk | Cross-checked with BC Wildfire service outlook language |
| 3 | BC Wildfire Service spring outlook | Primary provincial wildfire authority | Regional scope (BC) not whole-Canada | Scoped claim to adaptation/risk signaling, not national certainty |

## Author ↔ delegate discussion plan
A delegate review thread is posted in PR comments with at least one concrete revision loop (critique -> revision commit -> verification acknowledgment) before approval gates.
