### PR TITLE
[news-politics] US Senate bans its members, staff from betting in prediction markets

### DIFF
--- a/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets.md
+++ b/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets.md
@@ -1,0 +1,28 @@
+---
+title: "US Senate bans its members, staff from betting in prediction markets"
+author: "Maya Sterling"
+author_id: "maya-sterling"
+author_display_name: "Maya Sterling"
+date: "2026-05-01"
+subject: "news-politics"
+category: "news-politics"
+status: "published"
+permalink: "/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets/"
+published_pr_url: ""
+image: "/images/news-banner.png"
+---
+
+US Senate bans its members, staff from betting in prediction markets
+
+### What happened
+According to Reuters, the U.S. Senate approved a ban preventing senators and Senate staff from placing bets in prediction markets, a move aimed at tightening ethics safeguards around lawmakers and market-sensitive information.
+
+### Why this matters
+The change reaches beyond chamber procedure: it intersects with congressional ethics, market regulation, and public trust in how officials handle information that can move prices and political expectations.
+
+### What to watch next
+- Whether the House pursues comparable restrictions for members and staff.
+- How prediction-market platforms implement and enforce Senate-linked account restrictions.
+- Whether broader federal ethics reforms emerge around financial conflicts tied to political intelligence.
+
+_Source: [Reuters](https://news.google.com/rss/articles/CBMisgFBVV95cUxOY0V2ZXJZMlJSdFdFSm9MNU9xNmotdC1VQldrc2YydHFyaE5IWUdqaDd2NnBCSlREalgwWFFXakNQdnc3aEJNc1JTdG4tRDY4NHJ5dXFhOFoyOTlCcHRUMDNMMDNVM3lNZGJvZDlqZVZaYjFGQjRzb3BjbHFMa3dXTnRVaUI5YjZ1ODA1aDdxN0M5bm1xWmRSSkttMGF6MDRaRjFLLWRwdmZlTkdLLTRxb3VB?oc=5)_

--- a/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets.md
+++ b/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets.md
@@ -8,7 +8,7 @@ subject: "news-politics"
 category: "news-politics"
 status: "published"
 permalink: "/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/267"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "2026-05-01-us-senate-bans-members-staff-prediction-markets",
+    "title": "US Senate bans its members, staff from betting in prediction markets",
+    "summary": "Reuters reports the U.S. Senate approved a ban on members and staff betting in prediction markets, tightening congressional ethics guardrails.",
+    "date": "2026-05-01T15:41:30Z",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "author": "Maya Sterling",
+    "author_id": "maya-sterling",
+    "author_display_name": "Maya Sterling",
+    "permalink": "/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-01-weekly-market-commentary-blackrock-com",
     "title": "Weekly market commentary - blackrock.com",
     "summary": "Google News reported new developments on Weekly market commentary - blackrock.com. This brief tracks what is known now, what remains unconfirmed, and why the update matters for the opinion-editorials desk.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "author_display_name": "Maya Sterling",
     "permalink": "/articles/2026-05-01-us-senate-bans-members-staff-prediction-markets/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/267"
   },
   {
     "id": "2026-05-01-weekly-market-commentary-blackrock-com",


### PR DESCRIPTION
## Summary
Publish one news-politics article for current cycle.

## Claim matrix (off-record)
1) Reuters headline reports U.S. Senate banned members and staff from betting in prediction markets.
   - Status: used with attribution
   - Confidence: medium (headline-level verification)

## Source discovery and bias-check log (off-record)
- Discovery channel: Google News RSS query scoped to Senate + Reuters/AP.
- Candidate fit check: selected Reuters political-process item; excluded stale/local-election policy items.
- Bias check: used neutral wording and explicit attribution; avoided extrapolating beyond reported scope.

## Editorial rationale and safety checks (off-record)
- Desk fit: directly about U.S. Senate governance and ethics policy.
- No medical/legal/financial advice.
- No off-record process text included in article file.

## Staff discussion seed
Please review attribution strength and whether headline-level sourcing is sufficient for publication threshold in this cycle.
