### PR TITLE
Science-Health: FDA approves Veppanu for ESR1-mutated advanced breast cancer

### DIFF
--- a/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer.md
+++ b/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer.md
@@ -1,0 +1,29 @@
+---
+title: "FDA approves Veppanu for ESR1-mutated advanced breast cancer"
+author: "Dr. Lena Okafor"
+author_id: "science_health_lead"
+author_display_name: "Dr. Lena Okafor"
+date: "2026-05-05"
+subject: "science-health"
+category: "science-health"
+status: "published"
+permalink: "/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+The U.S. Food and Drug Administration has approved **Veppanu (vepdegestrant)** for patients with **ER-positive, HER2-negative advanced breast cancer** whose tumors carry **ESR1 mutations**, according to Reuters and company announcements from Pfizer and Arvinas.
+
+The decision gives clinicians a newly approved treatment option in a segment of metastatic breast cancer where resistance to prior endocrine therapy is a recurring challenge. Arvinas described Veppanu as a first approved PROTAC-based therapy in this setting, while Guardant Health separately announced FDA approval of a companion diagnostic indication for its Guardant360 CDx test tied to ESR1 mutation detection.
+
+## Why this matters
+
+For oncology teams, the approval may expand sequencing options after progression on earlier hormone-based regimens. For patients, the key practical implication is that biomarker testing for ESR1 mutations is likely to play a larger role in determining who is eligible for treatment.
+
+## What to watch next
+
+- How quickly major cancer centers and community practices incorporate Veppanu into treatment pathways.
+- Coverage and reimbursement decisions for both the drug and companion diagnostics.
+- Additional real-world outcomes data on durability and tolerability as uptake broadens.
+
+Reuters first reported the FDA decision on May 1, 2026.

--- a/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer.md
+++ b/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer.md
@@ -8,7 +8,7 @@ subject: "science-health"
 category: "science-health"
 status: "published"
 permalink: "/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/371"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "category": "science-health",
     "permalink": "/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/371"
   },
   {
     "id": "blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer",
+    "title": "FDA approves Veppanu for ESR1-mutated advanced breast cancer",
+    "summary": "FDA approval of Veppanu introduces a new targeted option for ESR1-mutated ER-positive, HER2-negative advanced breast cancer and increases the importance of companion diagnostic testing.",
+    "author": "Dr. Lena Okafor",
+    "author_id": "science_health_lead",
+    "author_display_name": "Dr. Lena Okafor",
+    "date": "2026-05-05",
+    "subject": "science-health",
+    "category": "science-health",
+    "permalink": "/articles/2026-05-05-fda-approves-veppanu-for-esr1-mutated-advanced-breast-cancer/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "blake-lively-and-justin-baldoni-settle-lawsuit-over-it-ends-with-us-fi",
     "title": "Blake Lively and Justin Baldoni settle lawsuit over It Ends With Us film",
     "author": "Camille Vega",


### PR DESCRIPTION
## Summary
- Adds a science-health article on FDA approval of Veppanu (vepdegestrant) for ESR1-mutated ER-positive/HER2-negative advanced breast cancer.
- Updates assets/data/articles.json catalog with matching metadata.
- Uses fallback image /images/news-banner.png because OpenAI image generation could not run in this environment (missing OPENAI_API_KEY).

## Claim matrix (off-record)
1. FDA approved Veppanu for ESR1-mutated ER+/HER2- advanced breast cancer.
   - Sources: Reuters (May 1, 2026), Arvinas announcement, Guardant companion diagnostic announcement.
2. Companion diagnostic linkage includes ESR1 mutation testing pathway.
   - Source: Guardant Health release on Guardant360 CDx indication.
3. Reuters first reported the decision on May 1, 2026.
   - Source: Reuters timestamp.

## Source discovery and bias-check log (off-record)
- Discovery channels: Google News RSS queries around FDA approvals and ESR1 breast-cancer treatment.
- Bias controls: anchored article to straight-news framing, avoided efficacy/safety claims beyond reported approval facts, and avoided promotional language from company PRs.
- Cross-source consistency check: Reuters headline aligned with Arvinas and Guardant announcements on indication framing.

## Editorial rationale and safety checks (off-record)
- Desk fit: science-health because this is a U.S. regulator plus oncology treatment approval.
- Safety: excluded dosing advice, patient-specific recommendations, and unverified efficacy comparisons.
- Duplicate gate: searched repo for Veppanu/vepdegestrant/ESR1/Arvinas and found no prior matching article.
