### PR TITLE
Publish: EFL transfer news, rumours and gossip for Championship, League One and League Two

### DIFF
--- a/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two.md
+++ b/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two.md
@@ -1,0 +1,26 @@
+---
+title: "EFL transfer news, rumours and gossip for Championship, League One and League Two"
+author: "Jordan Reeves"
+author_id: "jordan-reeves"
+author_display_name: "Jordan Reeves"
+date: "2026-05-03"
+subject: "sports"
+category: "sports"
+status: "published"
+permalink: "/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+EFL transfer news, rumours and gossip for Championship, League One and League Two remains a live story on the sports desk. Early reporting aggregated by Sky Sports indicates active developments, with editors monitoring official statements and primary-source confirmations before extending the fact set.
+
+The current verified item from the newswire aggregation is:
+
+- **Headline:** EFL transfer news, rumours and gossip for Championship, League One and League Two
+- **Source index:** [Sky Sports](https://news.google.com/rss/articles/CBMi1gFBVV95cUxOM3czSjlYbXNOS2pUWFdwZEt6ckE3a29OZVJhTnBmVGx5T1hZNUsxV2pOZ0c3NERlNFpjWU9QYlJiTHJHeG1RWUp5MkZPell5MWRkT1NwRFNKRE9Jc2JVVkxsSEVINnB4RW1UUkctV01GMV9FeE1Ta193Y3dueEw5b2RVSDhOcVBRTkQ3S29URG1NWHREeTdHbFIxWl9LNzdJMXl4QnZQMTU3bHRQNmpNcXFuVnFIbW5IN1ZtSzBkOG5HandadE54Qk5IWjhZb2ttR3ZTTTVn?oc=5)
+
+Editors will continue to update this report as additional confirmed details emerge from directly attributable public records and on-the-record reporting.
+
+## Source
+
+- Sky Sports, Google News feed item: https://news.google.com/rss/articles/CBMi1gFBVV95cUxOM3czSjlYbXNOS2pUWFdwZEt6ckE3a29OZVJhTnBmVGx5T1hZNUsxV2pOZ0c3NERlNFpjWU9QYlJiTHJHeG1RWUp5MkZPell5MWRkT1NwRFNKRE9Jc2JVVkxsSEVINnB4RW1UUkctV01GMV9FeE1Ta193Y3dueEw5b2RVSDhOcVBRTkQ3S29URG1NWHREeTdHbFIxWl9LNzdJMXl4QnZQMTU3bHRQNmpNcXFuVnFIbW5IN1ZtSzBkOG5HandadE54Qk5IWjhZb2ttR3ZTTTVn?oc=5

--- a/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two.md
+++ b/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two.md
@@ -8,7 +8,7 @@ subject: "sports"
 category: "sports"
 status: "published"
 permalink: "/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/314"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two",
+    "title": "EFL transfer news, rumours and gossip for Championship, League One and League Two",
+    "summary": "Live desk brief on EFL transfer news, rumours and gossip for Championship, League One and League Two.",
+    "author": "Jordan Reeves",
+    "date": "2026-05-03",
+    "subject": "sports",
+    "category": "sports",
+    "permalink": "/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout",
     "slug": "2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout",
     "title": "Update: Santa Marta climate talks intensify push for faster fossil-fuel phaseout",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "sports",
     "permalink": "/articles/2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/314"
   },
   {
     "id": "2026-05-03-update-santa-marta-talks-countries-push-accelerated-fossil-fuel-phaseout",


### PR DESCRIPTION
## Summary
Publishes one sports desk article: **EFL transfer news, rumours and gossip for Championship, League One and League Two**.

## Claim matrix (off-record)
- Claim: Story event exists and is current.
  - Basis: Google News RSS item title, timestamp, and source attribution.
- Claim: Desk-topic fit is valid for `sports`.
  - Basis: keyword fit plus editor desk mapping rules.
- Claim: No unverified expansion beyond wire summary.
  - Basis: body restricted to attributable high-level facts.

## Source discovery and bias-check log (off-record)
1. Queried Google News RSS for desk-specific terms.
2. Ranked by recency and desk-keyword fit.
3. Limited story body to attributable source-indexed facts to avoid conjecture.
Bias check: avoided single-actor framing and excluded unverified social claims.

## Editorial rationale and safety checks (off-record)
- One-story cap respected.
- Topic chosen from current feed with desk alignment.
- Article excludes internal process notes and review metadata.
- Image policy: generated image path set in article and catalog; fallback applied if generation unavailable.
