### PR TITLE
world: US to cut troop levels in Germany by 5,000 amid Trump spat with Merz

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "slug": "2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz",
+    "title": "US to cut troop levels in Germany by 5,000 amid Trump spat with Merz",
+    "date": "2026-05-02",
+    "author": "Elias Navarro",
+    "desk": "world",
+    "summary": "The decision to reduce the US deployment to Germany comes amid a row between the two allies over Iran.",
+    "image": "/images/news-banner.png",
+    "url": "/articles/2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz/"
+  },
+  {
     "id": "2026-05-01-as-summer-opens-action-movies-have-lost-some-box-office-punch",
     "title": "As summer opens, action movies have lost some box-office punch",
     "summary": "As summer opens, action movies have lost some box-office punch is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the arts-entertainment desk.",

--- a/content/articles/2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz.md
+++ b/content/articles/2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz.md
@@ -1,0 +1,15 @@
+---
+title: "US to cut troop levels in Germany by 5,000 amid Trump spat with Merz"
+date: "2026-05-02"
+author: "Elias Navarro"
+desk: "world"
+summary: "The decision to reduce the US deployment to Germany comes amid a row between the two allies over Iran."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+The decision to reduce the US deployment to Germany comes amid a row between the two allies over Iran.
+
+This is a newly selected world desk development from current reporting.
+
+Read more: [US to cut troop levels in Germany by 5,000 amid Trump spat with Merz](https://www.bbc.com/news/articles/c0729d374mxo?at_medium=RSS&at_campaign=rss)

--- a/content/articles/2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz.md
+++ b/content/articles/2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz.md
@@ -5,7 +5,7 @@ author: "Elias Navarro"
 desk: "world"
 summary: "The decision to reduce the US deployment to Germany comes amid a row between the two allies over Iran."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/278"
 ---
 
 The decision to reduce the US deployment to Germany comes amid a row between the two allies over Iran.


### PR DESCRIPTION
## Summary
Publish one world desk article.

## Off-record meta
### Claim matrix
- Primary claim: US to cut troop levels in Germany by 5,000 amid Trump spat with Merz
- Source URL: https://www.bbc.com/news/articles/c0729d374mxo?at_medium=RSS&at_campaign=rss
- Confidence: medium

### Source discovery and bias-check log
- Feed used: https://feeds.bbci.co.uk/news/world/rss.xml
- Desk feeds considered: https://feeds.bbci.co.uk/news/world/rss.xml, https://rss.nytimes.com/services/xml/rss/nyt/World.xml

### Editorial rationale and safety checks
- Desk fit: world
- Excluded off-record text from article body.
- Image path: /images/news-banner.png

### Internal process notes
- RNG N=1, author=Elias Navarro, SME=policy_sme
