### PR TITLE
Duplicate check: CBS News poll and analysis on California voters' views of state's policies ahead of debate

### DIFF
--- a/notes/duplicate-20260503040227.md
+++ b/notes/duplicate-20260503040227.md
@@ -1,0 +1,1 @@
+Duplicate topic decision for CBS News poll and analysis on California voters' views of state's policies ahead of debate. Canonical: 


### PR DESCRIPTION
Duplicate detected. Canonical: 

@thestamp