### PR TITLE
Sports: World Cup final resale listings top $2M amid ticket scrutiny

### DIFF
--- a/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny.md
+++ b/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny.md
@@ -7,7 +7,7 @@ subject: "sports"
 category: "sports"
 status: "published"
 permalink: "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/"
-published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/79"
 image: "/images/news-banner.png"
 ---
 
@@ -43,4 +43,4 @@ Extreme resale asks can turn major events into access and fairness debates rathe
 
 ## Publishing PR
 
-Published via PR: [pending](https://github.com/thestamp/Static-ai-articles/pull/TBD)
+Published via PR: [#79](https://github.com/thestamp/Static-ai-articles/pull/79)

--- a/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny.md
+++ b/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny.md
@@ -1,0 +1,46 @@
+---
+title: "World Cup Final Resale Listings Top $2M as Ticket-Price Scrutiny Intensifies"
+author: "Jordan Reeves"
+author_id: "sports_lead"
+date: "2026-04-24"
+subject: "sports"
+category: "sports"
+status: "published"
+permalink: "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/TBD"
+image: "/images/news-banner.png"
+---
+
+# World Cup Final Resale Listings Top $2M as Ticket-Price Scrutiny Intensifies
+
+Secondary-market listings for the 2026 World Cup final reached headline-grabbing levels this week, with The Guardian reporting four tickets listed on FIFA's resale site at about **$2.3 million each** at the time of publication.
+
+## Why this is a desk fit (sports)
+
+This is core sports-business coverage: pricing and access to a marquee global final directly affect fans, competition stakeholders, and the economics around the biggest event in men’s football.
+
+## What happened
+
+- The Guardian reported that four listings for the July 19 final at MetLife Stadium appeared at **$2,299,998.85** each on FIFA’s resale platform.
+- AP has separately reported unusually strong overall demand and active resale incentives around World Cup inventory.
+- AP also reports formal fan-advocacy pressure in Europe over World Cup ticket pricing practices, adding regulatory and governance scrutiny to the issue.
+
+## Why it matters
+
+Extreme resale asks can turn major events into access and fairness debates rather than purely sporting ones. For governing bodies, visibility of resale-price spikes can increase pressure over allocation design, anti-scalping controls, and consumer-protection guardrails.
+
+## What to watch next
+
+1. Whether FIFA adjusts resale guardrails (caps, transfer limits, verification, or queue controls).
+2. Whether fan-advocacy complaints in Europe trigger formal review outcomes that influence ticketing policy.
+3. Whether final-stage primary and resale pricing converges as the tournament approaches.
+
+## Sources
+
+- The Guardian: [World Cup final tickets listed for more than $2m on Fifa’s resale site](https://www.theguardian.com/football/2026/apr/23/world-cup-final-tickets-resale-prices-fifa-two-million)
+- AP News: [There is a massive demand for World Cup tickets and savvy resellers could be big winners](https://apnews.com/article/world-cup-tickets-price-fifa-697281ba3b1c7106804f9c251aff96b2)
+- AP News: [Soccer fans launch complaint over World Cup ticket prices to European Commission](https://apnews.com/article/world-cup-ticket-prices-c9809adff61b0091a79abae9b7604a46)
+
+## Publishing PR
+
+Published via PR: [pending](https://github.com/thestamp/Static-ai-articles/pull/TBD)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny",
+    "title": "World Cup Final Resale Listings Top $2M as Ticket-Price Scrutiny Intensifies",
+    "date": "2026-04-24",
+    "author": "Jordan Reeves",
+    "author_id": "sports_lead",
+    "author_display_name": "Jordan Reeves",
+    "subject": "sports",
+    "category": "sports",
+    "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-24-microsoft-first-voluntary-buyouts-us-workforce-ai-spending",
     "title": "Microsoft Launches First-Ever Voluntary Buyout Program for U.S. Staff as AI Spending Climbs",
     "date": "2026-04-24",


### PR DESCRIPTION
## Article Metadata
- Author persona: `sports_lead` (Jordan Reeves)
- Beat/Subject: `sports`
- Type: `news`
- Proposed article path: `articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny.md`
- `published_pr_url` field: present (placeholder; will be backfilled after PR creation)

## Duplicate/Update Gate
- Checked `articles/` and `assets/data/articles.json` for `world cup|fifa|resale|tickets` matches.
- Checked open PRs for related topic keywords.
- Result: **No duplicate found** and no active related open PR. Publishing as **new** story.

## Source discovery + bias-check log
- Discovery pass 1: Google News sports RSS surfaced this item cluster (ESPN + wire republish + Guardian).
- Discovery pass 2: AP search used to locate directly relevant World Cup ticket-pricing wire/context pieces.
- Discovery pass 3: Topic fit sanity check: this is sports-business access/economics around a major global final.

Bias check:
- Mix includes UK outlet (Guardian) + US wire (AP) to reduce single-outlet framing risk.
- Claims are constrained to what sources explicitly report; no speculative allegations added.
- Pricing claims are time-bound to “at time of publication”.

## Claim → Source Verification Matrix
| Claim | Source URL | Verified by | Status |
|---|---|---|---|
| Four World Cup final listings appeared on FIFA resale at about $2,299,998.85 each | https://www.theguardian.com/football/2026/apr/23/world-cup-final-tickets-resale-prices-fifa-two-million | sports_lead | ✅ |
| World Cup ticket demand is unusually high and resale dynamics are active | https://apnews.com/article/world-cup-tickets-price-fifa-697281ba3b1c7106804f9c251aff96b2 | sports_lead | ✅ |
| Fan advocates filed a complaint to the European Commission over World Cup ticket pricing | https://apnews.com/article/world-cup-ticket-prices-c9809adff61b0091a79abae9b7604a46 | sports_lead | ✅ |

## Author ↔ Delegate discussion (with feedback loop)
- **sports_lead (author):** Initial draft over-indexed on outrage framing (“price gouging”).
- **hermes_delegate (editorial QA):** Requested neutral rewrite, stricter attribution, and explicit time-bounding for resale listing claims.
- **sports_lead (revision):** Replaced loaded language with descriptive wording; narrowed claim scope to cited facts; added “What to watch next” policy-focused bullets.
- **hermes_delegate (final check):** Approved after verifying all key claims were source-mapped and headline stayed desk-appropriate.

## Image Attribution
- Requested: OpenAI Images API (`gpt-image-1`) for topical newsroom art.
- Result: generation unavailable in runner (`OPENAI_API_KEY` missing).
- Fallback used: `/images/news-banner.png` per runbook.

## Review Gates
- [x] Copilot gate is temporarily disabled
- [ ] Web developer approved (`/webdev-approved`)
- [ ] Domain SME review completed (`products_sme`)
- [ ] Chief editor review completed (`hermes_editor`)
- [x] Source verification completed
- [x] Opinion guidelines checked (N/A, not opinion)
- [x] Ad placement policy checked (`web_marketing_lead`) (no ad-placement changes)
