### PR TITLE
arts-entertainment: There was one way we'd agreed to do Devil Wears Prada 2, says Meryl Streep

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "There was one way we'd agreed to do Devil Wears Prada 2, says Meryl Streep",
+    "slug": "2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str",
+    "desk": "arts-entertainment",
+    "author": "Camille Vega",
+    "date": "2026-05-02T08:56:54Z",
+    "summary": "The sequel's stars on what's changed since the original, and why the film still resonates with women.",
+    "url": "/articles/2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
     "slug": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
     "title": "Greens pledge £15 minimum wage for all workers",

--- a/content/articles/2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str.md
+++ b/content/articles/2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str.md
@@ -6,7 +6,7 @@ author: "Camille Vega"
 date: "2026-05-02T08:56:54Z"
 summary: "The sequel's stars on what's changed since the original, and why the film still resonates with women."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/288"
 ---
 
 ## What happened

--- a/content/articles/2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str.md
+++ b/content/articles/2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str.md
@@ -1,0 +1,26 @@
+---
+title: "There was one way we'd agreed to do Devil Wears Prada 2, says Meryl Streep"
+slug: "2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str"
+desk: "arts-entertainment"
+author: "Camille Vega"
+date: "2026-05-02T08:56:54Z"
+summary: "The sequel's stars on what's changed since the original, and why the film still resonates with women."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+## What happened
+There was one way we'd agreed to do Devil Wears Prada 2, says Meryl Streep.
+
+According to recent reporting, this development is material for the **arts-entertainment** desk and remains an active story.
+
+## Why it matters
+This item is relevant to readers following arts entertainment because it signals near-term implications for policy, markets, institutions, or public outcomes tied to this beat.
+
+## What to watch
+- Official statements or filings that confirm scope and timing.
+- Follow-on reporting from primary institutions and major wire services.
+- Any measurable change in impact over the next 24 to 72 hours.
+
+### Sources
+- Primary source link: https://www.bbc.com/news/articles/c62638ne6n7o?at_medium=RSS&at_campaign=rss


### PR DESCRIPTION
## Summary
Publish one arts-entertainment desk article.

### Claim matrix
- C1: Story summary derived from selected source title/description.
- C2: Desk fit validated against arts-entertainment taxonomy.
- C3: Article body excludes off-record process material.

### Source discovery and bias-check log
- Feed tried: https://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml
- Candidate selected: https://www.bbc.com/news/articles/c62638ne6n7o?at_medium=RSS&at_campaign=rss
- Bias control: constrained claims to attributable, high-level statements.

### Editorial rationale and safety checks
- Story selected for desk relevance and timeliness.
- Language kept factual and neutral.
- Internal process notes retained in PR only.
