### PR TITLE
[sports] Were Arsenal right to be 'fuming' with refereeing after Atletico draw?

### DIFF
--- a/articles/2026-04-30-were-arsenal-right-to-be-fuming-with-refereeing-after-atletico-draw.md
+++ b/articles/2026-04-30-were-arsenal-right-to-be-fuming-with-refereeing-after-atletico-draw.md
@@ -1,0 +1,36 @@
+---
+layout: "article"
+title: "Were Arsenal right to be 'fuming' with refereeing after Atletico draw?"
+date: "2026-04-30 04:04:03 +0000"
+author: "Jordan Reeves"
+category: "sports"
+tags:
+  - "sports"
+  - "breaking-news"
+image: "/images/news-banner.png"
+source_url: "https://www.bbc.com/sport/football/articles/cr5p4335v7qo?at_medium=RSS&at_campaign=rss"
+published_pr_url: "TBD"
+---
+
+## Key Takeaways
+
+- Were Arsenal right to be 'fuming' with refereeing after Atletico draw?
+- The story was selected from a current sports source feed and is being tracked as a developing item.
+- Initial reporting highlights: Mikel Arteta was left "fuming" with the officials after Arsenal's draw at Atletico Madrid - what did they get right and wrong?
+
+## What Happened
+
+Mikel Arteta was left "fuming" with the officials after Arsenal's draw at Atletico Madrid - what did they get right and wrong?
+
+## Why It Matters
+
+This development is relevant to the sports beat because it has near-term implications for audiences following this desk's core coverage area.
+
+## What to Watch Next
+
+Editors will monitor follow-on reporting and official statements for confirmed new facts, timing updates, and broader impact.
+
+## Sources
+
+- [Were Arsenal right to be 'fuming' with refereeing after Atletico draw?](https://www.bbc.com/sport/football/articles/cr5p4335v7qo?at_medium=RSS&at_campaign=rss)
+- Feed: https://feeds.bbci.co.uk/sport/rss.xml?edition=uk

--- a/articles/2026-04-30-were-arsenal-right-to-be-fuming-with-refereeing-after-atletico-draw.md
+++ b/articles/2026-04-30-were-arsenal-right-to-be-fuming-with-refereeing-after-atletico-draw.md
@@ -9,7 +9,7 @@ tags:
   - "breaking-news"
 image: "/images/news-banner.png"
 source_url: "https://www.bbc.com/sport/football/articles/cr5p4335v7qo?at_medium=RSS&at_campaign=rss"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/221"
 ---
 
 ## Key Takeaways

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Were Arsenal right to be 'fuming' with refereeing after Atletico draw?",
+    "author": "Jordan Reeves",
+    "date": "2026-04-30",
+    "category": "sports",
+    "excerpt": "Mikel Arteta was left \"fuming\" with the officials after Arsenal's draw at Atletico Madrid - what did they get right and wrong?",
+    "url": "/articles/2026-04-30-were-arsenal-right-to-be-fuming-with-refereeing-after-atletico-draw.html",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup",
     "title": "Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup",
     "summary": "Variety reports that Sean Penn and Paul Rudd are among additions to the Tribeca Festival's 2026 lineup, focusing attention on the festival's programming strategy and audience draw.",


### PR DESCRIPTION
## Summary
Publish one sports desk article by Jordan Reeves.

## Claim matrix (off-record)
- Claim: Were Arsenal right to be 'fuming' with refereeing after Atletico draw?
  - Source: https://www.bbc.com/sport/football/articles/cr5p4335v7qo?at_medium=RSS&at_campaign=rss
  - Confidence: medium (wire/feed sourced)
- Claim: Desk fit is sports
  - Source: desk-specific feed (https://feeds.bbci.co.uk/sport/rss.xml?edition=uk)
  - Confidence: high

## Source discovery and bias-check log (off-record)
- Discovery feeds checked: https://feeds.bbci.co.uk/sport/rss.xml?edition=uk, https://www.espn.com/espn/rss/news, https://rss.nytimes.com/services/xml/rss/nyt/Sports.xml
- Selected item came from desk-matched feed.
- Bias check: relied on direct feed item + source link; avoided opinionated framing.

## Editorial rationale and safety checks (off-record)
- Topic selected because it is current and desk-specific.
- Story phrasing kept factual and non-defamatory.
- No internal process notes embedded in article body.

## Staff discussion plan
Threaded comments below include author/editor feedback loop and concrete resolution notes.