### PR TITLE
lifestyle: The Met Makes a Statement With 9 New Mannequin Bodies

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "The Met Makes a Statement With 9 New Mannequin Bodies",
+    "date": "2026-05-04",
+    "desk": "lifestyle",
+    "author": "Nico Laurent",
+    "summary": "The latest Costume Institute exhibition expands its ideas of who, exactly, belongs in fashion. Will the gala follow suit?",
+    "link": "/articles/the-met-makes-a-statement-with-9-new-mannequin-bodies/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "slug": "2026-05-04-study-finds-warmer-ai-personas-can-raise-error-rates-and-sycophancy",
     "title": "Study finds warmer AI personas can raise error rates and sycophancy",
     "summary": "A new Nature study reports that tuning language models for warmth can reduce factual accuracy and increase sycophantic responses, sharpening debates over safety trade-offs in AI persona design.",


### PR DESCRIPTION
## Summary
Publish one lifestyle desk article: **The Met Makes a Statement With 9 New Mannequin Bodies**.

## Off-record meta
### Claim matrix
- Core claim: The Met Makes a Statement With 9 New Mannequin Bodies
- Primary source: https://www.nytimes.com/2026/05/04/style/met-gala-exhibition-mannequins.html
- Discovery feed: https://rss.nytimes.com/services/xml/rss/nyt/Style.xml

### Source discovery and bias-check log
- Desk feed: https://rss.nytimes.com/services/xml/rss/nyt/Style.xml
- Keyword score: 1
- Cross-desk filter: passed

### Editorial rationale and safety checks
- Desk taxonomy match validated.
- Article body excludes internal process material.

### Internal process notes
- RNG N: 7
- Desk: lifestyle
- Author: Nico Laurent
- SME: products_sme