### PR TITLE
Science-Health: first malaria drug approved for babies

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone",
+    "slug": "2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone",
+    "title": "First malaria drug for babies approved in major public-health milestone",
+    "summary": "The first malaria treatment specifically approved for babies has cleared regulators, a move global-health groups describe as a major step toward closing a long-standing treatment gap for infants.",
+    "date": "2026-05-02T19:30:54Z",
+    "subject": "science-health",
+    "category": "science-health",
+    "author": "Dr. Lena Okafor",
+    "author_id": "dr-lena-okafor",
+    "author_display_name": "Dr. Lena Okafor",
+    "permalink": "/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-02-peter-kay-show-to-go-ahead-after-bomb-hoax-arrest",
     "slug": "2026-05-02-peter-kay-show-to-go-ahead-after-bomb-hoax-arrest",
     "title": "Peter Kay show to go ahead after bomb hoax arrest",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Dr. Lena Okafor",
     "permalink": "/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/301"
   },
   {
     "id": "2026-05-02-peter-kay-show-to-go-ahead-after-bomb-hoax-arrest",

--- a/content/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone.md
+++ b/content/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone.md
@@ -10,7 +10,7 @@ status: "published"
 summary: "The first malaria treatment specifically approved for babies has cleared regulators, a move global-health groups describe as a major step toward closing a long-standing treatment gap for infants."
 permalink: "/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone/"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/301"
 ---
 
 The first malaria treatment specifically approved for babies has cleared regulators, a move global-health groups describe as a major step toward closing a long-standing treatment gap for infants.

--- a/content/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone.md
+++ b/content/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone.md
@@ -1,0 +1,22 @@
+---
+title: "First malaria drug for babies approved in major public-health milestone"
+date: "2026-05-02"
+author: "Dr. Lena Okafor"
+author_id: "dr-lena-okafor"
+author_display_name: "Dr. Lena Okafor"
+subject: "science-health"
+category: "science-health"
+status: "published"
+summary: "The first malaria treatment specifically approved for babies has cleared regulators, a move global-health groups describe as a major step toward closing a long-standing treatment gap for infants."
+permalink: "/articles/2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone/"
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+The first malaria treatment specifically approved for babies has cleared regulators, a move global-health groups describe as a major step toward closing a long-standing treatment gap for infants.
+
+Malaria remains one of the deadliest infectious diseases for young children, particularly in parts of sub-Saharan Africa. Until now, treatment protocols for the youngest patients have often depended on adapted dosing from medicines designed for older children. Health advocates say a baby-specific option could improve safety, adherence and access in frontline clinics.
+
+The approval is expected to support wider procurement planning by public-health programs and aid agencies, though rollout speed will depend on local regulatory steps, financing and supply-chain readiness. Clinicians and NGOs are now watching for guidance on implementation, including training and distribution priorities in high-burden regions.
+
+Read more: [The Guardian report](https://www.theguardian.com/global-development/2026/may/02/first-malaria-drug-for-babies-is-approved-in-major-public-health-milestone)


### PR DESCRIPTION
## Summary
Publish one science-health article on infant malaria drug approval milestone.

## Article
- Title: First malaria drug for babies approved in major public-health milestone
- Desk: science-health
- Author: Dr. Lena Okafor
- Source: https://www.theguardian.com/global-development/2026/may/02/first-malaria-drug-for-babies-is-approved-in-major-public-health-milestone

## Claim matrix (off-record)
1. Claim: First malaria drug specifically approved for babies.
   - Source: Guardian global-development report (https://www.theguardian.com/global-development/2026/may/02/first-malaria-drug-for-babies-is-approved-in-major-public-health-milestone)
   - Confidence: Medium (single-source report of approval milestone)
2. Claim: Approval may improve infant treatment access and dosing safety.
   - Source: Guardian report plus standard public-health implementation logic
   - Confidence: Medium
3. Claim: Rollout depends on financing, procurement, and local implementation.
   - Source: Editorial analysis grounded in typical medicine deployment pathways
   - Confidence: Medium

## Source discovery and bias-check log (off-record)
- Discovery path: Google News RSS queries for health/public health/medical research.
- Candidate review: prioritized policy-impact pediatric treatment topic over lifestyle or opinion content to fit science-health desk.
- Bias check: avoided advocacy-only framing; used cautious wording; separated confirmed approval from expected implementation effects.

## Editorial rationale and safety checks (off-record)
- Desk fit validated: medicine/public-health development.
- Avoided clinical advice and avoided unverifiable efficacy claims.
- No sensitive personal data included.

## Internal review thread (off-record)
- Author note: Lead with approval fact and clearly mark uncertainties around rollout timelines.
- Editor note: Keep language precise: "expected" and "could" for forward-looking effects.
