### PR TITLE
Update: Santa Marta climate talks intensify push for faster fossil-fuel phaseout

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Rowan Hale",
     "permalink": "/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING_PR_URL"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/313"
   },
   {
     "id": "2026-05-03-arsenal-go-six-points-clear-after-3-0-fulham-win-raising-title-race-pressure",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout",
+    "slug": "2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout",
+    "title": "Update: Santa Marta climate talks intensify push for faster fossil-fuel phaseout",
+    "summary": "Delegates meeting in Santa Marta, Colombia, are framing a faster fossil-fuel phaseout as both a climate and energy-security priority, with countries using the talks to pressure for clearer transition timelines before COP negotiations intensify.",
+    "date": "2026-05-03T05:05:59Z",
+    "subject": "environment",
+    "category": "environment",
+    "author": "Rowan Hale",
+    "author_id": "rowan-hale",
+    "author_display_name": "Rowan Hale",
+    "permalink": "/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING_PR_URL"
+  },
+  {
     "id": "2026-05-03-arsenal-go-six-points-clear-after-3-0-fulham-win-raising-title-race-pressure",
     "slug": "2026-05-03-arsenal-go-six-points-clear-after-3-0-fulham-win-raising-title-race-pressure",
     "title": "Arsenal go six points clear after 3-0 Fulham win, raising title-race pressure",

--- a/content/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout.md
+++ b/content/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout.md
@@ -8,7 +8,7 @@ subject: "environment"
 category: "environment"
 status: "published"
 permalink: "/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout/"
-published_pr_url: "PENDING_PR_URL"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/313"
 image: "/images/news-banner.png"
 summary: "Delegates meeting in Santa Marta, Colombia, are framing a faster fossil-fuel phaseout as both a climate and energy-security priority, with countries using the talks to pressure for clearer transition timelines before COP negotiations intensify."
 ---

--- a/content/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout.md
+++ b/content/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout.md
@@ -1,0 +1,31 @@
+---
+title: "Update: Santa Marta climate talks intensify push for faster fossil-fuel phaseout"
+author: "Rowan Hale"
+author_id: "rowan-hale"
+author_display_name: "Rowan Hale"
+date: "2026-05-03"
+subject: "environment"
+category: "environment"
+status: "published"
+permalink: "/articles/2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout/"
+published_pr_url: "PENDING_PR_URL"
+image: "/images/news-banner.png"
+summary: "Delegates meeting in Santa Marta, Colombia, are framing a faster fossil-fuel phaseout as both a climate and energy-security priority, with countries using the talks to pressure for clearer transition timelines before COP negotiations intensify."
+---
+
+Santa Marta, Colombia, has become a focal point in this week's climate diplomacy as nearly 60 countries discuss how to convert broad climate pledges into concrete fossil-fuel phaseout plans.
+
+Reporting from The Guardian and France 24 indicates negotiators are trying to move from high-level commitments toward practical implementation: clearer timelines, transition financing, and accountability for delivery.
+
+The talks matter because they test whether governments can align three pressures at once: emissions cuts, energy security, and affordability. Officials and policy advocates describe the current moment as a bridge between headline commitments and the harder work of policy execution.
+
+What's New
+- Countries are explicitly linking fossil-fuel phaseout demands to near-term implementation mechanics, not only long-term targets.
+- The Santa Marta format has expanded participation and sharpened pressure ahead of upcoming multilateral climate rounds.
+- Delegates are emphasizing transition credibility: finance access, national planning detail, and measurable interim milestones.
+
+For readers tracking climate policy, the practical signal is whether these negotiations produce language that can be carried into formal COP channels and domestic policy updates in the coming months.
+
+Read more:
+- [The Guardian: Could Santa Marta climate talks mark ground zero in push to ditch fossil fuels?](https://www.theguardian.com/environment/2026/may/01/could-key-climate-talks-mark-ground-zero-in-global-push-to-ditch-fossil-fuels)
+- [France 24: Colombia hosts climate talks in bid to lead global transition away from fossil fuels](https://www.france24.com/en/live-news/20260429-colombia-hosts-climate-talks-in-bid-to-lead-global-transition-away-from-fossil-fuels)


### PR DESCRIPTION
## Summary
Environment desk update on Santa Marta climate talks and fossil-fuel phaseout negotiations.

## Claim matrix (off-record)
1) Nearly 60 countries are engaged in talks in Santa Marta focused on accelerating fossil-fuel transition framing.
- Source: The Guardian (May 1, 2026); France 24 (Apr 29, 2026).
2) Negotiations are emphasizing implementation details (timelines, finance, accountability), not only targets.
- Source synthesis from both reports.
3) Talks are positioned as a pre-COP pressure point likely to influence upcoming multilateral language.
- Editorial inference clearly labeled as analysis.

## Source discovery + bias-check log (off-record)
- Desk-constrained discovery used environment feeds first.
- Corroborated across UK newsroom (Guardian) and international wire-style outlet (France 24).
- Avoided activist-only sourcing as sole evidence; Greenpeace item excluded from core claims.

## Editorial rationale + safety checks (off-record)
- Classified as Update due material incremental framing and widened negotiation focus.
- No casualty counts or unverifiable claims included.
- Language avoids certainty where talks remain ongoing.
