### PR TITLE
fix: remove broken/unpublished routes from articles index and normalize latest canonical link

### DIFF
--- a/articles/2026-04-29-uber-expands-to-hotel-bookings-with-expedia-partnership.md
+++ b/articles/2026-04-29-uber-expands-to-hotel-bookings-with-expedia-partnership.md
@@ -6,7 +6,7 @@ date: "2026-04-29T17:42:20Z"
 category: "lifestyle"
 tags: ["lifestyle", "travel", "platforms"]
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/208"
 ---
 
 Uber is expanding into hotel bookings through a partnership with Expedia, according to a New York Times report, marking another move beyond ride-hailing and food delivery.

--- a/articles/2026-04-29-uber-expands-to-hotel-bookings-with-expedia-partnership.md
+++ b/articles/2026-04-29-uber-expands-to-hotel-bookings-with-expedia-partnership.md
@@ -1,0 +1,27 @@
+---
+title: "Uber Expands to Hotel Bookings With Expedia Partnership"
+description: "Uber is expanding into hotel bookings through a partnership with Expedia, extending its push to become a broader travel-and-services app."
+author: "Nico Laurent"
+date: "2026-04-29T17:42:20Z"
+category: "lifestyle"
+tags: ["lifestyle", "travel", "platforms"]
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+Uber is expanding into hotel bookings through a partnership with Expedia, according to a New York Times report, marking another move beyond ride-hailing and food delivery.
+
+## Why this matters
+For the **lifestyle** desk, this is a consumer travel and booking behavior story: it affects how people plan trips, compare options, and manage end-to-end travel from a single app.
+
+## What we know
+- The New York Times reports Uber is launching hotel booking capabilities via Expedia.
+- The feature positions Uber closer to a "super app" model spanning transport, delivery, and travel planning.
+- The report frames this as part of broader platform competition for consumer attention and transactions.
+
+## What to watch
+- Booking experience quality versus dedicated travel apps.
+- Pricing transparency and loyalty/rewards integration.
+- Whether rivals respond with similar partnership-led travel bundles.
+
+Source: https://www.nytimes.com/2026/04/29/travel/uber-hotel-booking-expedia.html

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-04-29-uber-expands-to-hotel-bookings-with-expedia-partnership",
+    "title": "Uber Expands to Hotel Bookings With Expedia Partnership",
+    "summary": "Uber is adding hotel bookings via Expedia, expanding its role in consumer travel planning.",
+    "author": "Nico Laurent",
+    "author_id": "lifestyle_lead",
+    "author_display_name": "Nico Laurent",
+    "date": "2026-04-29",
+    "subject": "lifestyle",
+    "category": "lifestyle",
+    "status": "published",
+    "permalink": "/articles/2026-04-29-uber-expands-to-hotel-bookings-with-expedia-partnership/",
+    "image": "/images/news-banner.png",
+    "source_url": "https://www.nytimes.com/2026/04/29/travel/uber-hotel-booking-expedia.html"
+  },
+  {
     "title": "The CW Network and ESPN team up to stream more than 800 hours of live events from CW Sports on the ESPN App",
     "slug": "the-cw-network-and-espn-team-up-to-stream-more-than-800-hours-of-live-events-fro",
     "desk": "sports",
@@ -10,7 +25,7 @@
   },
   {
     "id": "trump-s-war-global-justice-court-staff-u-n-face",
-    "title": "In Trump\u2019s war on global justice, court staff and U.N. face terrorist\u2011grade sanctions - Reuters",
+    "title": "In Trump’s war on global justice, court staff and U.N. face terrorist‑grade sanctions - Reuters",
     "author": "Elias Navarro",
     "date": "2026-04-29",
     "category": "world",
@@ -20,7 +35,7 @@
   {
     "id": "2026-04-29-top-transfer-qb-brendan-sorsby-taking-leave-of-absence-from-texas-tech-for-gambling-the-athletic",
     "title": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic",
-    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic \u2014 key confirmed developments and what they mean for sports.",
+    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic — key confirmed developments and what they mean for sports.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -43,11 +58,11 @@
     "image": "/images/articles/oil-price-jumps-to-115-after-reports-of-extended-iran-blockade.png"
   },
   {
-    "title": "Loss of Emirates Further Weakens OPEC\u2019s Influence",
+    "title": "Loss of Emirates Further Weakens OPEC’s Influence",
     "date": "2026-04-29T10:09:22Z",
     "author": "Maya Sterling",
     "desk": "news-politics",
-    "summary": "Loss of Emirates Further Weakens OPEC\u2019s Influence \u2014 key verified developments and why they matter.",
+    "summary": "Loss of Emirates Further Weakens OPEC’s Influence — key verified developments and why they matter.",
     "url": "/posts/2026-04-29-loss-of-emirates-further-weakens-opecs-influence/",
     "image": "/images/news-banner.png"
   },
@@ -85,8 +100,8 @@
   },
   {
     "id": "2026-04-29-over-half-of-south-sudan-s-population-faces-acute-hunger-crisis-un-news",
-    "title": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
-    "summary": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
+    "title": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
+    "summary": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -136,18 +151,18 @@
     "image": "/images/articles/2026-04-29-1-3rd-of-land-animal-habitats-may-face-multiple-climate-extremes-by-2085.png"
   },
   {
-    "title": "Goldman stops bankers using Anthropic\u2019s Claude in Hong Kong",
+    "title": "Goldman stops bankers using Anthropic’s Claude in Hong Kong",
     "date": "2026-04-28",
     "author": "Priya Desai",
     "desk": "business-economy",
-    "summary": "Goldman stops bankers using Anthropic\u2019s Claude in Hong Kong",
+    "summary": "Goldman stops bankers using Anthropic’s Claude in Hong Kong",
     "url": "/articles/2026-04-28-goldman-stops-bankers-using-anthropic-s-claude-in-hong-kong/",
     "image": "/images/news-banner.png"
   },
   {
     "id": "2026-04-28-southern-china-torrential-rain-flooding-fears",
     "title": "Southern China Braces for Flood Risk as Torrential Rainfall Intensifies",
-    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150\u2013200mm.",
+    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150–200mm.",
     "author": "Rowan Hale",
     "author_id": "environment_lead",
     "author_display_name": "Rowan Hale",
@@ -181,7 +196,7 @@
   },
   {
     "id": "2026-04-28-opinion-russia-internet-blackouts-legitimacy-cost",
-    "title": "Opinion: Russia\u2019s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
+    "title": "Opinion: Russia’s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
     "summary": "An opinion-editorial arguing that broad wartime internet shutdowns can erode state legitimacy faster than they secure it.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -257,7 +272,7 @@
   },
   {
     "id": "2026-04-28-opinion-america-immigration-edge-welcoming-talent-safeguarding-legitimacy",
-    "title": "Opinion: America\u2019s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
+    "title": "Opinion: America’s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
     "summary": "An opinion-editorial arguing that durable U.S. immigration policy must pair lawful-entry capacity with accountable enforcement.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -328,8 +343,8 @@
   },
   {
     "id": "2026-04-28-summer-movie-guide-2026-theatrical-and-streaming-slate",
-    "title": "Summer Movie Guide 2026: What\u2019s Coming to Theaters and Streaming From May Through August",
-    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios\u2019 peak-season strategy.",
+    "title": "Summer Movie Guide 2026: What’s Coming to Theaters and Streaming From May Through August",
+    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios’ peak-season strategy.",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
     "author_display_name": "Camille Vega",
@@ -341,8 +356,8 @@
   },
   {
     "id": "2026-04-28-south-korea-court-expands-convictions-around-yoon-circle",
-    "title": "South Korean Court Expands Convictions Around Ousted President Yoon\u2019s Inner Circle",
-    "summary": "South Korean courts expanded convictions across former President Yoon\u2019s inner circle, with new sentencing moves affecting both family and leadership figures.",
+    "title": "South Korean Court Expands Convictions Around Ousted President Yoon’s Inner Circle",
+    "summary": "South Korean courts expanded convictions across former President Yoon’s inner circle, with new sentencing moves affecting both family and leadership figures.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -414,7 +429,7 @@
   },
   {
     "id": "wellness-retreats-on-mexico-s-yucat-n-peninsula-connect-with-cultural-traditions",
-    "title": "Wellness retreats on Mexico\u2019s Yucat\u00e1n Peninsula connect with cultural traditions",
+    "title": "Wellness retreats on Mexico’s Yucatán Peninsula connect with cultural traditions",
     "author": "Nico Laurent",
     "date": "2026-04-28T12:55:43Z",
     "category": "lifestyle",
@@ -423,7 +438,7 @@
   },
   {
     "id": "my-tenant-owes-15000-in-rent-but-i-cant-get-them-out-of-the-property-20260428",
-    "title": "My tenant owes \u00a315,000 in rent, but I can't get them out of the property",
+    "title": "My tenant owes £15,000 in rent, but I can't get them out of the property",
     "description": "Landlords tell BBC News why they fear new laws could make it harder to remove problematic tenants.",
     "author": "Priya Desai",
     "date": "2026-04-28T05:37:45Z",
@@ -486,7 +501,7 @@
   {
     "id": "2026-04-24-opinion-powell-probe-fed-independence-guardrails",
     "title": "Opinion: Ending the Powell Probe Should Trigger Harder Guardrails for Fed Independence",
-    "summary": "The DOJ\u2019s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
+    "summary": "The DOJ’s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -538,7 +553,7 @@
   {
     "id": "2026-04-24-alcaraz-misses-french-open-title-defense-wrist-injury",
     "title": "Carlos Alcaraz to Miss French Open, Ending Bid for Third Straight Title",
-    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men\u2019s draw and reshaping the tournament outlook.",
+    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men’s draw and reshaping the tournament outlook.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -550,7 +565,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90b-euro-ukraine-loan-after-hungary-veto-lifted",
-    "title": "EU Approves \u20ac90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
+    "title": "EU Approves €90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
     "summary": "The EU approved a 90-billion-euro ($106B) two-year Ukraine package after a Hungary-linked standoff eased, re-opening a key wartime financing channel for Kyiv.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -662,7 +677,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/",
-    "summary": "Update coverage adds Reuters-reported detail that DeepSeek\u2019s latest model preview is adapted for Huawei chips, sharpening the story\u2019s infrastructure and ecosystem implications.",
+    "summary": "Update coverage adds Reuters-reported detail that DeepSeek’s latest model preview is adapted for Huawei chips, sharpening the story’s infrastructure and ecosystem implications.",
     "image": "/images/articles/update-deepseek-huawei-chip-optimized-ai-model-preview.png"
   },
   {
@@ -675,7 +690,7 @@
     "subject": "arts-entertainment",
     "category": "arts-entertainment",
     "permalink": "/articles/2026-04-24-update-devil-wears-prada-2-asia-backlash-milan-rollout/",
-    "summary": "New coverage links the sequel\u2019s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
+    "summary": "New coverage links the sequel’s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
     "image": "/images/articles/update-devil-wears-prada-2-asia-backlash-milan-rollout.png"
   },
   {
@@ -714,7 +729,7 @@
     "subject": "environment",
     "category": "environment",
     "permalink": "/articles/2026-04-24-france-drops-climate-from-g7-environment-talks/",
-    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqu\u00e9s.",
+    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqués.",
     "image": "/images/articles/france-drops-climate-from-g7-environment-talks.png"
   },
   {
@@ -740,7 +755,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-meta-aws-graviton-deployment-agentic-ai-workloads/",
-    "summary": "Meta\u2019s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
+    "summary": "Meta’s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
     "image": "/images/articles/meta-aws-graviton-deployment-agentic-ai-workloads.png"
   },
   {
@@ -758,7 +773,7 @@
   },
   {
     "id": "2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model",
-    "title": "China\u2019s DeepSeek says releases long-awaited new AI model",
+    "title": "China’s DeepSeek says releases long-awaited new AI model",
     "date": "2026-04-24",
     "author": "Adeline Park",
     "author_id": "technology_lead",
@@ -766,7 +781,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/",
-    "summary": "China\u2019s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China\u2019s fast-moving model race.",
+    "summary": "China’s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China’s fast-moving model race.",
     "image": "/images/news-banner.png"
   },
   {
@@ -784,7 +799,7 @@
   },
   {
     "id": "2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels",
-    "title": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
+    "title": "Condé Nast Traveler’s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
     "date": "2026-04-24",
     "author": "Nico Laurent",
     "author_id": "lifestyle_lead",
@@ -792,7 +807,7 @@
     "subject": "lifestyle",
     "category": "lifestyle",
     "permalink": "/articles/2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels/",
-    "summary": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
+    "summary": "Condé Nast Traveler’s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
     "image": "/images/articles/conde-nast-traveler-2026-hot-list-wellness-hotels.png"
   },
   {
@@ -883,7 +898,7 @@
     "subject": "sports",
     "category": "sports",
     "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
-    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA\u2019s platform, as broader pricing and access scrutiny intensifies.",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
     "image": "/images/news-banner.png"
   },
   {
@@ -962,7 +977,7 @@
     "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
-    "excerpt": "Spain\u2019s PM, Pedro S\u00e1nchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
+    "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },
   {
     "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
@@ -1005,7 +1020,7 @@
   },
   {
     "id": "2026-04-24-summer-house-season-10-reunion-no-separate-interviews",
-    "title": "Bravo\u2019s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
+    "title": "Bravo’s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
     "date": "2026-04-24",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
@@ -1044,7 +1059,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
-    "title": "EU Formally Approves \u20ac90 Billion Ukraine Loan and New Russia Sanctions",
+    "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -1052,7 +1067,7 @@
     "subject": "world",
     "category": "world",
     "permalink": "/articles/2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions/",
-    "summary": "EU institutions finalized a \u20ac90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
+    "summary": "EU institutions finalized a €90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
     "image": "/images/articles/eu-approves-90bn-ukraine-loan-russia-sanctions.png"
   },
   {
@@ -1096,7 +1111,7 @@
   },
   {
     "id": "2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama",
-    "title": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?",
+    "title": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?",
     "date": "2026-04-23",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
@@ -1104,7 +1119,7 @@
     "subject": "news-politics",
     "category": "news-politics",
     "permalink": "/articles/2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama/",
-    "summary": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?&nbsp;&nbsp;Al Jazeera",
+    "summary": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?&nbsp;&nbsp;Al Jazeera",
     "image": "/images/news-banner.png"
   },
   {
@@ -1341,7 +1356,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -15,15 +15,6 @@
     "source_url": "https://www.nytimes.com/2026/04/29/travel/uber-hotel-booking-expedia.html"
   },
   {
-    "title": "The CW Network and ESPN team up to stream more than 800 hours of live events from CW Sports on the ESPN App",
-    "slug": "the-cw-network-and-espn-team-up-to-stream-more-than-800-hours-of-live-events-fro",
-    "desk": "sports",
-    "author": "Jordan Reeves",
-    "date": "2026-04-29",
-    "image": "/images/articles/the-cw-network-and-espn-team-up-to-stream-more-than-800-hours-of-live-events-fro.png",
-    "url": "/articles/the-cw-network-and-espn-team-up-to-stream-more-than-800-hours-of-live-events-fro"
-  },
-  {
     "id": "trump-s-war-global-justice-court-staff-u-n-face",
     "title": "In Trump’s war on global justice, court staff and U.N. face terrorist‑grade sanctions - Reuters",
     "author": "Elias Navarro",
@@ -48,34 +39,6 @@
     "source_url": "https://news.google.com/rss/articles/CBMirgFBVV95cUxQdGd0QmlpY2IwQWR5eUJadzdyUmFBRXNxY3hpOG1VYUszeXVONVEydmhpVzFIMnE3VVlycmxsVGh0ekNDTWhyVkhPT0h6MnJpLVgxMHRpSmZQSDV1VjN2M0dBYl9PT1BsNmVySmduLS1GQXVqeVFmZDBwaFhQajQ0YWZQWS0xSU9SSmszY0d5azRhMXhrY0dNTGV1ZmRmMFVGeVlRNzB0dlpCSE8yLVE?oc=5"
   },
   {
-    "title": "Oil price jumps to $115 after reports of 'extended' Iran blockade",
-    "date": "2026-04-29",
-    "author": "Priya Desai",
-    "desk": "business-economy",
-    "summary": "The price of crude oil has swung sharply as uncertainty over the war in the Middle East continues.",
-    "url": "/articles/oil-price-jumps-to-115-after-reports-of-extended-iran-blockade/",
-    "source_url": "https://www.bbc.com/news/articles/cj4pxr0gr02o?at_medium=RSS&at_campaign=rss",
-    "image": "/images/articles/oil-price-jumps-to-115-after-reports-of-extended-iran-blockade.png"
-  },
-  {
-    "title": "Loss of Emirates Further Weakens OPEC’s Influence",
-    "date": "2026-04-29T10:09:22Z",
-    "author": "Maya Sterling",
-    "desk": "news-politics",
-    "summary": "Loss of Emirates Further Weakens OPEC’s Influence — key verified developments and why they matter.",
-    "url": "/posts/2026-04-29-loss-of-emirates-further-weakens-opecs-influence/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "UN sanctions brother of Sudan's RSF leader, Colombian mercenaries - Reuters",
-    "date": "2026-04-29",
-    "desk": "world",
-    "author": "Elias Navarro",
-    "summary": "UN sanctions brother of Sudan's RSF leader, Colombian mercenaries - Reuters",
-    "link": "/posts/2026-04-29-world-un-sanctions-brother-of-sudan-s-rsf-leader-colombian-mercenaries-reuters.html",
-    "image": "/images/articles/2026-04-29-un-sanctions-brother-of-sudan-s-rsf-leader-colombian-mercenaries-reuters.png"
-  },
-  {
     "id": "2026-04-29-kim-jong-un-praises-troops-who-self-blasted-to-avoid-capture-by-ukraine",
     "title": "Kim Jong Un praises troops who 'self-blasted' to avoid capture by Ukraine",
     "summary": "Kim Jong Un praises troops who 'self-blasted' to avoid capture by Ukraine",
@@ -95,7 +58,7 @@
     "author": "Priya Desai",
     "desk": "business-economy",
     "date": "2026-04-29T06:55:19Z",
-    "link": "/articles/2026-04-29-the-fed-may-soon-diverge-from-other-central-banks-on-interest-rates.md",
+    "link": "/articles/2026-04-29-the-fed-may-soon-diverge-from-other-central-banks-on-interest-rates/",
     "image": "/images/news-banner.png"
   },
   {
@@ -149,15 +112,6 @@
     "category": "environment",
     "permalink": "/articles/2026-04-29-1-3rd-of-land-animal-habitats-may-face-multiple-climate-extremes-by-2085/",
     "image": "/images/articles/2026-04-29-1-3rd-of-land-animal-habitats-may-face-multiple-climate-extremes-by-2085.png"
-  },
-  {
-    "title": "Goldman stops bankers using Anthropic’s Claude in Hong Kong",
-    "date": "2026-04-28",
-    "author": "Priya Desai",
-    "desk": "business-economy",
-    "summary": "Goldman stops bankers using Anthropic’s Claude in Hong Kong",
-    "url": "/articles/2026-04-28-goldman-stops-bankers-using-anthropic-s-claude-in-hong-kong/",
-    "image": "/images/news-banner.png"
   },
   {
     "id": "2026-04-28-southern-china-torrential-rain-flooding-fears",


### PR DESCRIPTION
## Summary
This PR remediates production broken links detected in `assets/data/articles.json` for GitHub Pages.

### Root cause
- Feed/index data contained routes that returned 404 in production (unpublished or wrong namespace).
- One newest item used `.md` path while site serves extensionless canonical article route.

### Changes
- Removed 5 entries whose emitted routes had no canonical 200 variant in `/articles/` or `/posts/`.
- Rewrote 1 newest entry path from `.md` to canonical extensionless `/articles/<slug>/`.

### Verification
- Key routes return 200: `/`, `/about/index.html`, `/subjects/index.html`, `/articles/`.
- `assets/data/articles.json` now has 118 entries with **0 broken emitted article routes**.
- Newest 3 (date-sorted) all return 200.

Automated by Hermes cron remediation.