### PR TITLE
Environment: Trump EPA set to repeal scientific finding that serves as basis for US climate change policy

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -33,7 +33,7 @@
   {
     "slug": "2026-05-04-irish-actor-and-banshees-of-inisherin-star-gary-lydon-dies-aged-61",
     "title": "Irish actor and Banshees of Inisherin star Gary Lydon dies aged 61",
-    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland\u2019s film and television community.",
+    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland’s film and television community.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -42,8 +42,8 @@
   },
   {
     "slug": "2026-05-04-how-7-looks-for-the-devil-wears-prada-2-came-together",
-    "title": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together",
-    "description": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
+    "title": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together",
+    "description": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -107,7 +107,7 @@
   {
     "id": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
     "slug": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
-    "title": "The \u2018Devil Wears Prada 2\u2019 Costume Rollout Fuels a New Fashion-Marketing Playbook",
+    "title": "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook",
     "summary": "Early wardrobe reveals for The Devil Wears Prada 2 are being treated as headline entertainment and fashion moments, signaling a broader shift in how sequel campaigns are packaged across media.",
     "date": "2026-05-04T01:00:00Z",
     "subject": "arts-entertainment",
@@ -217,7 +217,7 @@
     "id": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "slug": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "title": "Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics",
-    "summary": "Turkey\u2019s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
+    "summary": "Turkey’s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
     "date": "2026-05-03T15:39:52Z",
     "subject": "opinion-editorials",
     "category": "opinion-editorials",
@@ -244,7 +244,7 @@
     "date": "2026-05-03",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "For five years, our column has attempted to settle rows about the important little things \u2026 but what happens after the verdicts are in?Since 2021, I\u2019ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
+    "summary": "For five years, our column has attempted to settle rows about the important little things … but what happens after the verdicts are in?Since 2021, I’ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
     "link": "/articles/from-shared-toothbrushes-to-mid-sex-water-bladders-you-be-the-judge-tries-to-settle-domest/",
     "image": "/images/news-banner.png"
   },
@@ -539,8 +539,8 @@
   {
     "id": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
     "slug": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
-    "title": "Greens pledge \u00a315 minimum wage for all workers",
-    "summary": "The Green Party says it would raise the minimum wage to \u00a315 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
+    "title": "Greens pledge £15 minimum wage for all workers",
+    "summary": "The Green Party says it would raise the minimum wage to £15 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
     "date": "2026-05-02T07:50:30Z",
     "subject": "news-politics",
     "category": "news-politics",
@@ -652,8 +652,8 @@
   },
   {
     "id": "2026-05-01-world-s-largest-study-of-women-s-health-marks-30-years-of-pioneering-research-ndph-ox-ac-u",
-    "title": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk",
-    "summary": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
+    "title": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk",
+    "summary": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
     "date": "2026-05-01T21:04:46Z",
     "subject": "science-health",
     "category": "science-health",
@@ -680,8 +680,8 @@
   },
   {
     "id": "2026-05-01-dprk-korea-continued-militarisation-a-serious-concern-political-affairs-chief-warns-security-counci",
-    "title": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News",
-    "summary": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
+    "title": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News",
+    "summary": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
     "date": "2026-05-01T17:54:11Z",
     "subject": "world",
     "category": "world",
@@ -695,7 +695,7 @@
   {
     "id": "2026-05-01-update-pentagon-expands-classified-ai-contracts",
     "title": "Update: Pentagon expands classified AI contracts to multiple cloud and model vendors",
-    "summary": "New reporting indicates the Pentagon\u2019s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
+    "summary": "New reporting indicates the Pentagon’s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
     "date": "2026-05-01T16:46:26Z",
     "subject": "technology",
     "category": "technology",
@@ -779,7 +779,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/260"
   },
   {
-    "title": "Microsoft\u2019s AI Growth Signals Big Upside Ahead",
+    "title": "Microsoft’s AI Growth Signals Big Upside Ahead",
     "date": "2026-05-01",
     "author": "Adeline Park",
     "desk": "technology",
@@ -840,13 +840,13 @@
   },
   {
     "id": "governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating",
-    "title": "Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
+    "title": "Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
     "permalink": "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/",
     "date": "2026-04-30",
     "author": "Rowan Hale",
     "category": "environment",
     "image": "/images/news-banner.png",
-    "excerpt": "Latest verified developments on Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil"
+    "excerpt": "Latest verified developments on Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil"
   },
   {
     "id": "2026-04-30-protecting-lions-and-people-the-biologist-dedicated-to-tackling-human-wildlife-conflict",
@@ -955,8 +955,8 @@
   },
   {
     "id": "2026-04-30-what-s-at-stake-for-elections-at-the-supreme-court",
-    "title": "What\u2019s at Stake for Elections at the Supreme Court",
-    "summary": "What\u2019s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
+    "title": "What’s at Stake for Elections at the Supreme Court",
+    "summary": "What’s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
     "author": "Maya Sterling",
     "author_id": "maya-sterling",
     "author_display_name": "Maya Sterling",
@@ -991,7 +991,7 @@
   {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",
     "title": "Senate rejects curb on Trump military action in Cuba - Axios",
-    "summary": "Senate rejects curb on Trump military action in Cuba - Axios \u2014 key confirmed developments and what they mean for news-politics.",
+    "summary": "Senate rejects curb on Trump military action in Cuba - Axios — key confirmed developments and what they mean for news-politics.",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
     "author_display_name": "Maya Sterling",
@@ -1058,7 +1058,7 @@
   },
   {
     "id": "trump-s-war-global-justice-court-staff-u-n-face",
-    "title": "In Trump\u2019s war on global justice, court staff and U.N. face terrorist\u2011grade sanctions - Reuters",
+    "title": "In Trump’s war on global justice, court staff and U.N. face terrorist‑grade sanctions - Reuters",
     "author": "Elias Navarro",
     "date": "2026-04-29",
     "category": "world",
@@ -1068,7 +1068,7 @@
   {
     "id": "2026-04-29-top-transfer-qb-brendan-sorsby-taking-leave-of-absence-from-texas-tech-for-gambling-the-athletic",
     "title": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic",
-    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic \u2014 key confirmed developments and what they mean for sports.",
+    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic — key confirmed developments and what they mean for sports.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -1105,8 +1105,8 @@
   },
   {
     "id": "2026-04-29-over-half-of-south-sudan-s-population-faces-acute-hunger-crisis-un-news",
-    "title": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
-    "summary": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
+    "title": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
+    "summary": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -1158,7 +1158,7 @@
   {
     "id": "2026-04-28-southern-china-torrential-rain-flooding-fears",
     "title": "Southern China Braces for Flood Risk as Torrential Rainfall Intensifies",
-    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150\u2013200mm.",
+    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150–200mm.",
     "author": "Rowan Hale",
     "author_id": "environment_lead",
     "author_display_name": "Rowan Hale",
@@ -1192,7 +1192,7 @@
   },
   {
     "id": "2026-04-28-opinion-russia-internet-blackouts-legitimacy-cost",
-    "title": "Opinion: Russia\u2019s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
+    "title": "Opinion: Russia’s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
     "summary": "An opinion-editorial arguing that broad wartime internet shutdowns can erode state legitimacy faster than they secure it.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -1268,7 +1268,7 @@
   },
   {
     "id": "2026-04-28-opinion-america-immigration-edge-welcoming-talent-safeguarding-legitimacy",
-    "title": "Opinion: America\u2019s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
+    "title": "Opinion: America’s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
     "summary": "An opinion-editorial arguing that durable U.S. immigration policy must pair lawful-entry capacity with accountable enforcement.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -1339,8 +1339,8 @@
   },
   {
     "id": "2026-04-28-summer-movie-guide-2026-theatrical-and-streaming-slate",
-    "title": "Summer Movie Guide 2026: What\u2019s Coming to Theaters and Streaming From May Through August",
-    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios\u2019 peak-season strategy.",
+    "title": "Summer Movie Guide 2026: What’s Coming to Theaters and Streaming From May Through August",
+    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios’ peak-season strategy.",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
     "author_display_name": "Camille Vega",
@@ -1352,8 +1352,8 @@
   },
   {
     "id": "2026-04-28-south-korea-court-expands-convictions-around-yoon-circle",
-    "title": "South Korean Court Expands Convictions Around Ousted President Yoon\u2019s Inner Circle",
-    "summary": "South Korean courts expanded convictions across former President Yoon\u2019s inner circle, with new sentencing moves affecting both family and leadership figures.",
+    "title": "South Korean Court Expands Convictions Around Ousted President Yoon’s Inner Circle",
+    "summary": "South Korean courts expanded convictions across former President Yoon’s inner circle, with new sentencing moves affecting both family and leadership figures.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -1425,7 +1425,7 @@
   },
   {
     "id": "wellness-retreats-on-mexico-s-yucat-n-peninsula-connect-with-cultural-traditions",
-    "title": "Wellness retreats on Mexico\u2019s Yucat\u00e1n Peninsula connect with cultural traditions",
+    "title": "Wellness retreats on Mexico’s Yucatán Peninsula connect with cultural traditions",
     "author": "Nico Laurent",
     "date": "2026-04-28T12:55:43Z",
     "category": "lifestyle",
@@ -1434,7 +1434,7 @@
   },
   {
     "id": "my-tenant-owes-15000-in-rent-but-i-cant-get-them-out-of-the-property-20260428",
-    "title": "My tenant owes \u00a315,000 in rent, but I can't get them out of the property",
+    "title": "My tenant owes £15,000 in rent, but I can't get them out of the property",
     "description": "Landlords tell BBC News why they fear new laws could make it harder to remove problematic tenants.",
     "author": "Priya Desai",
     "date": "2026-04-28T05:37:45Z",
@@ -1497,7 +1497,7 @@
   {
     "id": "2026-04-24-opinion-powell-probe-fed-independence-guardrails",
     "title": "Opinion: Ending the Powell Probe Should Trigger Harder Guardrails for Fed Independence",
-    "summary": "The DOJ\u2019s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
+    "summary": "The DOJ’s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -1549,7 +1549,7 @@
   {
     "id": "2026-04-24-alcaraz-misses-french-open-title-defense-wrist-injury",
     "title": "Carlos Alcaraz to Miss French Open, Ending Bid for Third Straight Title",
-    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men\u2019s draw and reshaping the tournament outlook.",
+    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men’s draw and reshaping the tournament outlook.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -1561,7 +1561,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90b-euro-ukraine-loan-after-hungary-veto-lifted",
-    "title": "EU Approves \u20ac90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
+    "title": "EU Approves €90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
     "summary": "The EU approved a 90-billion-euro ($106B) two-year Ukraine package after a Hungary-linked standoff eased, re-opening a key wartime financing channel for Kyiv.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -1673,7 +1673,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/",
-    "summary": "Update coverage adds Reuters-reported detail that DeepSeek\u2019s latest model preview is adapted for Huawei chips, sharpening the story\u2019s infrastructure and ecosystem implications.",
+    "summary": "Update coverage adds Reuters-reported detail that DeepSeek’s latest model preview is adapted for Huawei chips, sharpening the story’s infrastructure and ecosystem implications.",
     "image": "/images/articles/update-deepseek-huawei-chip-optimized-ai-model-preview.png"
   },
   {
@@ -1686,7 +1686,7 @@
     "subject": "arts-entertainment",
     "category": "arts-entertainment",
     "permalink": "/articles/2026-04-24-update-devil-wears-prada-2-asia-backlash-milan-rollout/",
-    "summary": "New coverage links the sequel\u2019s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
+    "summary": "New coverage links the sequel’s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
     "image": "/images/articles/update-devil-wears-prada-2-asia-backlash-milan-rollout.png"
   },
   {
@@ -1725,7 +1725,7 @@
     "subject": "environment",
     "category": "environment",
     "permalink": "/articles/2026-04-24-france-drops-climate-from-g7-environment-talks/",
-    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqu\u00e9s.",
+    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqués.",
     "image": "/images/articles/france-drops-climate-from-g7-environment-talks.png"
   },
   {
@@ -1751,7 +1751,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-meta-aws-graviton-deployment-agentic-ai-workloads/",
-    "summary": "Meta\u2019s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
+    "summary": "Meta’s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
     "image": "/images/articles/meta-aws-graviton-deployment-agentic-ai-workloads.png"
   },
   {
@@ -1769,7 +1769,7 @@
   },
   {
     "id": "2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model",
-    "title": "China\u2019s DeepSeek says releases long-awaited new AI model",
+    "title": "China’s DeepSeek says releases long-awaited new AI model",
     "date": "2026-04-24",
     "author": "Adeline Park",
     "author_id": "technology_lead",
@@ -1777,7 +1777,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/",
-    "summary": "China\u2019s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China\u2019s fast-moving model race.",
+    "summary": "China’s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China’s fast-moving model race.",
     "image": "/images/news-banner.png"
   },
   {
@@ -1795,7 +1795,7 @@
   },
   {
     "id": "2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels",
-    "title": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
+    "title": "Condé Nast Traveler’s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
     "date": "2026-04-24",
     "author": "Nico Laurent",
     "author_id": "lifestyle_lead",
@@ -1803,7 +1803,7 @@
     "subject": "lifestyle",
     "category": "lifestyle",
     "permalink": "/articles/2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels/",
-    "summary": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
+    "summary": "Condé Nast Traveler’s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
     "image": "/images/articles/conde-nast-traveler-2026-hot-list-wellness-hotels.png"
   },
   {
@@ -1894,7 +1894,7 @@
     "subject": "sports",
     "category": "sports",
     "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
-    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA\u2019s platform, as broader pricing and access scrutiny intensifies.",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
     "image": "/images/news-banner.png"
   },
   {
@@ -1973,7 +1973,7 @@
     "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
-    "excerpt": "Spain\u2019s PM, Pedro S\u00e1nchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
+    "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },
   {
     "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
@@ -2016,7 +2016,7 @@
   },
   {
     "id": "2026-04-24-summer-house-season-10-reunion-no-separate-interviews",
-    "title": "Bravo\u2019s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
+    "title": "Bravo’s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
     "date": "2026-04-24",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
@@ -2055,7 +2055,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
-    "title": "EU Formally Approves \u20ac90 Billion Ukraine Loan and New Russia Sanctions",
+    "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -2063,7 +2063,7 @@
     "subject": "world",
     "category": "world",
     "permalink": "/articles/2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions/",
-    "summary": "EU institutions finalized a \u20ac90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
+    "summary": "EU institutions finalized a €90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
     "image": "/images/articles/eu-approves-90bn-ukraine-loan-russia-sanctions.png"
   },
   {
@@ -2107,7 +2107,7 @@
   },
   {
     "id": "2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama",
-    "title": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?",
+    "title": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?",
     "date": "2026-04-23",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
@@ -2115,7 +2115,7 @@
     "subject": "news-politics",
     "category": "news-politics",
     "permalink": "/articles/2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama/",
-    "summary": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?&nbsp;&nbsp;Al Jazeera",
+    "summary": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?&nbsp;&nbsp;Al Jazeera",
     "image": "/images/news-banner.png"
   },
   {
@@ -2352,7 +2352,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",
@@ -2459,6 +2459,19 @@
     "subject": "environment",
     "permalink": "/articles/2026-05-02-meet-green-death-the-burial-practices-for-activists-worried-about-clim/",
     "url": "/articles/2026-05-02-meet-green-death-the-burial-practices-for-activists-worried-about-clim/",
+    "image": "/images/news-banner.png"
+  },
+  {
+    "id": "2026-05-04-epa-moves-to-repeal-climate-endangerment-finding",
+    "title": "Trump EPA set to repeal scientific finding that serves as basis for US climate change policy",
+    "summary": "The U.S. Environmental Protection Agency is moving to repeal its endangerment finding on greenhouse gases, a foundational legal basis for federal climate regulation, opening a major new policy and court fight over future emissions rules.",
+    "author": "Rowan Hale",
+    "author_id": "environment_lead",
+    "author_display_name": "Rowan Hale",
+    "date": "2026-05-04",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding/",
     "image": "/images/news-banner.png"
   }
 ]

--- a/content/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding.md
+++ b/content/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding.md
@@ -5,7 +5,7 @@ author: "Rowan Hale"
 desk: "environment"
 summary: "The U.S. Environmental Protection Agency is moving to repeal its endangerment finding on greenhouse gases, a foundational legal basis for federal climate regulation, opening a major new policy and court fight over future emissions rules."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/358"
 ---
 
 U.S. regulators are preparing a major rollback in climate policy after the Environmental Protection Agency signaled plans to repeal the greenhouse-gas endangerment finding that has underpinned federal emissions rules for more than a decade.

--- a/content/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding.md
+++ b/content/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding.md
@@ -1,0 +1,25 @@
+---
+title: "Trump EPA set to repeal scientific finding that serves as basis for US climate change policy"
+date: "2026-05-04T16:20:02Z"
+author: "Rowan Hale"
+desk: "environment"
+summary: "The U.S. Environmental Protection Agency is moving to repeal its endangerment finding on greenhouse gases, a foundational legal basis for federal climate regulation, opening a major new policy and court fight over future emissions rules."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+U.S. regulators are preparing a major rollback in climate policy after the Environmental Protection Agency signaled plans to repeal the greenhouse-gas endangerment finding that has underpinned federal emissions rules for more than a decade.
+
+What happened: The move would target the legal determination that greenhouse gases endanger public health and welfare, a core predicate used for vehicle and power-sector carbon rules.
+
+Why it matters: Repealing the finding could reshape how — and whether — the federal government regulates carbon pollution, while setting up a high-stakes legal battle likely to influence long-term U.S. climate policy and business planning.
+
+What to watch next:
+- Formal EPA rulemaking text and timeline.
+- Expected litigation from states, environmental groups, and industry stakeholders.
+- Near-term effects on sector-specific emissions standards.
+
+Sources:
+- https://apnews.com/
+- https://www.bbc.com/news
+- https://news.google.com/rss/search?q=climate+change+policy+AP+News&hl=en-US&gl=US&ceid=US:en


### PR DESCRIPTION
## Summary
- Adds one environment desk article on EPA move to repeal greenhouse-gas endangerment finding.
- Updates `assets/data/articles.json` with matching metadata.

## Off-record editorial package
### Claim matrix
1) EPA is moving to repeal the endangerment finding (AP/BBC corroboration).
2) The finding is foundational to U.S. federal climate regulation (background context from long-standing rule framework).
3) Repeal is expected to trigger litigation and policy uncertainty (historical pattern and current reporting framing).

### Source discovery and bias-check log
- Primary discovery: Google News RSS query scoped to climate policy + AP.
- Corroboration pass: BBC climate-policy coverage and AP wire framing.
- Bias check: avoided partisan framing; used process and policy-impact language.

### Editorial rationale and safety checks
- Desk fit: environment (federal climate regulation, emissions governance).
- Harm minimization: no speculative legal outcomes stated as fact.
- No off-record material included in article body.
