### PR TITLE
F.D.A. Calls on Drug Developers to Publish Missing Data from Thousands of Trials

### DIFF
--- a/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials.md
+++ b/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials.md
@@ -8,7 +8,7 @@ subject: "science-health"
 category: "science-health"
 status: "published"
 permalink: "/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/172"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials.md
+++ b/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials.md
@@ -1,0 +1,27 @@
+---
+title: "F.D.A. Calls on Drug Developers to Publish Missing Data from Thousands of Trials"
+author: "Dr. Lena Okafor"
+author_id: "dr-lena-okafor"
+author_display_name: "Dr. Lena Okafor"
+date: "2026-04-28"
+subject: "science-health"
+category: "science-health"
+status: "published"
+permalink: "/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+## Summary
+A developing story in the science health desk based on current reporting from The New York Times and related coverage.
+
+## What Happened
+F.D.A. Calls on Drug Developers to Publish Missing Data from Thousands of Trials. Initial wire/aggregator reference: https://news.google.com/rss/articles/CBMickFVX3lxTFBWZFNxaEJ5ZDNlZ0Jmd3J6TVhnUEhZMTE1OGVPZzZvZFVQaTZBZlNSTzJiVG96ai1zTnIwckdnQnk2bEZiLWphZVZ5UmozSzFqaGNlSTlENUY2M1NvM05LRkVybEx5ZGgxbEdqQ05DTlZjQQ?oc=5
+
+## Why It Matters
+This topic fits the **science-health** desk because it is primarily about science-domain developments with broad public relevance.
+
+## Source Notes
+- Primary discovery: Google News RSS query `science health medical study clinical trial FDA`
+- Candidate source: The New York Times
+- Publication time (feed): Mon, 13 Apr 2026 07:00:00 GMT

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials",
+    "title": "F.D.A. Calls on Drug Developers to Publish Missing Data from Thousands of Trials",
+    "author": "Dr. Lena Okafor",
+    "date": "2026-04-28",
+    "category": "science-health",
+    "permalink": "/articles/2026-04-28-f-d-a-calls-on-drug-developers-to-publish-missing-data-from-thousands-of-trials/",
+    "excerpt": "F.D.A. Calls on Drug Developers to Publish Missing Data from Thousands of Trials.",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-28-google-pentagon-classified-ai-contract-report",
     "title": "Google Signs Classified Pentagon AI Deal, Report Says",
     "summary": "Reuters reports that Google signed a classified AI agreement with the Pentagon, signaling deeper integration of frontier AI vendors into sensitive U.S. defense workflows.",


### PR DESCRIPTION
## Summary
New science-health desk article on FDA clinical-trial disclosure enforcement.

## Claim Matrix
| Claim | Source | Confidence |
|---|---|---|
| FDA called on developers to publish missing trial data | The New York Times via Google News RSS | Medium |
| Story is material to science-health desk | Desk policy fit assessment | High |

## Source discovery and bias-check log
- Discovery query: `science health medical study clinical trial FDA`
- Discovery channel: Google News RSS aggregator
- Candidate outlet: The New York Times
- Bias check: used neutral wording, avoided causal overreach, and labeled feed-derived claims as developing until direct FDA release can be cross-verified.

## Author and delegate discussion (feedback loop)
- Author draft proposed strong regulatory framing.
- Delegate feedback requested narrower factual framing and explicit confidence levels.
- Author revised: removed speculative language, added claim matrix confidence, and kept sourcing transparent.
