### PR TITLE
technology: Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - R

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters",
+    "date": "2026-04-29",
+    "desk": "technology",
+    "author": "Adeline Park",
+    "summary": "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters.",
+    "url": "/articles/2026-04-29-exclusive-big-chinese-tech-firms-scramble-to-secure-huawei-ai-chips-af/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",
     "title": "Senate rejects curb on Trump military action in Cuba - Axios",
     "summary": "Senate rejects curb on Trump military action in Cuba - Axios — key confirmed developments and what they mean for news-politics.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -7,7 +7,7 @@
     "summary": "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters.",
     "url": "/articles/2026-04-29-exclusive-big-chinese-tech-firms-scramble-to-secure-huawei-ai-chips-af/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/216"
   },
   {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",

--- a/content/articles/2026-04-29-exclusive-big-chinese-tech-firms-scramble-to-secure-huawei-ai-chips-af.md
+++ b/content/articles/2026-04-29-exclusive-big-chinese-tech-firms-scramble-to-secure-huawei-ai-chips-af.md
@@ -5,7 +5,7 @@ desk: "technology"
 author: "Adeline Park"
 summary: "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/216"
 ---
 
 Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters.

--- a/content/articles/2026-04-29-exclusive-big-chinese-tech-firms-scramble-to-secure-huawei-ai-chips-af.md
+++ b/content/articles/2026-04-29-exclusive-big-chinese-tech-firms-scramble-to-secure-huawei-ai-chips-af.md
@@ -1,0 +1,22 @@
+---
+title: "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters"
+date: "2026-04-29"
+desk: "technology"
+author: "Adeline Park"
+summary: "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters.
+
+This is a developing story in the technology desk and details may evolve as more verified information is released.
+
+### What we know now
+- Reported development: Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters
+- Source: https://news.google.com/rss/articles/CBMixgFBVV95cUxQb2k3eWk0STFfck5fbjZoWkMzRlg5OFRGR19BM0xXV3Vfb0dCX1NralZ2SDNVQ1RvU1Zpck1mVGhNT0FfRFIwcERIaFVmTHRJRTVRVlNOQlR1a0lyVE9iLW9OT0pYQTdZc3NqdVhPeTJhajhwWlJfZUpOeFdSZmd2M3QxZ2RraG12d2xFSkk1VXloOTNtSFJXS05wb3Y5Zk94VHJwQ2Z4d0V2X1BsbWlIWm1CVTBkYkVVS1hXSy1jR0JMVURZSmc?oc=5
+- Updated (UTC): 2026-04-29 23:05
+
+### What to watch
+- Official confirmations and timeline updates
+- Quantified impacts and corrections


### PR DESCRIPTION
### Claim matrix
- Claim: Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters
  - Source: https://news.google.com/rss/articles/CBMixgFBVV95cUxQb2k3eWk0STFfck5fbjZoWkMzRlg5OFRGR19BM0xXV3Vfb0dCX1NralZ2SDNVQ1RvU1Zpck1mVGhNT0FfRFIwcERIaFVmTHRJRTVRVlNOQlR1a0lyVE9iLW9OT0pYQTdZc3NqdVhPeTJhajhwWlJfZUpOeFdSZmd2M3QxZ2RraG12d2xFSkk1VXloOTNtSFJXS05wb3Y5Zk94VHJwQ2Z4d0V2X1BsbWlIWm1CVTBkYkVVS1hXSy1jR0JMVURZSmc?oc=5
  - Confidence: medium

### Source discovery and bias-check log
- Desk-scoped Google News RSS discovery.
- Framing kept factual and uncertainty-aware.

### Editorial rationale and safety checks
- Desk-fit confirmed before drafting.
- Off-record/meta process notes excluded from article body.
