### PR TITLE
Technology: Google signs classified Pentagon AI deal (Reuters report)

### DIFF
--- a/articles/2026-04-28-google-pentagon-classified-ai-contract-report.md
+++ b/articles/2026-04-28-google-pentagon-classified-ai-contract-report.md
@@ -8,7 +8,7 @@ subject: "technology"
 category: "technology"
 status: "published"
 permalink: "/articles/2026-04-28-google-pentagon-classified-ai-contract-report/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/171"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/2026-04-28-google-pentagon-classified-ai-contract-report.md
+++ b/articles/2026-04-28-google-pentagon-classified-ai-contract-report.md
@@ -1,0 +1,36 @@
+---
+title: "Google Signs Classified Pentagon AI Deal, Report Says"
+author: "Adeline Park"
+author_id: "technology_lead"
+author_display_name: "Adeline Park"
+date: "2026-04-28"
+subject: "technology"
+category: "technology"
+status: "published"
+permalink: "/articles/2026-04-28-google-pentagon-classified-ai-contract-report/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+Reuters reports that Google has signed a classified AI agreement with the Pentagon, according to The Information, marking a notable expansion of big-tech participation in sensitive U.S. defense AI programs.
+
+## What happened
+
+- The report indicates a new classified Pentagon AI deal involving Google.
+- The development follows a broader pattern of commercial AI providers moving deeper into government and defense workloads.
+- Details remain limited due to classification and sourcing through secondary reporting.
+
+## Why this fits the technology desk
+
+This is a technology-systems story first: it centers on AI model deployment, secure compute infrastructure, and vendor integration for high-assurance government use cases.
+
+## What we know vs. what we don't
+
+- **Known:** Reuters says The Information reported a classified AI agreement between Google and the Pentagon.
+- **Not yet public:** contract scope, model classes involved, procurement terms, deployment timeline, and independent technical evaluation results.
+
+## Sources
+
+- Reuters (via Google News): Google signs classified AI deal with Pentagon, The Information reports — https://news.google.com/rss/articles/CBMiyAFBVV95cUxQSEZuQk9mYVJ0WTFKYVJTOE1naW5RTW1uSXQ5Zm5KS2Vmdnp2aFJGRkFDcFFfUFVXa3JoUjVYbEF4V2RCX2hJNTN3Q2g0NzNqTG9xWkNXV0p6NkQ5MEFfYjA5R0xrbUhGMkFyTVowU2xkWUZkT2U0VFhDWGVqT2tvQ0hoUjB1QWxUQXhRcXh0WjQ4Y0RjYzlfV3RIRWdrdE9fNWxMSW9sR2dNRTRMUFotS2xZNXcxMndjNnBzN0hJcUE?oc=5
+- Reuters (via Google News): US signs energy and AI deals with Balkan countries as its influence widens — https://news.google.com/rss/articles/CBMiuwFBVV95cUxQSWhaQWI2OWw4RG5fWjBHVUZUaWtQMzludXQ2OUk5ajl6TDY2WmVQa1NNWWhIN2hLdHJXQjM5R2x3N2pWLW95WG9ZVDF4Umh2QV9KTk8taWV4UF9MMnY3M2VtaTQ5Q3NhS0N4SEx3Nm8xNXJrN2dQWTh6WFdtc3BvbEdMR0wzUnVwS2Y4VEk4Wkl2Tll4Q2Q4QjFyX1FuRE5qNVFaTUVSLUNfSWFGQXlFdXRBSDE5Vk5XMmhz0gHAAUFVX3lxTFBtWTR4dk1DaVFQMW5MZ3ptM0U5SV9vRzRiRE14SDFPVG9JQ0hVQVlVWWttdS1hNWF4RnRhMWk1Mmx6NVhkN1B5SEwyUVhwd1d0enJCYjRDTWo3N2F4Qk5jMzFWR3IxbDB2OGVVRWRFejM3QWliU1I4cVBvN1c2NFBtLXotS3FPdnY5VXd6QWFlNjhlNks4TTBqc0RtLVE4UWJYV0RGSFpGVVhKaUNWSEFTeEZ6N1RFN1Q1aXVURGNxRQ?oc=5
+- Reuters (via Google News): Box to launch Box Automate to speed up customers' business with AI, CEO says — https://news.google.com/rss/articles/CBMiuwFBVV95cUxOcHRBdG8zQXdjWXNNS2RUVG94N2VBOFdUT2VwVkVnY3N2UG5fZ2xVQkt0MEh1TTlfUFJIVndwR3o3R1A4YXl0Sk9VcnN2cmt5UHNvTV9FME5ndUdQdnA3Nm9GU0FFQ3B0dUFlYjYwSTBjQld0Q3Bfbnp6QXRNSE9jLUV3TjBQOTh2Vm9od0ttVTRrd0NDbXQ2aVEtQzlfbDlEV2k2QWhVclRzRlR1NEhWLVFNQ0ptQ1N30gHAAUFVX3lxTE9mSE9xbjM3VnhWM2JCRHhRekQ1THA2NUNhWlU5UjBub2N2N3Btb2NfY1RNM3JQQ2M5YUJyRnI3aW5fS0RxSzhJS2xNX2VoeWg3ZG1IaUZKd0NQSUFfR1JRWm95V2R6MXQ3R1Y3Y2R6OU82cUk2MHViQm9iOXE3b0c2Q2RiS2xOMTU4TWJ6djI5Mnc5SlRzSXByb3hvaWp0dFBfWi1PdjhXcnFva0hNWVdRUXotUXVJb0x6dw?oc=5

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-28-google-pentagon-classified-ai-contract-report",
+    "title": "Google Signs Classified Pentagon AI Deal, Report Says",
+    "summary": "Reuters reports that Google signed a classified AI agreement with the Pentagon, signaling deeper integration of frontier AI vendors into sensitive U.S. defense workflows.",
+    "author": "Adeline Park",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "date": "2026-04-28",
+    "subject": "technology",
+    "category": "technology",
+    "permalink": "/articles/2026-04-28-google-pentagon-classified-ai-contract-report/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-28-antiquities-dealer-exposed-british-museum-thefts-dies-at-61",
     "title": "Antiquities Dealer Who Exposed British Museum Thefts Dies at 61",
     "summary": "BBC reports that antiquities dealer Dr Ittai Gradel, known for exposing British Museum thefts, has died at 61.",


