### PR TITLE
News-Politics: Supreme Court ruling and gerrymandering outlook

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -7,7 +7,8 @@
     "desk": "news-politics",
     "summary": "NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles.",
     "image": "/images/news-banner.png",
-    "url": "/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering/"
+    "url": "/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering/",
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/280"
   },
   {
     "slug": "2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "slug": "2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering",
+    "title": "Supreme Court ruling expected to expand gerrymandering battles",
+    "date": "2026-05-02",
+    "author": "Maya Sterling",
+    "desk": "news-politics",
+    "summary": "NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles.",
+    "image": "/images/news-banner.png",
+    "url": "/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering/"
+  },
+  {
     "slug": "2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz",
     "title": "US to cut troop levels in Germany by 5,000 amid Trump spat with Merz",
     "date": "2026-05-02",

--- a/content/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering.md
+++ b/content/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering.md
@@ -5,7 +5,7 @@ author: "Maya Sterling"
 desk: "news-politics"
 summary: "NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/280"
 ---
 
 NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles.

--- a/content/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering.md
+++ b/content/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering.md
@@ -1,0 +1,15 @@
+---
+title: "Supreme Court ruling expected to expand gerrymandering battles"
+date: "2026-05-02"
+author: "Maya Sterling"
+desk: "news-politics"
+summary: "NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles.
+
+The decision is likely to shift legal and political strategy in multiple states where district maps are already under challenge. Election-law groups say the ruling could reduce avenues for federal court intervention and push more disputes into state courts and legislatures.
+
+Read more: [After a Supreme Court ruling, expect even more gerrymandering](https://www.npr.org/2026/05/01/nx-s1-5806320/after-a-supreme-court-ruling-expect-even-more-gerrymandering)


### PR DESCRIPTION
## Summary
New news-politics desk article on expected redistricting impacts after a Supreme Court ruling.

## Off-record editorial package
### Claim matrix
- Claim: The ruling is expected to increase partisan gerrymandering pressure in upcoming map cycles.
  - Source: NPR political desk report
  - Confidence: Medium-High
- Claim: Litigation strategy likely shifts toward state-level venues.
  - Source: NPR analysis + historical post-ruling pattern context
  - Confidence: Medium

### Source discovery and bias-check log
- Checked desk-fit feeds: BBC Politics, NPR Politics.
- Selected NPR item due to direct relevance to U.S. political institutions and election administration.
- Bias check: single-source risk flagged; language in article kept measured and attribution-explicit.

### Editorial rationale and safety checks
- Desk fit: U.S. domestic politics and institutional decision effects.
- Avoided speculative numerical claims and avoided quoting unverifiable private sources.
- Body includes only publishable content; internal notes kept in PR.
