### PR TITLE
Arts-entertainment: Devil Wears Prada 2 costume rollout trend brief

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "author_display_name": "Camille Vega",
     "permalink": "/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/339"
   },
   {
     "id": "2026-05-04-alphabet-investors-push-for-safeguards-on-use-of-its-cloud-ai-tech-reuters",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
+    "slug": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
+    "title": "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook",
+    "summary": "Early wardrobe reveals for The Devil Wears Prada 2 are being treated as headline entertainment and fashion moments, signaling a broader shift in how sequel campaigns are packaged across media.",
+    "date": "2026-05-04T01:00:00Z",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "author": "Camille Vega",
+    "author_id": "arts-entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "permalink": "/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-04-alphabet-investors-push-for-safeguards-on-use-of-its-cloud-ai-tech-reuters",
     "slug": "2026-05-04-alphabet-investors-push-for-safeguards-on-use-of-its-cloud-ai-tech-reuters",
     "title": "Alphabet investors push for safeguards on use of its cloud, AI tech - Reuters",

--- a/content/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz.md
+++ b/content/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz.md
@@ -5,7 +5,7 @@ desk: "arts-entertainment"
 author: "Camille Vega"
 date: "2026-05-04"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/339"
 ---
 
 A wave of early wardrobe reveals tied to *The Devil Wears Prada 2* is turning a film sequel into a cross-platform fashion event before release, with entertainment and style outlets treating costume stills as standalone news moments.

--- a/content/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz.md
+++ b/content/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz.md
@@ -1,0 +1,30 @@
+---
+title: "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook"
+slug: "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz"
+desk: "arts-entertainment"
+author: "Camille Vega"
+date: "2026-05-04"
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+A wave of early wardrobe reveals tied to *The Devil Wears Prada 2* is turning a film sequel into a cross-platform fashion event before release, with entertainment and style outlets treating costume stills as standalone news moments.
+
+Coverage from major publications highlights how character styling is being rolled out in serialized beats—first-look images, individual outfit breakdowns, and shopping-oriented explainers—rather than a single traditional trailer cycle.
+
+## What’s happening
+
+- The New York Times reported on how seven key looks for the sequel were developed and positioned the costumes as a central storytelling and marketing element.
+- Variety and Vogue published look-by-look analyses, expanding attention beyond film audiences to fashion-focused readers.
+- Consumer-facing outlets such as People and Good Morning America amplified the trend with “shop the look” and nostalgia-framed follow-ups.
+
+## Why it matters
+
+For the arts-and-entertainment desk, this is a clear example of how film promotion is converging with creator commerce and editorial fashion coverage. Costume design is no longer just supporting material around a movie release; it is increasingly a primary content engine that sustains attention across entertainment, lifestyle, and retail media.
+
+## Sources
+
+- The New York Times: https://www.nytimes.com/2026/05/02/movies/devil-wears-prada-2-costumes.html
+- Variety: https://variety.com/ (coverage: “The Devil Wears Prada 2” fashion/outfit explainer)
+- Vogue: https://www.vogue.com/ (coverage: “Andy! Miranda! Emily! Recreate the Major Looks from The Devil Wears Prada 2”)
+- People: https://people.com/ (coverage: Anne Hathaway / outfit-focused follow-up)


### PR DESCRIPTION
## Summary
Adds one arts-entertainment article on the *Devil Wears Prada 2* costume rollout trend and updates `assets/data/articles.json`.

## Editorial decision
- Desk fit: **arts-entertainment** (film marketing + costume design coverage)
- Decision: **new item** (no prior matching article slug/topic found)
- Image generation: attempted OpenAI `gpt-image-1`, fallback used due to missing `OPENAI_API_KEY`

## OFF-RECORD: Claim matrix
1. Claim: Early costume reveals are being treated as major news beats.
   - Source(s): NYT costume development feature; Variety outfit explainer; Vogue look recreation post.
   - Confidence: Medium.
2. Claim: Coverage crossed from entertainment press into consumer/style amplification.
   - Source(s): People and GMA outfit/shop-angle follow-ups.
   - Confidence: Medium.
3. Claim: This reflects a broader marketing pattern for high-fashion franchise IP.
   - Source(s): comparative framing across outlets above.
   - Confidence: Medium-low (interpretive trend claim, labeled analysis).

## OFF-RECORD: Source discovery + bias-check log
- Discovery path: Google News RSS query for "Devil Wears Prada 2 costumes".
- Outlet mix: NYT, Variety, Vogue, People/GMA.
- Bias checks: avoided unverifiable social posts; framed uncertain inference as analysis.

## OFF-RECORD: Editorial rationale and safety checks
- Desk purity: entertainment/fashion-media intersection.
- Avoided speculative production or financial claims.
- Fallback house image used.