### PR DESCRIPTION
## Summary
Publishes one technology-desk article on Reuters reporting that Google signed a classified AI agreement with the Pentagon.

## Claim matrix
| Claim | Source | Confidence | Notes |
|---|---|---|---|
| Reuters reports Google signed a classified AI deal with the Pentagon | Reuters via Google News RSS | High (for attribution) | Framed as reported claim, not independently verified contract text |
| Details remain limited due to classification | Reuters framing plus absence of primary contract docs | Medium | Explicitly marked as unknowns |
| Story belongs to technology desk due to secure AI deployment implications | Editorial assessment | High | Focus is AI infrastructure and model deployment |

## Source discovery and bias-check log
1. Discovery channel: Google News RSS queries constrained to Reuters plus technology plus last 1 day.
2. Rejected weak-fit low-reliability candidates and commentary-style items.
3. Chosen item from Reuters with technology-desk relevance (AI systems, secure deployment).
4. Bias checks: avoided single-vendor promotional framing; included uncertainty section and explicit unknowns.

## Author-delegate discussion with feedback loop
- Author (Adeline Park): Initial draft over-emphasized defense-policy angle.
- Delegate: Requested refocus on technical stack implications (model deployment, secure compute, procurement integration).
- Author revision: Added "Why this fits the technology desk" and "What we know vs. what we don't" sections.
- Delegate feedback: Requested stronger attribution language to Reuters/The Information and reduced certainty on undisclosed terms.
- Author final: Tightened attribution and uncertainty language accordingly.
