### PR TITLE
sports: Pistons rally from 24 down to beat Magic 93-79, force Game 7

### DIFF
--- a/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7.md
+++ b/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7.md
@@ -1,0 +1,27 @@
+---
+title: "Pistons rally from 24 down to beat Magic 93-79, force Game 7"
+author: "Jordan Reeves"
+author_id: "jordan-reeves"
+author_display_name: "Jordan Reeves"
+date: "2026-05-02"
+subject: "sports"
+category: "sports"
+status: "published"
+permalink: "/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+The Detroit Pistons erased a 24-point deficit to beat the Orlando Magic 93-79 in Game 6, pushing their first-round NBA playoff series to a decisive Game 7.
+
+Detroit's turnaround was driven by a second-half defensive clampdown after Orlando built early control. Multiple game recaps described the comeback as one of the defining momentum swings of the series.
+
+Game 7 now shifts pressure to both teams, with Orlando trying to recover from a late-series collapse and Detroit carrying renewed confidence into the winner-take-all finale.
+
+### Why it matters
+A Game 7 resets everything: matchups tighten, coaching adjustments matter more, and role players can swing outcomes. For a young Pistons group, the comeback signals postseason composure under extreme pressure.
+
+### Sources
+- https://news.google.com/rss/articles/CBMiowFBVV95cUxNa2RlTDAwaFcwdEZrYnRvN2E3WEdveWpmS2FQUnZlOUlTR24ta0NUTE0xQU51RmxSSWZleXcxLWc3N01jcVR6THJfZ3dURXNmX0J4ZnZSRVJSbTZKczM2QzFIMlZtU1oxQ3BQOVdOOEM1S0RLNGFaMXpTeW54MEhHcmJDNG0xR3REcGRrbE92RGNOYXZETG1vb0pkZjBwVElZeFlr?oc=5
+- https://news.google.com/rss/articles/CBMieEFVX3lxTFBRNTQyVjUyM0lyOEprT3B1UzEtRDRhSWY1aVVKQmh1dTZUUE5mUENBVHNtbWFfZTl6T0NWMzZWQktMRnF4OWF3VXU3VE12Z1VDZE80TnAyZ1dlMWZlMEk2ajU2TnhaYmVGQkQ2YXBCUXkxMnZVdk9jMg?oc=5
+- https://news.google.com/rss/articles/CBMiekFVX3lxTFBsWnJqaHhkT3QybElpYjdTVV9nWHFFYk5kaWdjTEs4ekFfU1NyWGVWMk9mZ1MtODlXaE1vZ2NTQzBrd1BWMW9udDc4R3FYNFRzVWxkTk5yRjJ5aC1QMHdlai1QN21VdFE1c0REcnFhMjNnSlpLd0stRzd30gGCAUFVX3lxTE1nbk8zZlBMeTlycnFpY0pFUVVyczF5eFJINnRROC1SdnRUWmNjcTVldFZYSUpxQ1JldWVVbjRseVZkdnNsTWsya0pTWDJGd3ItYnFQbkJId1lkUTNzOWp6RWRQSjA3RGpyMXlHQUJLWUNjYTQ3SWFiRkhEVDN2SmdablE?oc=5

--- a/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7.md
+++ b/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7.md
@@ -8,7 +8,7 @@ subject: "sports"
 category: "sports"
 status: "published"
 permalink: "/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/285"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7",
+    "slug": "2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7",
+    "title": "Pistons rally from 24 down to beat Magic 93-79, force Game 7",
+    "summary": "Detroit rallied from 24 points down to beat Orlando 93-79 in Game 6 and force a winner-take-all Game 7.",
+    "date": "2026-05-02T06:46:58Z",
+    "subject": "sports",
+    "category": "sports",
+    "author": "Jordan Reeves",
+    "author_id": "jordan-reeves",
+    "author_display_name": "Jordan Reeves",
+    "permalink": "/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-02-gen-z-leads-birdwatching-boom-as-more-britons-reach-for-binoculars",
     "slug": "2026-05-02-gen-z-leads-birdwatching-boom-as-more-britons-reach-for-binoculars",
     "title": "Gen Z leads birdwatching boom as more Britons reach for binoculars",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Jordan Reeves",
     "permalink": "/articles/2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/285"
   },
   {
     "id": "2026-05-02-gen-z-leads-birdwatching-boom-as-more-britons-reach-for-binoculars",


### PR DESCRIPTION
## Summary
Publish one sports desk article for today's cycle.

## Topic fit rationale
This item is a pure sports desk story (NBA playoffs), centered on game result, comeback dynamics, and Game 7 implications.

## Duplicate/update gate
Decision: **New article**. Repo search found no prior Pistons-Magic Game 7 article.

## Claim matrix
1. Pistons overcame a 24-point deficit — supported by multiple recaps.
2. Final score was 93-79 in Game 6 — corroborated across recaps.
3. Result forces Game 7 — core headline fact across sources.

## Source discovery and bias-check log
- Started from Google News SPORTS feed, then narrowed to event-specific RSS search.
- Prioritized multi-outlet convergence on core numerical claims.
- Avoided speculative injury/lineup claims not consistently confirmed.

## Editorial rationale and safety checks
- Kept to verified game result facts and immediate implications.
- Excluded betting advice and unverified locker-room claims.
- Article contains publishable content only; off-record process notes remain in PR.

## Internal process notes
- Image generation: fallback used.
- published_pr_url patched after PR creation.
