### PR TITLE
Business-Economy: Mortgages, jobs and energy bills - how the Iran war will affect your money

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Priya Desai",
     "permalink": "/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/295"
   },
   {
     "id": "hard-choices-test-breakaway-climate-summit",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact",
+    "slug": "2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact",
+    "title": "Mortgages, jobs and energy bills - how the Iran war will affect your money",
+    "summary": "BBC reports that households in the UK could face pressure on mortgages, jobs and energy bills as Iran-war volatility feeds into inflation and borrowing costs.",
+    "date": "2026-05-02T14:14:38Z",
+    "subject": "business-economy",
+    "category": "business-economy",
+    "author": "Priya Desai",
+    "author_id": "priya-desai",
+    "author_display_name": "Priya Desai",
+    "permalink": "/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "hard-choices-test-breakaway-climate-summit",
     "title": "Hard choices test breakaway climate summit",
     "date": "2026-05-02T13:09:21Z",

--- a/content/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact.md
+++ b/content/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact.md
@@ -1,0 +1,15 @@
+---
+title: "Mortgages, jobs and energy bills - how the Iran war will affect your money"
+date: "2026-05-02"
+author: "Priya Desai"
+desk: "business-economy"
+summary: "BBC reports that households in the UK could face pressure on mortgages, jobs and energy bills as Iran-war volatility feeds into inflation and borrowing costs."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+BBC reports that households in the UK could face pressure on mortgages, jobs and energy bills as Iran-war volatility feeds into inflation and borrowing costs.
+
+The piece highlights how conflict-driven swings in energy and commodity prices can ripple through monthly budgets, while uncertainty can influence hiring and wage growth. For borrowers, the key watchpoint is whether persistent price pressure delays interest-rate relief.
+
+Read more: [Mortgages, jobs and energy bills - how the Iran war will affect your money](https://www.bbc.com/news/articles/cg4pqe1zzgqo?at_medium=RSS&at_campaign=rss)

--- a/content/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact.md
+++ b/content/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact.md
@@ -5,7 +5,7 @@ author: "Priya Desai"
 desk: "business-economy"
 summary: "BBC reports that households in the UK could face pressure on mortgages, jobs and energy bills as Iran-war volatility feeds into inflation and borrowing costs."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/295"
 ---
 
 BBC reports that households in the UK could face pressure on mortgages, jobs and energy bills as Iran-war volatility feeds into inflation and borrowing costs.


### PR DESCRIPTION
## Summary
New business-economy desk article on UK household financial impact from Iran-war volatility.

## Claim matrix (off-record)
1. UK households may feel pressure via mortgages/energy/jobs channels. Source: BBC analysis citing BoE context. Confidence: medium.
2. Energy and commodity volatility can sustain inflation pressure. Source: macroeconomic consensus plus BBC framing. Confidence: medium.
3. Borrowing-cost outlook depends on persistence of inflation pressure. Source: central-bank reaction-function logic. Confidence: medium.

## Source discovery and bias-check log (off-record)
- Desk feeds checked: BBC Business RSS, NYT Economy RSS.
- Selected BBC Business for direct desk fit and timeliness.
- Single-source risk mitigated by strict attribution and no unsupported quant claims.

## Editorial rationale and safety checks (off-record)
- Desk fit: business-economy (household finance, rates, prices, labor channel).
- No medical/legal advice.
- Avoids deterministic forecasting language.
