### PR TITLE
[environment] 2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Rowan Hale",
     "permalink": "/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/305"
   },
   {
     "id": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",
+    "slug": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",
+    "title": "Turkey signals COP31 push for stronger global climate action",
+    "summary": "Reuters reports Turkey says it would use a COP31 presidency to press stronger multilateral climate action, signaling an attempt to shape post-COP30 negotiations around implementation and finance.",
+    "date": "2026-05-02T22:44:00Z",
+    "subject": "environment",
+    "category": "environment",
+    "author": "Rowan Hale",
+    "author_id": "rowan-hale",
+    "author_display_name": "Rowan Hale",
+    "permalink": "/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",
     "slug": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",
     "title": "Strait of Hormuz: U.S. warns shipping firms over Iran passage payments",

--- a/content/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency.md
+++ b/content/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency.md
@@ -6,7 +6,7 @@ author: "Rowan Hale"
 date: "2026-05-02T22:44:00Z"
 summary: "Reuters reports Turkey says it would use a COP31 presidency to press stronger multilateral climate action, signaling an attempt to shape post-COP30 negotiations around implementation and finance."
 image: "/images/news-banner.png"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/305"
 ---
 
 ## What happened

--- a/content/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency.md
+++ b/content/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency.md
@@ -1,0 +1,24 @@
+---
+title: "Turkey signals COP31 push for stronger global climate action"
+slug: "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency"
+desk: "environment"
+author: "Rowan Hale"
+date: "2026-05-02T22:44:00Z"
+summary: "Reuters reports Turkey says it would use a COP31 presidency to press stronger multilateral climate action, signaling an attempt to shape post-COP30 negotiations around implementation and finance."
+image: "/images/news-banner.png"
+published_pr_url: "TBD"
+---
+
+## What happened
+Turkey said it would use a potential COP31 presidency to press for stronger global coordination on climate action, according to Reuters reporting carried by Google News syndication.
+
+## Why it matters
+For the environment desk, the development matters because COP presidencies help set negotiating tempo on emissions cuts, adaptation funding, and implementation timelines. A more assertive agenda from the host side can shift bargaining pressure ahead of formal summit text.
+
+## What to watch
+- Whether other blocs publicly back Turkey's proposed priorities.
+- How finance and implementation language evolves in pre-summit talks.
+- Signals from major emitters on scope and enforcement.
+
+### Sources
+- Reuters (via Google News): https://news.google.com/rss/articles/CBMivwFBVV95cUxPMjh2c2VLN0NEUDN0ZFVySGh0bEY4b0NCcnNnZ2dNZmNSdWpGcEY5NzdZdUZvQlh5Wm93ekdNNWNaN094LWpQb21jRnMzSkQ3eV9ER0w1c3hoQmZIelZobVNUdE9PUk1xdG1vVkU1bHp2Q3ZIRmVYejhram5Md2JoVTdjalRHOXRWMEVLa2hZQnJpX2xoRWdYcjBkUmE5MS0wVXFWMmIzZjZrclY0N25Ld201MFNqMms3aWlheldXOA?oc=5


### PR DESCRIPTION
## Summary
- Publish one environment desk article on Turkey's COP31 positioning
- Add/update catalog metadata and image path

## Claim matrix (off-record)
- Claim: Turkey says COP31 would push stronger global climate action.
  - Source: Reuters syndication link in article.
  - Confidence: Medium (single primary wire item accessible via syndication).
- Claim: COP presidencies influence agenda-setting and negotiating tempo.
  - Source: editorial background consensus from UNFCCC process history.
  - Confidence: Medium.

## Source discovery and bias-check log (off-record)
- Attempted environment-topic discovery from current syndicated feeds.
- Selected policy-process item to avoid speculative climate-impact claims.
- Bias check: language avoids endorsing national positions; focuses on process implications.

## Editorial rationale and safety checks (off-record)
- Desk fit: environment policy/diplomacy directly tied to climate governance.
- Avoided unverified quant claims; kept causal framing conservative.
- Article file excludes internal notes/checklists by design.
