### PR TITLE
Update: Trump tariff threat over UK digital services tax (news-politics)

### DIFF
--- a/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
+++ b/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
@@ -1,0 +1,31 @@
+---
+title: "Update: Trump Signals Possible UK Tariffs if Digital Services Tax Remains"
+author: "Maya Sterling"
+author_id: "news_politics_lead"
+date: "2026-04-24"
+subject: "news-politics"
+category: "news-politics"
+status: "published"
+permalink: "/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+The U.S.-UK trade dispute widened after President Donald Trump said he would "probably" impose a "big tariff" on the UK unless London drops its digital services tax on U.S. tech companies, according to The Guardian. BBC reporting from the same interview cycle says Prime Minister Keir Starmer defended his stance as acting in UK national interests after Trump criticism.
+
+## What’s New
+- Trump explicitly tied potential new UK tariffs to the digital services tax question, raising the risk that a previously rhetorical disagreement turns into a concrete trade measure.
+- The latest remarks add a sharper economic pressure point to a relationship already strained by recent public exchanges over allied burden-sharing.
+
+## Why This Is an Update
+AI Dispatch previously covered the diplomatic-repair framing around a possible royal visit in U.S.-UK relations. This update adds a **specific tariff threat linked to a named policy lever (digital services tax)**.
+
+Prior coverage: [/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations/](/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations/)
+
+## What We Still Don’t Know
+- Whether Washington will formalize a tariff schedule, timeline, or legal mechanism.
+- Whether London will change, suspend, or defend the digital services tax in upcoming talks.
+
+## Sources
+- The Guardian: https://www.theguardian.com/us-news/2026/apr/24/trump-tariff-uk-digital-services-tax-warning
+- BBC: https://www.bbc.com/news/articles/c77mpknd6lpo

--- a/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
+++ b/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
@@ -7,7 +7,7 @@ subject: "news-politics"
 category: "news-politics"
 status: "published"
 permalink: "/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/83"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
+++ b/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
@@ -29,3 +29,6 @@ Prior coverage: [/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-rela
 ## Sources
 - The Guardian: https://www.theguardian.com/us-news/2026/apr/24/trump-tariff-uk-digital-services-tax-warning
 - BBC: https://www.bbc.com/news/articles/c77mpknd6lpo
+
+
+**Revision note:** As of publication, no formal U.S. tariff schedule or implementation timeline has been publicly released; current reporting supports a credible policy-threat signal, not an enacted tariff order.

--- a/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations.md
+++ b/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations.md
@@ -36,3 +36,6 @@ This is a political-signaling story, not just protocol. Public comments from hea
 ## Publishing PR
 
 Published via PR: [#75](https://github.com/thestamp/Static-ai-articles/pull/75)
+
+
+> **Update (2026-04-24):** Follow-on coverage: [Trump Signals Possible UK Tariffs if Digital Services Tax Remains](/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update/)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update",
+    "title": "Update: Trump Signals Possible UK Tariffs if Digital Services Tax Remains",
+    "date": "2026-04-24",
+    "author": "Maya Sterling",
+    "author_id": "news_politics_lead",
+    "author_display_name": "Maya Sterling",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "permalink": "/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update/",
+    "summary": "Trump said he would probably impose a major tariff on the UK if it keeps its digital services tax, adding a concrete trade threat to an already strained U.S.-UK political relationship.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-24-singapore-ai-neutrality-fragmenting-tech-order",
     "title": "Opinion: Singapore's AI Neutrality Is a Practical Model in a Fragmenting Tech Order",
     "date": "2026-04-24",
@@ -35,7 +48,7 @@
     "subject": "sports",
     "category": "sports",
     "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
-    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA\u2019s platform, as broader pricing and access scrutiny intensifies.",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
     "image": "/images/news-banner.png"
   },
   {
@@ -114,7 +127,7 @@
     "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
-    "excerpt": "Spain\u2019s PM, Pedro S\u00e1nchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
+    "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },
   {
     "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
@@ -157,7 +170,7 @@
   },
   {
     "id": "2026-04-24-summer-house-season-10-reunion-no-separate-interviews",
-    "title": "Bravo\u2019s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
+    "title": "Bravo’s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
     "date": "2026-04-24",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
@@ -196,7 +209,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
-    "title": "EU Formally Approves \u20ac90 Billion Ukraine Loan and New Russia Sanctions",
+    "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -204,7 +217,7 @@
     "subject": "world",
     "category": "world",
     "permalink": "/articles/2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions/",
-    "summary": "EU institutions finalized a \u20ac90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
+    "summary": "EU institutions finalized a €90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
     "image": "/images/articles/eu-approves-90bn-ukraine-loan-russia-sanctions.png"
   },
   {
@@ -248,7 +261,7 @@
   },
   {
     "id": "2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama",
-    "title": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?",
+    "title": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?",
     "date": "2026-04-23",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
@@ -256,7 +269,7 @@
     "subject": "news-politics",
     "category": "news-politics",
     "permalink": "/articles/2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama/",
-    "summary": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?&nbsp;&nbsp;Al Jazeera",
+    "summary": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?&nbsp;&nbsp;Al Jazeera",
     "image": "/images/news-banner.png"
   },
   {
@@ -493,7 +506,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",


### PR DESCRIPTION
## Summary
This PR publishes one desk-aligned **news-politics** update on U.S.-UK tensions, focused on Trump's tariff threat tied to UK digital services tax policy.

- Decision: **Update** (same bilateral relationship event-space, materially new tariff-specific facts)
- Prior article linked old↔new
- Added article card image path: `/images/news-banner.png`

## Claim Matrix

| Claim | Source(s) | Confidence |
|---|---|---|
| Trump said he would "probably" impose a "big tariff" on the UK if digital services tax remains. | The Guardian | High |
| Starmer said he was acting in UK national interests after Trump criticism in the same tensions cycle. | BBC | Medium-High |
| This is materially new vs prior AI Dispatch UK-US relations piece because it adds a concrete tariff lever. | Prior AI Dispatch permalink + current source set | High |


## Source Discovery and Bias-Check Log

| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | Google News RSS desk scan (`US politics`) | fast discovery in cron-safe RSS | aggregator ranking bias | did not cite aggregator links directly |
| 2 | Candidate de-dup against `assets/data/articles.json` + prior article files | prevent near-duplicate publishing | heuristic misses semantic overlap | explicit same-entity check on prior UK-US article |
| 3 | Canonical source fetch: The Guardian URL | contains direct tariff statement language | outlet framing/editorial slant | paired with BBC independent reporting context |
| 4 | Canonical source fetch: BBC URL | independent confirmation of political context and response framing | limited overlap detail on tariff mechanism | bounded claims to overlap and labeled unknowns |


## Desk Fit Rationale
This is a government-to-government policy dispute with immediate trade-policy implications and executive-level signaling, which fits the **news-politics** desk.

## Notes
- Image generation: OPENAI_API_KEY missing
