### PR TITLE
Update: Starmer avoids Mandelson vetting inquiry after Commons vote

### DIFF
--- a/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote.md
+++ b/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote.md
@@ -7,7 +7,7 @@ subject: "news-politics"
 category: "news-politics"
 status: "published"
 permalink: "/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/177"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote.md
+++ b/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote.md
@@ -1,0 +1,28 @@
+---
+title: "Update: Starmer Avoids Mandelson Vetting Inquiry After Commons Vote"
+author: "Maya Sterling"
+author_id: "news_politics_lead"
+date: "2026-04-28"
+subject: "news-politics"
+category: "news-politics"
+status: "published"
+permalink: "/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+Prime Minister Keir Starmer avoided a formal parliamentary inquiry Tuesday into the government’s handling of Peter Mandelson’s vetting, after MPs voted down an opposition push for a Privileges Committee process.
+
+## What’s New
+- MPs voted against opening a Privileges Committee inquiry tied to claims Starmer misled Parliament on vetting disclosures.
+- No. 10’s position hardened from damage control to procedural closure, at least for now in the Commons.
+- The political dispute continues, but the immediate escalation route through committee referral was blocked.
+
+## Old ↔ New coverage links
+- Previous update: /articles/2026-04-28-update-uk-mandelson-vetting-row-starmer-adviser/
+- This update: /articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote/
+
+## Sources
+- BBC Politics (Apr 28, 2026): PM won't face inquiry over claims he misled MPs on Mandelson vetting — https://www.bbc.com/news/articles/cx21lx9ne83o
+- The Guardian Politics (Apr 28, 2026): Starmer sees off major Labour rebellion over call for Mandelson inquiry — https://www.theguardian.com/politics/2026/apr/28/starmer-sees-off-tory-calls-for-inquiry-into-mandelson-role-after-no-10-flexes-muscle
+- BBC Politics background (Apr 28, 2026): I made 'serious mistake' advising Starmer to appoint Mandelson, PM's ex-top adviser says — https://www.bbc.com/news/articles/czx26yz7kxzo

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote",
+    "title": "Update: Starmer Avoids Mandelson Vetting Inquiry After Commons Vote",
+    "summary": "UK MPs voted down an inquiry push in the Mandelson vetting dispute, preventing immediate escalation to a Privileges Committee process.",
+    "author": "Maya Sterling",
+    "author_id": "news_politics_lead",
+    "author_display_name": "Maya Sterling",
+    "date": "2026-04-28",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "permalink": "/articles/2026-04-28-update-starmer-avoids-mandelson-vetting-inquiry-vote/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-28-third-ukrainian-strike-hits-russian-oil-refinery-and-prompts-evacuations",
     "title": "Third Ukrainian Strike Hits Russian Oil Refinery and Prompts Evacuations",
     "summary": "BBC and corroborating reports say a third Ukrainian strike hit Russia's Tuapse refinery, triggering fire response and evacuations nearby.",


### PR DESCRIPTION
## Summary
This PR publishes a **news-politics update** on the UK Mandelson vetting dispute, focused on the new parliamentary outcome that Starmer will not face the requested inquiry route.

## Duplicate/update gate decision
- Existing related story found: `/articles/2026-04-28-update-uk-mandelson-vetting-row-starmer-adviser/`
- Decision: **Update (material new facts)**, not duplicate.
- Material delta: Commons vote outcome blocked the immediate Privileges Committee escalation path.

## Claim matrix
| Claim | Evidence | Source |
|---|---|---|
| MPs voted against advancing inquiry route tied to Mandelson vetting dispute | Same-day politics report on vote outcome and parliamentary handling | BBC Politics: https://www.bbc.com/news/articles/cx21lx9ne83o |
| Political pressure was already elevated by adviser "serious mistake" remarks | Earlier same-day reporting provides direct quote and context | BBC Politics: https://www.bbc.com/news/articles/czx26yz7kxzo |
| Opposition pressure and intra-party strain were actively in play | Independent report of rebellion/inquiry push dynamics | The Guardian: https://www.theguardian.com/politics/2026/apr/28/starmer-sees-off-tory-calls-for-inquiry-into-mandelson-role-after-no-10-flexes-muscle |

## Source discovery and bias-check log
1. Discovery attempt 1 (desk-fit): BBC Politics RSS (high reliability, direct UK politics desk).
2. Discovery attempt 2: NPR Politics RSS scanned; skipped for this run because selected lead topic was UK parliamentary process and BBC/Guardian offered stronger primary UK parliament detail.
3. Discovery attempt 3: Guardian Politics RSS used as independent corroboration with different editorial framing.

Bias/quality checks:
- Avoided single-source dependence by using BBC + Guardian.
- Kept wording procedural and attributed; avoided speculative motives.
- Framed as update because prior event chronology already existed in-repo.

## Author and delegate discussion (with feedback loop)
- **Author (Maya Sterling):** Lead should emphasize what changed *today* and why it changes parliamentary trajectory.
- **Delegate:** Draft initially centered too much on prior adviser quote; proposed refocus on vote outcome and committee pathway.
- **Author feedback:** Accepted. Requested explicit "What's New" bullets and old↔new linking for continuity.
- **Delegate revision:** Rewrote lede around Commons vote outcome, added "What's New", and linked previous coverage.
- **Author final:** Approved for publication as Update.

## Checklist
- [x] Article added under `articles/`
- [x] `assets/data/articles.json` updated
- [x] Update framing with old↔new links included
- [x] Ready for SME/editor/webdev approval commands
