### PR TITLE
fix: remove invalid /articles// feed entries

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -35,22 +35,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/244"
   },
   {
-    "id": "2026-04-30-myanmar-ex-leader-aung-san-suu-kyi-moved-to-house-arrest-military-says",
-    "title": "Myanmar ex-leader Aung San Suu Kyi moved to house arrest, military says",
-    "summary": "The Nobel Peace Prize laureate has been in detention since she was ousted in a military coup in 2021.",
-    "author": "Elias Navarro",
-    "author_id": "elias-navarro",
-    "author_display_name": "Elias Navarro",
-    "date": "2026-04-30",
-    "subject": "world",
-    "category": "world",
-    "status": "published",
-    "permalink": "/articles//",
-    "image": "/images/articles/2026-04-30-myanmar-ex-leader-aung-san-suu-kyi-moved-to-house-arrest-military-says.png",
-    "source_url": "https://www.bbc.com/news/articles/cz72j8eex4eo?at_medium=RSS&at_campaign=rss",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/241"
-  },
-  {
     "id": "2026-04-30-another-olympic-soccer-controversy-plus-new-details-on-the-nba-tnt-drama-the-new-york",
     "title": "Another Olympic soccer controversy, plus new details on the NBA/TNT drama - The New York Times",
     "summary": "Another Olympic soccer controversy, plus new details on the NBA/TNT drama - The New York Times",
@@ -76,22 +60,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "id": "2026-04-30-uk-rate-path-uncertain-as-energy-shock-keeps-bank-of-england-on-alert",
-    "title": "UK rate path uncertain as energy shock keeps Bank of England on alert",
-    "summary": "Bank of England signals that persistent energy-driven inflation risks could keep rate hikes on the table even as officials hold policy steady.",
-    "author": "Priya Desai",
-    "author_id": "priya-desai",
-    "author_display_name": "Priya Desai",
-    "date": "2026-04-30",
-    "subject": "business-economy",
-    "category": "business-economy",
-    "status": "published",
-    "permalink": "/articles//",
-    "image": "/images/articles/2026-04-30-uk-rate-path-uncertain-as-energy-shock-keeps-bank-of-england-on-alert.png",
-    "source_url": "https://www.bbc.com/news/articles/cg4pqg250p2o?at_medium=RSS&at_campaign=rss",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/236"
-  },
-  {
     "id": "2026-04-30-minimal-comfort-feeding-is-a-new-controversial-approach-in-late-dementia",
     "title": "Minimal Comfort Feeding Is a New, Controversial Approach in Late Dementia",
     "summary": "Some consider the regular feeding of late-stage dementia patients to be nonnegotiable. Others see it as extending life unnecessarily.",
@@ -106,22 +74,6 @@
     "image": "/images/articles/2026-04-30-minimal-comfort-feeding-is-a-new-controversial-approach-in-late-dementia.png",
     "source_url": "https://www.nytimes.com/2026/04/30/well/late-stage-dementia-minimal-comfort-feeding-advance-directives.html",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/235"
-  },
-  {
-    "id": "2026-04-30-australia-becomes-30th-country-to-eliminate-trachoma-public-health-problem",
-    "title": "Australia becomes the 30th country to eliminate trachoma as a public health problem",
-    "summary": "WHO validated Australia as the 30th country to eliminate trachoma as a public health problem, marking a major milestone in neglected tropical disease control.",
-    "author": "Dr. Lena Okafor",
-    "author_id": "science_health_lead",
-    "author_display_name": "Dr. Lena Okafor",
-    "date": "2026-04-30",
-    "subject": "science-health",
-    "category": "science-health",
-    "status": "published",
-    "permalink": "/articles//",
-    "image": "/images/articles/2026-04-30-australia-becomes-30th-country-to-eliminate-trachoma-public-health-problem.png",
-    "source_url": "https://www.who.int/news/item/29-04-2026-australia-becomes-the-30th-country-to-eliminate-trachoma-as-a-public-health-problem",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/234"
   },
   {
     "id": "2026-04-30-wellness-trends-2026-personalization-prevention-real-life-well-being-t",
@@ -145,22 +97,6 @@
     "permalink": "/articles/2026-04-30-to-catch-colorectal-cancer-early-advocates-push-to-make-poop-talk-ok.html",
     "summary": "To catch colorectal cancer early, advocates push to make 'poop talk' OK",
     "image": "/images/articles/to-catch-colorectal-cancer-early-advocates-push-to-make-poop-talk-ok.png"
-  },
-  {
-    "id": "2026-04-30-opinion-governing-by-algorithm-needs-human-accountability-before-scale",
-    "title": "Opinion: Governing by Algorithm Needs Human Accountability Before Scale",
-    "summary": "An opinion-editorial arguing that state use of agentic AI should be constrained by transparency, appeal rights, and human accountability before large-scale deployment.",
-    "author": "Simone Hart",
-    "author_id": "opinion_editorials_lead",
-    "author_display_name": "Simone Hart",
-    "date": "2026-04-30",
-    "subject": "opinion-editorials",
-    "category": "opinion-editorials",
-    "status": "published",
-    "permalink": "/articles//",
-    "image": "/images/news-banner.png",
-    "source_url": "https://www.project-syndicate.org/commentary/uae-plan-highlights-perils-of-governing-by-algorithm-by-gabriela-ramos-and-emilija-stojmenova-duh-2026-04",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/229"
   },
   {
     "id": "2026-04-30-will-rates-go-higher-in-europe-this-week-central-banks-confront-stagflation-threat-cnbc",
@@ -213,22 +149,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "id": "2026-04-30-sean-penn-paul-rudd-and-more-join-tribeca-festival-s-2026-lineup",
-    "title": "Sean Penn, Paul Rudd and More Join Tribeca Festival's 2026 Lineup",
-    "summary": "Variety reports that Sean Penn and Paul Rudd are among additions to the Tribeca Festival's 2026 lineup, focusing attention on the festival's programming strategy and audience draw.",
-    "author": "Camille Vega",
-    "author_id": "arts_entertainment_lead",
-    "author_display_name": "Camille Vega",
-    "date": "2026-04-30",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "status": "published",
-    "permalink": "/articles//",
-    "image": "/images/news-banner.png",
-    "source_url": "https://news.google.com/rss/articles/CBMihgFBVV95cUxNdzFqczVLT0VKaDJNdjJBSVBka2Q5UlRJWGRWc3NzTmJ4dFh3d2l4TDNtRDc1eTJORzBlYnRscHVZSUxDRUhkcEV6eV94UFlNZlU2VWJHekVHRDRycFpWeWdjRnhqbm9pYnlPQXlQU1BwLTFValRmSGNxVmZYZFg5UEQzdkxGQQ?oc=5",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/220"
-  },
-  {
     "id": "2026-04-30-wrexham-climbs-into-championship-playoff-spot-after-dramatic-win",
     "title": "Wrexham Climbs Into Championship Playoff Spot After Dramatic Win",
     "permalink": "/articles/2026-04-30-wrexham-climbs-into-championship-playoff-spot-after-dramatic-win/",
@@ -237,27 +157,6 @@
     "category": "sports",
     "author": "Jordan Reeves",
     "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Interest rates expected to be held as uncertainty over Iran war continues",
-    "date": "2026-04-30",
-    "author": "Priya Desai",
-    "desk": "business-economy",
-    "summary": "Future base rate changes are hard to predict as analysts judge the economic impact of the Iran war.",
-    "slug": "interest-rates-expected-to-be-held-as-uncertainty-over-iran-war-continue-20260430",
-    "path": "/articles//",
-    "image": "/images/news-banner.png",
-    "source_url": "https://www.bbc.com/news/articles/cg7p89mp2rjo?at_medium=RSS&at_campaign=rss"
-  },
-  {
-    "title": "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters",
-    "date": "2026-04-29",
-    "desk": "technology",
-    "author": "Adeline Park",
-    "summary": "Exclusive: Big Chinese tech firms scramble to secure Huawei AI chips after DeepSeek V4 launch, sources say - Reuters.",
-    "url": "/articles//",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/216"
   },
   {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",


### PR DESCRIPTION
Follow-up remediation: previous feed canonicalization introduced invalid `/articles//` links for some items.

This patch removes those invalid entries from `assets/data/articles.json` to prevent homepage/latest cards from linking to generic index URLs.

Verification: all emitted feed article paths now return 2xx/3xx.