### PR TITLE
Science Health: Algeria trachoma elimination validation milestone

### DIFF
--- a/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation.md
+++ b/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation.md
@@ -1,0 +1,32 @@
+---
+title: "Algeria Eliminates Trachoma as Public Health Problem, WHO Validation Marks New African Milestone"
+author: "Dr. Lena Okafor"
+author_id: "science_health_lead"
+date: "2026-04-24"
+subject: "science-health"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# Algeria Eliminates Trachoma as Public Health Problem, WHO Validation Marks New African Milestone
+
+The World Health Organization (WHO) said on 23 April that **Algeria has eliminated trachoma as a public health problem**, a milestone that makes Algeria the **10th country in WHO’s African Region** and the **29th globally** to reach this validation status.
+
+Trachoma is a bacterial eye infection that can cause irreversible blindness when repeated infections scar the eyelid and cornea. WHO said Algeria’s result follows long-running control work in 12 southern wilayas where the disease burden remained highest, alongside surveillance and treatment programs designed to push active disease and trachomatous trichiasis below elimination thresholds.
+
+In a follow-up statement, Africa CDC said the validation highlights progress in region-wide neglected tropical disease control while warning that post-validation monitoring and integrated primary-care systems are essential to prevent resurgence.
+
+Why this matters: elimination validation is not the same as eradication, but it is a high bar for sustained public-health delivery. For health systems and donors, Algeria’s outcome is a signal that multi-year NTD campaigns can produce durable blindness-prevention gains when surveillance and frontline care stay funded.
+
+## Sources
+
+- WHO news release (23 Apr 2026): [Algeria eliminates trachoma as a public health problem](https://www.who.int/news/item/23-04-2026-algeria-eliminates-trachoma-as-a-public-health-problem)
+- Africa CDC statement (24 Apr 2026): [Africa CDC Statement on Algeria’s Elimination of Trachoma as a Public Health Problem](https://africacdc.org/news-item/africa-cdc-statement-on-algerias-elimination-of-trachoma-as-a-public-health-problem/)
+- News-Medical (WHO-syndicated, 24 Apr 2026): [Algeria eliminates trachoma as a public health problem after decades of effort](https://www.news-medical.net/news/20260424/Algeria-eliminates-trachoma-as-a-public-health-problem-after-decades-of-effort.aspx)
+
+## Publishing PR
+
+Published via PR: TBD

--- a/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation.md
+++ b/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation.md
@@ -7,7 +7,7 @@ subject: "science-health"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/107"
 image: "/images/news-banner.png"
 ---
 
@@ -29,4 +29,4 @@ Why this matters: elimination validation is not the same as eradication, but it 
 
 ## Publishing PR
 
-Published via PR: TBD
+Published via PR: [#107](https://github.com/thestamp/Static-ai-articles/pull/107)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation",
+    "title": "Algeria Eliminates Trachoma as Public Health Problem, WHO Validation Marks New African Milestone",
+    "date": "2026-04-24",
+    "author": "Dr. Lena Okafor",
+    "author_id": "science_health_lead",
+    "author_display_name": "Dr. Lena Okafor",
+    "subject": "science-health",
+    "category": "science-health",
+    "permalink": "/articles/2026-04-24-algeria-eliminates-trachoma-public-health-problem-who-validation/",
+    "summary": "WHO validated Algeria for eliminating trachoma as a public-health problem, with Africa CDC framing the result as a regional NTD milestone that now depends on sustained surveillance to prevent rebound.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-24-meta-plans-10-percent-workforce-cut-ai-spending-pressure-builds",
     "title": "Meta Plans 10% Workforce Cut as AI Spending Pressure Builds",
     "date": "2026-04-24",


### PR DESCRIPTION
## Summary
Adds a science-health article on WHO validation that Algeria eliminated trachoma as a public-health problem, with regional context from Africa CDC.

## Duplicate/Update Gate
- Decision: **NEW** (not duplicate)
- Checked existing `articles/*.md` and `assets/data/articles.json` for `trachoma`/`Algeria` event overlap.
- No prior Algeria-trachoma elimination article found, so no update-mode linkage required.

## Claim matrix
| Claim | Source | Status |
|---|---|---|
| WHO validated Algeria as having eliminated trachoma as a public-health problem. | WHO news release (2026-04-23) | Verified |
| Algeria is the 10th country in WHO African Region and 29th globally to achieve this milestone. | WHO release; Africa CDC statement | Cross-verified |
| Africa CDC frames this as progress but emphasizes surveillance/post-validation monitoring to prevent resurgence. | Africa CDC statement (2026-04-24) | Verified |

## Source discovery and bias-check log
1. Discovery pass 1: Google News science-health RSS (high noise; many non-authoritative items).
2. Discovery pass 2: BBC health/science RSS (desk-adjacent candidates but less direct primary documentation for this run).
3. Discovery pass 3: WHO news RSS yielded direct primary release on Algeria trachoma elimination.
4. Corroboration added from Africa CDC official statement for regional framing and implementation context.
5. Additional syndication check from News-Medical (WHO-attributed) used as tertiary confirmation, not as sole evidence.

Bias/quality controls:
- Prioritized institutional primary source (WHO) over aggregator wrappers.
- Added regional public-health body (Africa CDC) for independent framing beyond a single institution.
- Avoided extrapolating to eradication or claiming zero cases; language kept to validation/elimination threshold definitions.

## Author ↔ delegate discussion (with feedback loop)
- **Delegate (round 1):** Proposed framing as “eradication success.”
- **Author (Dr. Lena Okafor):** Requested correction: distinguish elimination as a public-health problem from eradication; add post-validation surveillance caveat.
- **Delegate (round 2):** Revised lede and “Why this matters” to clarify elimination threshold vs eradication and inserted monitoring requirement.
- **Author sign-off:** Approved revised framing and source stack.

## Image generation
- Attempted OpenAI Images API `gpt-image-1` for topical editorial art.
- API returned HTTP 400 in-run; fallback applied per runbook.
- Fallback image used: `/images/news-banner.png`.
