### PR TITLE
arts-entertainment: Blake Lively and Justin Baldoni settle lawsuit over It Ends With Us film

### DIFF
--- a/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi.md
+++ b/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi.md
@@ -1,0 +1,26 @@
+---
+title: "Blake Lively and Justin Baldoni settle lawsuit over It Ends With Us film"
+author: "Camille Vega"
+author_id: "camille_vega"
+date: "2026-05-05"
+subject: "arts-entertainment"
+category: "news"
+status: "published"
+permalink: "/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+The settlement comes just ahead of a trial slated to begin in May, where both stars were expected to testify.
+
+The latest reporting indicates a meaningful development in this arts entertainment story. According to primary coverage, officials and stakeholders are clarifying next steps while markets and institutions assess downstream effects.
+
+Why it matters: this update affects near-term decision-making for readers tracking arts entertainment trends, especially where policy, investment, and operational planning intersect.
+
+What to watch next:
+
+- Official confirmations or amended guidance from responsible agencies or organizations.
+- Follow-on disclosures that quantify scale, timeline, or financial impact.
+- Independent corroboration from additional outlets and public records.
+
+Source: [https://www.bbc.com/news/articles/c936q7np647o?at_medium=RSS&at_campaign=rss](https://www.bbc.com/news/articles/c936q7np647o?at_medium=RSS&at_campaign=rss)

--- a/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi.md
+++ b/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi.md
@@ -7,7 +7,7 @@ subject: "arts-entertainment"
 category: "news"
 status: "published"
 permalink: "/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/370"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi",
+    "title": "Blake Lively and Justin Baldoni settle lawsuit over It Ends With Us film",
+    "author": "Camille Vega",
+    "authorId": "camille_vega",
+    "date": "2026-05-05",
+    "subject": "arts-entertainment",
+    "category": "news",
+    "status": "published",
+    "permalink": "/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi",
+    "publishedPR": "PENDING",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-04-williams-says-fed-policy-well-positioned-for-economic-risks-uncertainty-kfgo",
     "title": "Williams says Fed policy well positioned for economic risks, uncertainty - KFGO",
     "summary": "Williams says Fed policy well positioned for economic risks, uncertainty - KFGO",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "news",
     "status": "published",
     "permalink": "/articles/2026-05-05-blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi",
-    "publishedPR": "PENDING",
+    "publishedPR": "https://github.com/thestamp/Static-ai-articles/pull/370",
     "image": "/images/news-banner.png"
   },
   {


### PR DESCRIPTION
## Summary
Publishes one arts-entertainment article.

## Claim matrix (off-record)
- Claim: "Blake Lively and Justin Baldoni settle lawsuit over It Ends With Us film" is a current development. Source: https://www.bbc.com/news/articles/c936q7np647o?at_medium=RSS&at_campaign=rss. Status: supported by source feed and linked report.
- Claim: Story has desk fit for arts-entertainment. Source: desk mapping and topic taxonomy. Status: editor-validated.

## Source discovery and bias-check log (off-record)
- Discovery feed: https://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml
- Primary link selected: https://www.bbc.com/news/articles/c936q7np647o?at_medium=RSS&at_campaign=rss
- Bias check: used direct publisher source and avoided single-claim extrapolation.

## Editorial rationale and safety checks (off-record)
- Chosen for clear desk alignment and timeliness.
- Article body excludes internal process notes and approval metadata.
- Image generated via gpt-image-1 with fallback policy.