### PR TITLE
Arts & Entertainment: Antiquities dealer who exposed British Museum thefts dies at 61

### DIFF
--- a/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61.md
+++ b/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61.md
@@ -1,0 +1,36 @@
+---
+title: "Antiquities Dealer Who Exposed British Museum Thefts Dies at 61"
+author: "Camille Vega"
+author_id: "arts_entertainment_lead"
+author_display_name: "Camille Vega"
+date: "2026-04-28"
+subject: "arts-entertainment"
+category: "arts-entertainment"
+status: "published"
+permalink: "/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+Dr Ittai Gradel, an antiquities dealer and scholar who helped expose thefts from the British Museum, has died at age 61, according to BBC reporting published on April 28.
+
+## Why This Matters
+- Gradel played a central role in bringing international attention to accountability failures at one of the world's most influential museums.
+- His disclosures helped trigger wider scrutiny over provenance controls, cataloging, and restitution governance in major cultural institutions.
+- The story remains significant for the global arts and museum sector because it links individual whistleblowing to structural reforms.
+
+## What We Know
+- BBC reports Gradel died at 61.
+- BBC says he was instrumental in exposing stolen items tied to the British Museum scandal.
+- The report frames his role as pivotal in elevating concerns that later drove institutional response.
+
+## What To Watch Next
+- Whether UK cultural institutions announce further governance reforms tied to inventory and provenance controls.
+- Potential new statements from the British Museum on legacy remediation and restitution pathways.
+- Broader spillover into policy and donor due-diligence standards in the arts sector.
+
+## Sources
+- BBC News: https://www.bbc.com/news/articles/c1mk2pr39k7o
+- BBC Entertainment & Arts RSS: http://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml
+
+**Verification note:** At publication time, this brief relies on BBC's direct report and BBC's own desk feed metadata; additional independent confirmations may expand available detail.

--- a/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61.md
+++ b/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61.md
@@ -8,7 +8,7 @@ subject: "arts-entertainment"
 category: "arts-entertainment"
 status: "published"
 permalink: "/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/170"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61",
+    "title": "Antiquities Dealer Who Exposed British Museum Thefts Dies at 61",
+    "summary": "BBC reports that antiquities dealer Dr Ittai Gradel, known for exposing British Museum thefts, has died at 61.",
+    "author": "Camille Vega",
+    "author_id": "arts_entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "date": "2026-04-28",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "cbs-news-poll-and-analysis-on-california-voters-views-of-state-s-policies-ahead-of-debate",
     "title": "CBS News poll and analysis on California voters' views of state's policies ahead of debate - CBS News",
     "author": "Simone Hart",


### PR DESCRIPTION
## Summary
Publishes one arts-entertainment desk brief on the death of Dr Ittai Gradel and why his role in exposing British Museum thefts remains institutionally consequential.

## Claim matrix
| Claim | Source | Confidence |
|---|---|---|
| Dr Ittai Gradel died at age 61 | BBC article | High |
| Gradel helped expose British Museum thefts | BBC article | High |
| Event has governance implications for museums | Derived analysis from source context | Medium |

## Source discovery log
1. Desk RNG selected arts-entertainment; discovery attempted via BBC entertainment RSS + desk-specific feed scan.
2. Candidate selected: BBC direct report URL (reachable in runner).
3. Duplicate screen against existing `assets/data/articles.json` and article slugs/titles: no exact or near-duplicate found.

## Bias-check log
- Primary-source concentration risk: only BBC direct report was fully reachable in this run.
- Mitigation: constrained claims strictly to attributable facts and labeled verification limits.
- Avoided speculative cause-of-death details and unattributed institutional claims.

## Author ↔ delegate discussion (with feedback loop)
**Author (Camille Vega):** Draft lead focuses on obituary headline and sector implications.

**Delegate (Research assistant):** Tighten to verifiable facts only; remove any claim that implies official museum response unless explicitly sourced.

**Author revision:** Rewrote "What We Know" bullets to source-bound facts and added verification note in Sources section.

**Delegate follow-up:** Approved revised framing as publication-safe with evidence limits explicitly disclosed.
