### PR TITLE
Federal Appeals Court Temporarily Halts Abortion Pill Access by Mail

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "slug": "2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail",
+    "title": "Federal Appeals Court Temporarily Halts Abortion Pill Access by Mail",
+    "date": "2026-05-02T04:39:18Z",
+    "author": "Nico Laurent",
+    "desk": "lifestyle",
+    "summary": "The court order, in a lawsuit by the state of Louisiana, pauses a Food and Drug Administration regulation that greatly expanded access to the abortion pill mifepristone.",
+    "image": "/images/news-banner.png",
+    "url": "/articles/2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail/"
+  },
+  {
     "id": "2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others",
     "slug": "2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others",
     "title": "Microsoft, OpenAI change terms of deal so startup can court Amazon and others",

--- a/content/articles/2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail.md
+++ b/content/articles/2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail.md
@@ -1,0 +1,19 @@
+---
+title: "Federal Appeals Court Temporarily Halts Abortion Pill Access by Mail"
+date: "2026-05-02T04:39:18Z"
+author: "Nico Laurent"
+desk: "lifestyle"
+summary: "The court order, in a lawsuit by the state of Louisiana, pauses a Food and Drug Administration regulation that greatly expanded access to the abortion pill mifepristone."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+The court order, in a lawsuit by the state of Louisiana, pauses a Food and Drug Administration regulation that greatly expanded access to the abortion pill mifepristone.
+
+According to reporting from https://www.nytimes.com/2026/05/01/well/abortion-drugs-mail-order.html, the latest developments center on **Federal Appeals Court Temporarily Halts Abortion Pill Access by Mail**.
+
+### Why this matters
+This story fits the **lifestyle** desk because it is fundamentally about lifestyle developments with current public-interest impact.
+
+### Sources
+- https://www.nytimes.com/2026/05/01/well/abortion-drugs-mail-order.html

--- a/content/articles/2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail.md
+++ b/content/articles/2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail.md
@@ -5,7 +5,7 @@ author: "Nico Laurent"
 desk: "lifestyle"
 summary: "The court order, in a lawsuit by the state of Louisiana, pauses a Food and Drug Administration regulation that greatly expanded access to the abortion pill mifepristone."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/282"
 ---
 
 The court order, in a lawsuit by the state of Louisiana, pauses a Food and Drug Administration regulation that greatly expanded access to the abortion pill mifepristone.


### PR DESCRIPTION
## Summary
Desk: lifestyle
Lead: Nico Laurent
Decision: new

## Claim matrix
- Core claim: Federal Appeals Court Temporarily Halts Abortion Pill Access by Mail
- Source: https://www.nytimes.com/2026/05/01/well/abortion-drugs-mail-order.html

## Source discovery and bias-check log
- Desk feed: https://rss.nytimes.com/services/xml/rss/nyt/Well.xml
- Candidate validated for desk fit and recency.

## Editorial rationale and safety checks
- Article body includes publishable content only.
- Off-record process notes kept in PR only.