### PR TITLE
Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup",
+    "title": "Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup",
+    "summary": "Variety reports that Sean Penn and Paul Rudd are among additions to the Tribeca Festival's 2026 lineup, focusing attention on the festival's programming strategy and audience draw.",
+    "author": "Camille Vega",
+    "author_id": "arts_entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "date": "2026-04-30",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "status": "published",
+    "permalink": "/articles/2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup/",
+    "image": "/images/news-banner.png",
+    "source_url": "https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5"
+  },
+  {
     "id": "2026-04-30-wrexham-climbs-into-championship-playoff-spot-after-dramatic-win",
     "title": "Wrexham Climbs Into Championship Playoff Spot After Dramatic Win",
     "permalink": "/articles/2026-04-30-wrexham-climbs-into-championship-playoff-spot-after-dramatic-win/",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,8 @@
     "status": "published",
     "permalink": "/articles/2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup/",
     "image": "/images/news-banner.png",
-    "source_url": "https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5"
+    "source_url": "https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5",
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/220"
   },
   {
     "id": "2026-04-30-wrexham-climbs-into-championship-playoff-spot-after-dramatic-win",

--- a/content/articles/2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup.md
+++ b/content/articles/2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup.md
@@ -1,0 +1,26 @@
+---
+title: "Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup"
+description: "Variety reports that Sean Penn and Paul Rudd are among additions to the Tribeca Festival's 2026 lineup, focusing attention on the festival's programming strategy and audience draw."
+author: "Camille Vega"
+author_role: "arts-entertainment Desk Lead"
+date: "2026-04-30"
+last_updated: "2026-04-30"
+category: "arts-entertainment"
+tags: ["arts-entertainment", "festival", "film"]
+image: "/images/news-banner.png"
+image_alt: "Editorial image representing Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup"
+sources:
+  - name: "Google News / Variety"
+    url: "https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5"
+---
+
+## Summary
+Variety reports that Sean Penn and Paul Rudd are among additions to the Tribeca Festival's 2026 lineup, focusing attention on the festival's programming strategy and audience draw.
+
+## What Happened
+- Coverage indicates Tribeca Festival expanded its 2026 lineup with additional high-profile talent.
+- The reported additions include Sean Penn and Paul Rudd.
+- The update points to a continued emphasis on headline talent in festival positioning.
+
+## Why It Matters
+For the arts-entertainment desk, lineup updates can alter media momentum, screening demand, and distribution attention ahead of the festival window.

--- a/content/articles/2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup.md
+++ b/content/articles/2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup.md
@@ -12,6 +12,7 @@ image_alt: "Editorial image representing Sean Penn, Paul Rudd and More Join Trib
 sources:
   - name: "Google News / Variety"
     url: "https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/220"
 ---
 
 ## Summary


### PR DESCRIPTION
## Article
Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup

## OFF-RECORD: Claim matrix
- Claim: Tribeca Festival 2026 lineup includes Sean Penn and Paul Rudd.
- Source: https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5
- Confidence: Medium.

## OFF-RECORD: Source discovery and bias-check log
- Discovery: desk-targeted Google News RSS query for festival/film headlines.
- Bias check: attribution-first language; removed speculative framing.

## OFF-RECORD: Editorial rationale and safety checks
- Desk fit: arts-entertainment coverage of film festival programming.
- Safety: no defamatory claims; source-linked facts only.
