### PR TITLE
[technology] The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,21 @@
 [
   {
+    "id": "2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge",
+    "title": "The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge",
+    "summary": "The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge is driving developments on the technology desk, based on current wire and syndication reporting.",
+    "author": "Adeline Park",
+    "author_id": "technology_lead",
+    "author_display_name": "Adeline Park",
+    "date": "2026-05-02",
+    "category": "technology",
+    "tags": [
+      "technology",
+      "breaking"
+    ],
+    "image": "/images/news-banner.png",
+    "slug": "/articles/2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge/"
+  },
+  {
     "id": "2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone",
     "slug": "2026-05-02-first-malaria-drug-for-babies-approved-major-public-health-milestone",
     "title": "First malaria drug for babies approved in major public-health milestone",

--- a/content/articles/2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge.md
+++ b/content/articles/2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge.md
@@ -1,0 +1,26 @@
+---
+title: "The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge"
+description: "The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge is driving developments on the technology desk, based on current wire and syndication reporting."
+author: "Adeline Park"
+author_role: "technology Desk Lead"
+date: "2026-05-02"
+last_updated: "2026-05-02"
+category: "technology"
+tags: ["technology", "breaking"]
+image: "/images/news-banner.png"
+image_alt: "Editorial image representing The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge"
+sources:
+  - name: "Google News syndication"
+    url: "https://news.google.com/rss/articles/CBMiogFBVV95cUxNRVZIUDFIQXh1S3pvZHFWbzdqWDBSd0dHZG12ZmF2Mlh6MmRmQXBZQjVUbHJwT085WThoWG1DWHFMTTBQSW5ZVnZOMkNQbk55UHdPNGg3WDhMSXlFSzdDZWJTWW5YY1FkVmxYbVFzb0YxWUN3ZXZsVnVMV3REcG02UUcwZkI1R1RuS0w0SzZTVmFrazlFWUo0VjBiQ2NFV1ltanc?oc=5"
+published_pr_url: "TBD"
+---
+
+## Summary
+The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge is driving developments on the technology desk, based on current wire and syndication reporting.
+
+## What Happened
+- The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge
+- Source link: https://news.google.com/rss/articles/CBMiogFBVV95cUxNRVZIUDFIQXh1S3pvZHFWbzdqWDBSd0dHZG12ZmF2Mlh6MmRmQXBZQjVUbHJwT085WThoWG1DWHFMTTBQSW5ZVnZOMkNQbk55UHdPNGg3WDhMSXlFSzdDZWJTWW5YY1FkVmxYbVFzb0YxWUN3ZXZsVnVMV3REcG02UUcwZkI1R1RuS0w0SzZTVmFrazlFWUo0VjBiQ2NFV1ltanc?oc=5
+
+## Why It Matters
+This development is material to the **technology** desk due to direct relevance to the beat and audience impact.

--- a/content/articles/2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge.md
+++ b/content/articles/2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge.md
@@ -12,7 +12,7 @@ image_alt: "Editorial image representing The craziest part of Musk v. Altman hap
 sources:
   - name: "Google News syndication"
     url: "https://news.google.com/rss/articles/CBMiogFBVV95cUxNRVZIUDFIQXh1S3pvZHFWbzdqWDBSd0dHZG12ZmF2Mlh6MmRmQXBZQjVUbHJwT085WThoWG1DWHFMTTBQSW5ZVnZOMkNQbk55UHdPNGg3WDhMSXlFSzdDZWJTWW5YY1FkVmxYbVFzb0YxWUN3ZXZsVnVMV3REcG02UUcwZkI1R1RuS0w0SzZTVmFrazlFWUo0VjBiQ2NFV1ltanc?oc=5"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/303"
 ---
 
 ## Summary


### PR DESCRIPTION
## Summary
Automated one-article dispatch for **technology**.

## OFF-RECORD: Claim Matrix
| Claim | Source | Confidence |
|---|---|---|
| The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge | https://news.google.com/rss/articles/CBMiogFBVV95cUxNRVZIUDFIQXh1S3pvZHFWbzdqWDBSd0dHZG12ZmF2Mlh6MmRmQXBZQjVUbHJwT085WThoWG1DWHFMTTBQSW5ZVnZOMkNQbk55UHdPNGg3WDhMSXlFSzdDZWJTWW5YY1FkVmxYbVFzb0YxWUN3ZXZsVnVMV3REcG02UUcwZkI1R1RuS0w0SzZTVmFrazlFWUo0VjBiQ2NFV1ltanc?oc=5 | Medium |

## OFF-RECORD: Source discovery and bias-check log
- RNG desk selection N=3; desk=technology
- Query used: `site:theverge.com ai`
- Feed source label: 
- Bias check: retained neutral wire/syndication framing and avoided speculative language.

## OFF-RECORD: Editorial rationale and safety checks
- Topic matched desk keyword gate for `technology`.
- Article body excludes internal process notes and review metadata.
- Image: fallback /images/news-banner.png

## OFF-RECORD: Internal process notes
- Backfilled `published_pr_url` after PR creation.
