### PR TITLE
Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics

### DIFF
--- a/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance.md
+++ b/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance.md
@@ -1,0 +1,40 @@
+---
+title: "Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics"
+author: "Simone Hart"
+author_id: "simone-hart"
+author_display_name: "Simone Hart"
+date: "2026-05-03"
+subject: "opinion-editorials"
+category: "opinion-editorials"
+status: "published"
+permalink: "/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance/"
+image: "/images/news-banner.png"
+---
+
+Turkey’s confirmation as COP31 host — paired with Australia’s expanded role in the negotiation track — creates a revealing stress test for climate diplomacy: can process design beat geopolitical fragmentation?
+
+The answer matters because climate talks are no longer insulated from hard-power economics. Energy chokepoints, inflation pressure, and regional conflict are now shaping what governments are willing to sign, finance, and enforce.
+
+## What’s New
+- Reuters and follow-on policy reporting indicate Turkey is now set to host COP31, shifting the talks from speculative bids to operational planning.
+- Australia is expected to take a larger role in government-to-government negotiation management, signaling a split between convening authority and bridge-building diplomacy.
+- The new arrangement raises the probability that COP31 focuses less on headline ambition and more on implementation credibility: financing terms, phaseout sequencing, and compliance transparency.
+
+## Why this update changes the policy picture
+The earlier policy debate centered on whether a prospective Turkish presidency could pressure countries toward stronger commitments. The update reframes that question: now the issue is delivery architecture.
+
+A dual-center format can help if it broadens trust across blocs. It can also fail if parties treat venue politics as a proxy fight over burden-sharing. In practice, COP31’s success will hinge on whether negotiators can turn energy-security concerns into transition design rather than into veto points.
+
+## The hard tradeoff negotiators should state plainly
+Governments keep promising faster decarbonization while simultaneously prioritizing resilience against fuel shocks. Those goals are compatible only if countries publish realistic transition pathways with auditable milestones, not just end-state targets.
+
+Without that shift, COP31 risks producing familiar language and fragile consensus. With it, the summit could become a template for integrating climate ambition with security-era constraints.
+
+## Related coverage
+- Previous: [/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/](/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/)
+- News baseline: [/articles/hard-choices-test-breakaway-climate-summit/](/articles/hard-choices-test-breakaway-climate-summit/)
+
+## Sources
+- [Reuters: Turkey set to host COP31 climate summit, Australia to lead government talks](https://www.reuters.com/)
+- [POLITICO: It’s official: Turkey will be boss of COP31 climate talks](https://www.politico.eu/)
+- [Lowy Institute: COP31 still offers Australia and the Pacific a chance to reset global climate ambition](https://www.lowyinstitute.org/)

--- a/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance.md
+++ b/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance.md
@@ -8,6 +8,7 @@ subject: "opinion-editorials"
 category: "opinion-editorials"
 status: "published"
 permalink: "/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance/"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/327"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
+    "slug": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
+    "title": "Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics",
+    "summary": "Turkey’s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
+    "date": "2026-05-03T15:39:52Z",
+    "subject": "opinion-editorials",
+    "category": "opinion-editorials",
+    "author": "Simone Hart",
+    "author_id": "simone-hart",
+    "author_display_name": "Simone Hart",
+    "permalink": "/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-03-just-10-minutes-of-daily-floor-exercises-may-improve-balance-and-agility-study-f",
     "title": "Just 10 minutes of daily floor exercises may improve balance and agility, study finds",
     "summary": "Just 10 minutes of daily floor exercises may improve balance and agility, study finds: key verified developments for the science-health desk.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,8 @@
     "author_id": "simone-hart",
     "author_display_name": "Simone Hart",
     "permalink": "/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance/",
-    "image": "/images/news-banner.png"
+    "image": "/images/news-banner.png",
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/327"
   },
   {
     "id": "2026-05-03-just-10-minutes-of-daily-floor-exercises-may-improve-balance-and-agility-study-f",


### PR DESCRIPTION
## Summary
Opinion update on COP31 leadership structure and what it implies for implementation-era climate diplomacy.

## OFF-RECORD: Claim matrix
1. Turkey is set to host COP31 — confidence: high (Reuters plus Politico convergence).
2. Australia has a larger government-negotiation role — confidence: medium-high (Reuters framing, secondary policy commentary).
3. Governance split shifts focus from ambition rhetoric to delivery architecture — confidence: medium (editorial inference grounded in known negotiation dynamics).

## OFF-RECORD: Source discovery and bias-check log
- Seed query: Google News RSS for COP31 hosting and climate talks.
- Prioritized wire plus institutional analysis (Reuters, Politico Europe policy desk, Lowy Institute).
- Bias check: balanced hard-news source (Reuters) with policy framing source (Lowy) to avoid single-outlet narrative lock.

## OFF-RECORD: Editorial rationale and safety checks
- Desk fit check: opinion-editorials (argument-driven analysis, not straight reporting).
- Duplicate gate: related environment piece exists; this item framed as Update with explicit What is New and linked prior and baseline coverage.
- Content safety: avoided fabricated quotes and unverifiable numerics; clearly separated reported facts from editorial argument.

## OFF-RECORD: Internal process notes
- Image generation via gpt-image-1 attempted; unavailable in run environment, fallback image retained.
- Article body intentionally excludes this off-record process section.
