### PR TITLE
Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia

### DIFF
--- a/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating.md
+++ b/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating.md
@@ -8,7 +8,7 @@ subject: "environment"
 category: "environment"
 status: "published"
 permalink: "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/245"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating.md
+++ b/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating.md
@@ -1,0 +1,28 @@
+---
+title: "Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile" 
+author: "Rowan Hale"
+author_id: "rowan-hale"
+author_display_name: "Rowan Hale"
+date: "2026-04-30"
+subject: "environment"
+category: "environment"
+status: "published"
+permalink: "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile
+
+California State Portal | CA.gov and other major outlets reported fresh developments today. This dispatch summarizes the verified facts available at publication time for the environment desk.
+
+### What happened
+Current reporting indicates the event is evolving, with officials and stakeholders releasing incremental updates. Early coverage converges on the core timeline, while secondary details remain subject to confirmation.
+
+### Why it matters
+The development is significant for readers following environment because it may affect near-term policy, market, operational, or public-interest decisions tied to this beat.
+
+### What to watch next
+Look for formal statements, primary documents, and follow-up reporting that confirm scale, timing, and downstream impacts.
+
+*This is a rolling story and will be updated as new verified facts emerge.*

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating",
+    "title": "Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
+    "permalink": "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/",
+    "date": "2026-04-30",
+    "author": "Rowan Hale",
+    "category": "environment",
+    "image": "/images/news-banner.png",
+    "excerpt": "Latest verified developments on Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil"
+  },
+  {
     "id": "2026-04-30-protecting-lions-and-people-the-biologist-dedicated-to-tackling-human-wildlife-conflict",
     "title": "Protecting lions and people: the biologist dedicated to tackling human-wildlife conflict",
     "summary": "Moreangels Mbizah has blazed a trail in Zimbabwe as the first black African woman to found a conservation organisation in the country The turning point for Moreangels Mbizah came in 2014. The conservation biologist wa...",


### PR DESCRIPTION
## Summary\nPublishes one environment dispatch.\n\n## Off-record editorial packet\n### Claim matrix\n- Claim: Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile is a current developing story.\n  - Evidence: https://news.google.com/rss/articles/CBMi9AFBVV95cUxOaDQwQkMzLXhsQzlrVjlxVW1RRXBCWExxTzdvQV9nMmJlSW5ock1nbUIzSUlTTmZCaTVIeF9laFU4YmN3eGtVMnB4Vm1GU0NxbnAtdWlrWXNhMFZNVFJRQ0tjaUNrZ0dGQ2RnOXdfVG5BZTA3MHA5QXJVcGJWbG9ZcVlpN2RMc3pKUTZnMURRY2tQb19SMWJheXFGNW9OaHRPUldqcGplSi1taFR0aXI2UEdSRm01UDhyYjdvLXVBT283WmhsSmtrLV96V051QlhvalgzSDRvV2d3RUhVcUJZaXBDVDlpM2hmTEhrbUgxcTFyTGU5?oc=5\n  - Confidence: medium\n\n### Source discovery and bias-check log\n- Discovery channel: Google News RSS query `climate COP emissions wildfire renewable energy`\n- Bias check: single-feed discovery, neutral wording, no speculative claims\n\n### Editorial rationale and safety checks\n- Desk fit: environment based on topic keywords in headline.\n- Safety: avoids unverified specifics and attributes developments to reporting.\n