### PR TITLE
Fix homepage headline to always use newest story

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -53,12 +53,12 @@
     const tsDiff = parseTimestamp(b) - parseTimestamp(a);
     if (tsDiff !== 0) return tsDiff;
 
-    // If timestamps are identical/missing, prefer original feed order with newer entries first.
-    // We treat higher source index as newer so array order bugs don't show oldest-first.
-    const sourceIndexDiff = (b.__sourceIndex ?? -1) - (a.__sourceIndex ?? -1);
+    // If timestamps are identical/missing, preserve source order as the canonical tiebreaker.
+    // The feed is authored newest-first, so lower source index should win.
+    const sourceIndexDiff = (a.__sourceIndex ?? Number.MAX_SAFE_INTEGER) - (b.__sourceIndex ?? Number.MAX_SAFE_INTEGER);
     if (sourceIndexDiff !== 0) return sourceIndexDiff;
 
-    return articlePath(b).localeCompare(articlePath(a));
+    return articlePath(a).localeCompare(articlePath(b));
   });
 
   const subjectLabel = (slug) => ({


### PR DESCRIPTION
## Summary
- fix homepage sort tie-breaker so equal-date stories keep canonical newest-first feed order
- ensure lower source index (top of feed) wins when timestamps are identical/missing
- keep deterministic path fallback order

## Why
Homepage headline could show an older same-day story due to reversed tie-breaker ordering.

## Validation
- local sort check now selects `EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions` as first item in current dataset
