### PR TITLE
[technology] Microsoft, OpenAI change terms of deal so startup can court Amazon and others

### DIFF
--- a/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others.md
+++ b/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others.md
@@ -1,0 +1,30 @@
+---
+title: "Microsoft, OpenAI change terms of deal so startup can court Amazon and others"
+author: "adeline_park"
+author_id: "adeline_park"
+author_display_name: "Adeline Park"
+date: "2026-05-02T03:35:33Z"
+subject: "technology"
+category: "technology"
+status: "published"
+permalink: "/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others/"
+published_pr_url: ""
+image: "/images/news-banner.png"
+---
+
+Microsoft, OpenAI change terms of deal so startup can court Amazon and others is drawing significant attention on the technology desk after fresh reporting from major outlets.
+
+Microsoft, OpenAI change terms of deal so startup can court Amazon and others&nbsp;&nbsp;Reuters
+
+At publication time, the core facts are based on currently available reporting and may evolve as officials and institutions release additional details.
+
+### Why it matters
+
+- The development has immediate relevance to readers tracking technology developments.
+- Near-term policy, market, or public-response implications may follow as more facts are confirmed.
+- We will update this story as new verified information becomes available.
+
+
+### Source
+
+- Google News (latest coverage): https://news.google.com/rss/articles/CBMipgFBVV95cUxONWJqVk9uV3RUa0tsclVNMjc5WFQ3SW9ZUC1MbXdKOVY3clg0aUU4QnhOYlJzRUJGcldaLVF3ZU8wZXgxVWlwQ2l6ckdZOWM3QnFoTXRkOGEzZ0E4LUhZNW1uVXF0bUpHYnM1Sl9rWTRLSWNEZjl3RXdUZ2dQeFpSMU9obmZjbzZMOUctaXRUSjdrZFpGS2pxWEhHM2dvekUtdG9KdktB?oc=5

--- a/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others.md
+++ b/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others.md
@@ -8,7 +8,7 @@ subject: "technology"
 category: "technology"
 status: "published"
 permalink: "/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/281"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Adeline Park",
     "permalink": "/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/281"
   },
   {
     "slug": "2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others",
+    "slug": "2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others",
+    "title": "Microsoft, OpenAI change terms of deal so startup can court Amazon and others",
+    "summary": "Microsoft, OpenAI change terms of deal so startup can court Amazon and others&nbsp;&nbsp;Reuters",
+    "date": "2026-05-02T03:35:33Z",
+    "subject": "technology",
+    "category": "technology",
+    "author": "Adeline Park",
+    "author_id": "adeline_park",
+    "author_display_name": "Adeline Park",
+    "permalink": "/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "slug": "2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering",
     "title": "Supreme Court ruling expected to expand gerrymandering battles",
     "date": "2026-05-02",


### PR DESCRIPTION
## Summary
- Publish one technology desk article: **Microsoft, OpenAI change terms of deal so startup can court Amazon and others**
- Update assets/data/articles.json
- Add story image path /images/news-banner.png

## Off-record editorial packet

### Claim matrix
1. Claim: Topic is currently in active coverage.
   - Evidence: Google News RSS item and linked coverage URL.
   - Confidence: Medium.
2. Claim: Story fits technology desk scope.
   - Evidence: Query and topic category alignment.
   - Confidence: High.
3. Claim: No off-record process notes are in article body.
   - Evidence: Manual article-body check before commit.
   - Confidence: High.

### Source discovery and bias-check log
- Discovery channel: Google News RSS search using desk-matched query.
- Selection criteria: timeliness, desk fit, duplicate filter against repository index.
- Bias check: language kept neutral and attribution-based.

### Editorial rationale and safety checks
- Chosen for relevance to technology readers and current public interest.
- Content limited to publishable article copy plus source link.
- Internal process details kept in PR only.
