### PR TITLE
World: U.S. warns shipping firms over Iran passage payments

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Elias Navarro",
     "permalink": "/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/304"
   },
   {
     "id": "2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",
+    "slug": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",
+    "title": "Strait of Hormuz: U.S. warns shipping firms over Iran passage payments",
+    "summary": "The US has warned shipping companies they could face sanctions if they pay Iran for safe passage through the Strait of Hormuz, as tanker traffic through the waterway drops sharply.",
+    "date": "2026-05-02T21:40:37Z",
+    "subject": "world",
+    "category": "world",
+    "author": "Elias Navarro",
+    "author_id": "elias-navarro",
+    "author_display_name": "Elias Navarro",
+    "permalink": "/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge",
     "title": "The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge",
     "summary": "The craziest part of Musk v. Altman happened while the jury was out of the room - The Verge is driving developments on the technology desk, based on current wire and syndication reporting.",

--- a/content/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls.md
+++ b/content/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls.md
@@ -1,0 +1,27 @@
+---
+title: "Strait of Hormuz: U.S. warns shipping firms over Iran passage payments"
+description: "U.S. sanctions authorities say companies that pay Iranian entities for passage through the Strait of Hormuz could face sanctions exposure."
+author: "Elias Navarro"
+author_role: "world Desk Lead"
+date: "2026-05-02"
+last_updated: "2026-05-02"
+category: "world"
+tags: ["world", "geopolitics", "shipping"]
+image: "/images/news-banner.png"
+image_alt: "Cargo ships transiting a narrow strait under tense geopolitical conditions"
+sources:
+  - name: "BBC"
+    url: "https://www.bbc.com/news/articles/c3v2l2qq9qlo?at_medium=RSS&at_campaign=rss"
+  - name: "U.S. Treasury OFAC"
+    url: "https://ofac.treasury.gov/recent-actions/20260501"
+published_pr_url: "PENDING"
+---
+
+## Summary
+Washington has warned shipping firms that payments to Iranian government-linked entities for passage through the Strait of Hormuz could trigger U.S. sanctions risk, adding pressure to a maritime corridor already seeing reduced tanker traffic.
+
+## What Happened
+A U.S. sanctions alert published by the Treasury Department’s Office of Foreign Assets Control said U.S. persons are generally barred from making such payments and that non-U.S. parties may also face exposure. The warning landed as vessel traffic through Hormuz remained constrained and diplomatic signals between Washington and Tehran stayed unsettled.
+
+## Why It Matters
+The Strait of Hormuz is a critical chokepoint for global energy and trade flows. Fresh sanctions risk for shipping intermediaries raises compliance costs and may further complicate routing, insurance, and freight pricing for cargo moving through the region.

--- a/content/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls.md
+++ b/content/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls.md
@@ -14,7 +14,7 @@ sources:
     url: "https://www.bbc.com/news/articles/c3v2l2qq9qlo?at_medium=RSS&at_campaign=rss"
   - name: "U.S. Treasury OFAC"
     url: "https://ofac.treasury.gov/recent-actions/20260501"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/304"
 ---
 
 ## Summary


### PR DESCRIPTION
## Summary
Publishes a world-desk report on the U.S. sanctions warning tied to Strait of Hormuz passage payments.

## Claim matrix (off-record)
- Claim: OFAC published an Iran-related alert on sanctions risks for Hormuz passage payments.  
  Source: https://ofac.treasury.gov/recent-actions/20260501
- Claim: Shipping firms were warned of sanctions exposure linked to Iranian toll demands.  
  Source: https://www.bbc.com/news/articles/c3v2l2qq9qlo?at_medium=RSS&at_campaign=rss
- Claim: Traffic through Hormuz has dropped sharply in current reporting context.  
  Source: https://www.bbc.com/news/articles/c3v2l2qq9qlo?at_medium=RSS&at_campaign=rss

## Source discovery + bias-check log (off-record)
- Discovery started from BBC World RSS item matching desk taxonomy.
- Corroborated policy mechanism with primary U.S. Treasury/OFAC release.
- Reuters/Guardian automation fetch paths were restricted in-run; used direct primary-source substitution to avoid single-outlet framing.

## Editorial rationale and safety checks (off-record)
- Desk fit: world (state-level policy + maritime chokepoint).
- Avoided casualty/speculative military claims not present in corroborated sources.
- Language kept conditional where attribution is to source reporting.
