### PR TITLE
science-health: WHO Member States agree to extend negotiations on Pathogen Access and Benefit Sharing annex

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,16 @@
 [
   {
+    "slug": "who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh",
+    "title": "WHO Member States agree to extend negotiations on Pathogen Access and Benefit Sharing annex",
+    "date": "2026-05-02T23:48:19Z",
+    "author": "Dr. Lena Okafor",
+    "desk": "science-health",
+    "summary": "Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to ",
+    "image": "/images/news-banner.png",
+    "url": "/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh/",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",
     "slug": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",
     "title": "Turkey signals COP31 push for stronger global climate action",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -8,7 +8,7 @@
     "summary": "Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to ",
     "image": "/images/news-banner.png",
     "url": "/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh/",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/306"
   },
   {
     "id": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",

--- a/content/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh.md
+++ b/content/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh.md
@@ -1,0 +1,23 @@
+---
+title: "WHO Member States agree to extend negotiations on Pathogen Access and Benefit Sharing annex"
+date: "2026-05-02T23:48:19Z"
+author: "Dr. Lena Okafor"
+desk: "science-health"
+summary: "Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to "
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+WHO Member States agree to extend negotiations on Pathogen Access and Benefit Sharing annex is a developing story on the science health desk.
+
+According to current reporting, Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to 
+
+Why it matters: This development is relevant to readers following science health because it signals near-term changes worth monitoring.
+
+What to watch next:
+- Official statements or verified updates from primary institutions.
+- Follow-on reporting that adds concrete figures, dates, or policy implications.
+- Any corrections or clarifications that materially change the initial framing.
+
+Source:
+- https://www.who.int/news/item/01-05-2026-who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sharing-annex

--- a/content/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh.md
+++ b/content/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh.md
@@ -5,7 +5,7 @@ author: "Dr. Lena Okafor"
 desk: "science-health"
 summary: "Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to "
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/306"
 ---
 
 WHO Member States agree to extend negotiations on Pathogen Access and Benefit Sharing annex is a developing story on the science health desk.


### PR DESCRIPTION
## Article
Published one desk-fit story for **science-health** by **Dr. Lena Okafor**.

## Off-record editorial meta
### Claim matrix
- Claim: Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to 
  - Source: https://www.who.int/news/item/01-05-2026-who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sharing-annex
  - Confidence: medium

### Source discovery and bias-check log
- Feed used: https://www.who.int/rss-feeds/news-english.xml
- Candidate selected for desk fit and timeliness.
- Bias check: single-source initial write-up; language kept cautious and attributed.

### Editorial rationale and safety checks
- Avoided speculative claims; framed as developing story.
- No off-record/process text included in article body.

### Internal process notes
- RNG N=4; SME target=research_sme
