### PR TITLE
News-Politics: U.S. expands sanctions on Cuban government and affiliated entities

### DIFF
--- a/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities.md
+++ b/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities.md
@@ -1,0 +1,31 @@
+---
+title: "U.S. expands sanctions on Cuban government and affiliated entities"
+author: "Maya Sterling"
+author_id: "maya-sterling"
+author_display_name: "Maya Sterling"
+date: "2026-05-03T10:24:01Z"
+subject: "news-politics"
+category: "news-politics"
+status: "published"
+permalink: "/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities/"
+published_pr_url: ""
+image: "/images/news-banner.png"
+---
+
+The White House has expanded U.S. sanctions targeting the Cuban government and affiliated entities, reopening debate over whether economic pressure can change behavior in Havana without worsening conditions for civilians.
+
+### What happened
+Reuters reported that President Donald Trump broadened sanctions authorities aimed at Cuban state-linked actors and affiliated channels, with the administration framing the move as a tightening of pressure over security and foreign-policy concerns. Follow-on coverage from regional outlets said the order also targets financial and commercial pathways tied to those entities.
+
+### Why it matters
+For Washington, the move signals a harder-line Cuba posture with domestic political implications in South Florida and in Congress. For Havana, it raises near-term financing and trade friction at a time of already severe economic strain. Markets and compliance teams will now watch how aggressively Treasury and other agencies enforce the new designations.
+
+### What to watch next
+- Whether the Treasury Department issues new guidance, licenses, or designation lists clarifying enforcement scope.
+- Whether U.S. allies or regional partners align with, or distance from, the expanded sanctions posture.
+- Whether Cuba announces reciprocal diplomatic, legal, or commercial countermeasures.
+
+### Sources
+- Reuters: https://news.google.com/rss/articles/CBMimgFBVV95cUxOQmEtR3kxSFZRdWJfVmFPSlY0UG1pYk1ncWNObk9Vcmh3VXRKN1hfT3hWdTRyeWQyUFE5YXVjdDZuRVFOOFpwcTJBcHJCTzZCV3NKS1BvSnB0LVFLWUVEcDZnQm4yNk83NGRiVDBOeVlfQ0tDY1ZQSVpPcEc2ZlIyM1doVHE0WGdkdkV6SWM0c2taamotRVhuaVdB?oc=5
+- Miami Herald: https://news.google.com/rss/articles/CBMikAFBVV95cUxNdHk3MmlyYkJuNVQ0eE9oOTdrbjFOLTUzU2NoVnZRd1VOX0M2TDhnQndqdjJZNS1MeWsxeC1KM2ppTXh2TjNyZFZ5T3BPSEdMX1ZDLWJ4Wk1PSFNHdmFsVnNXVzl4bTJVVXRMMlYwRi1NNjNjc01BQ19NMTQtNnUtSXprRVFCZVFwRm5mMEgxZmk?oc=5
+- The Guardian: https://news.google.com/rss/articles/CBMihAFBVV95cUxNZkRvYlhCX19UVEJTUHlVZXFGNHlnUGNuV2Jfdkg5TDRiLVFsaE42emhSQ0ZmYjlETUZyaXJjV0lTZ1lRQlVUeENVTTZqQVVtOEdMU2dNLUdWQW9qUGYtQ3ZHaTBpOUpvVVBJNWV3ZG43V2pzUGlabDZ1ZE5ReTJtOTBsbHE?oc=5

--- a/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities.md
+++ b/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities.md
@@ -8,7 +8,7 @@ subject: "news-politics"
 category: "news-politics"
 status: "published"
 permalink: "/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/321"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Maya Sterling",
     "permalink": "/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/321"
   },
   {
     "id": "music-labels-pilot-consent-first-synthetic-voice-collaboration-programs",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities",
+    "slug": "2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities",
+    "title": "U.S. expands sanctions on Cuban government and affiliated entities",
+    "summary": "Reuters and follow-on regional reporting say Washington broadened sanctions targeting Cuban state entities and affiliated channels, drawing a sharp response from Havana and raising pressure over enforcement details.",
+    "date": "2026-05-03T10:24:01Z",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "author": "Maya Sterling",
+    "author_id": "maya-sterling",
+    "author_display_name": "Maya Sterling",
+    "permalink": "/articles/2026-05-03-us-expands-sanctions-on-cuban-government-and-affiliated-entities/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "music-labels-pilot-consent-first-synthetic-voice-collaboration-programs",
     "title": "Music labels pilot consent-first synthetic voice collaboration programs",
     "summary": "A new development in the arts entertainment desk is drawing attention this week: Music labels pilot consent-first synthetic voice collaboration programs.",


### PR DESCRIPTION
## Summary
Publishes one news-politics article on the U.S. expansion of sanctions targeting Cuban government-affiliated entities.

## Claim matrix (off-record)
1. Claim: The U.S. expanded sanctions targeting Cuban government and affiliates.
   - Source: Reuters (wire via Google News RSS)
2. Claim: The order includes financial/commercial pathway pressure.
   - Source: Miami Herald follow-on coverage
3. Claim: Cuba publicly condemned the move as collective punishment.
   - Source: The Guardian follow-on report citing Cuban response

## Source discovery and bias-check log (off-record)
- Discovery path: Google News RSS query tuned for desk fit (news-politics) and recency (<72h).
- Outlet spread: wire + regional + international to reduce single-outlet framing risk.
- Bias check: avoided opinion framing; retained uncertainty where implementation details remain pending agency guidance.

## Editorial rationale and safety checks (off-record)
- Desk fit: sanctions policy action by U.S. executive branch with geopolitical implications.
- Duplicate gate: checked repository for Cuba-sanctions coverage; no matching event article found.
- Article excludes internal process notes and includes only publishable content.

## Internal process notes (off-record)
- Image generation fallback used due to missing OPENAI_API_KEY in cron environment.
