### PR TITLE
[environment] Norway fish-farm waste report and fjord pollution pressure

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -2,7 +2,7 @@
   {
     "id": "white-house-news-latest-updates-and-video-on-us-politics-and-government",
     "title": "White House News: Latest Updates and Video on U.S. Politics and Government",
-    "summary": "White House News: Latest Updates and Video on U.S. Politics and Government \u2014 key verified developments and why they matter for the news politics desk.",
+    "summary": "White House News: Latest Updates and Video on U.S. Politics and Government — key verified developments and why they matter for the news politics desk.",
     "author": "Maya Sterling",
     "date": "2026-05-05T11:31:47Z",
     "category": "news-politics",
@@ -13,8 +13,8 @@
   },
   {
     "id": "market-expert-says-potential-fed-rate-cuts-could-spark-one-of-the-biggest-explosions-in-us",
-    "title": "Market expert says potential Fed rate cuts could spark \u2018one of the biggest explosions\u2019 in US economy",
-    "summary": "Priya Desai reports on Market expert says potential Fed rate cuts could spark \u2018one of the biggest explosions\u2019 in US economy and why it matters for the business economy desk.",
+    "title": "Market expert says potential Fed rate cuts could spark ‘one of the biggest explosions’ in US economy",
+    "summary": "Priya Desai reports on Market expert says potential Fed rate cuts could spark ‘one of the biggest explosions’ in US economy and why it matters for the business economy desk.",
     "author": "Priya Desai",
     "date": "2026-05-05T09:27:05Z",
     "category": "business-economy",
@@ -36,7 +36,7 @@
   {
     "id": "towards-a-people-centered-regulatory-democracy",
     "title": "Towards a People-centered Regulatory Democracy",
-    "summary": "Towards a People-centered Regulatory Democracy \u2014 latest confirmed developments and what to watch next.",
+    "summary": "Towards a People-centered Regulatory Democracy — latest confirmed developments and what to watch next.",
     "author": "Simone Hart",
     "date": "2026-05-05",
     "subject": "opinion-editorials",
@@ -60,8 +60,8 @@
   },
   {
     "id": "2026-05-05-disabled-people-are-being-abandoned-by-the-g-o-p",
-    "title": "Opinion: Disabled Americans and the GOP\u2019s Policy Crossroads",
-    "summary": "A new New York Times opinion essay argues Republicans have moved away from an older bipartisan disability-rights posture, using George H.W. Bush\u2019s legacy as a benchmark for what policy support once looked like.",
+    "title": "Opinion: Disabled Americans and the GOP’s Policy Crossroads",
+    "summary": "A new New York Times opinion essay argues Republicans have moved away from an older bipartisan disability-rights posture, using George H.W. Bush’s legacy as a benchmark for what policy support once looked like.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -152,7 +152,7 @@
   },
   {
     "id": "2026-05-04-openai-google-and-microsoft-back-bill-to-fund-ai-literacy-in-schools",
-    "title": "OpenAI, Google, and Microsoft Back Bill to Fund \u2018AI Literacy\u2019 in Schools",
+    "title": "OpenAI, Google, and Microsoft Back Bill to Fund ‘AI Literacy’ in Schools",
     "permalink": "/articles/2026-05-04-openai-google-and-microsoft-back-bill-to-fund-ai-literacy-in-schools",
     "date": "2026-05-04",
     "author_id": "technology_lead",
@@ -175,7 +175,7 @@
     "title": "UK joining Ukraine loan scheme would be good for EU ties, Starmer says",
     "author": "Maya Sterling",
     "date": "2026-05-04",
-    "summary": "The UK is \"discussing participating\" in a \u00a378bn (\u20ac90bn) European Union loan scheme to support Ukraine, the prime minister says.",
+    "summary": "The UK is \"discussing participating\" in a £78bn (€90bn) European Union loan scheme to support Ukraine, the prime minister says.",
     "link": "/articles/2026-05-04-uk-joining-ukraine-loan-scheme-would-be-good-for-eu-ties-starmer-says/",
     "image": "/images/news-banner.png",
     "desk": "news-politics"
@@ -183,7 +183,7 @@
   {
     "id": "2026-05-04-what-champions-league-failure-means-for-broken-club-chelsea",
     "title": "What Champions League failure means for 'broken club' Chelsea",
-    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far\u2011reaching consequences.",
+    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far‑reaching consequences.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -236,7 +236,7 @@
   {
     "slug": "2026-05-04-irish-actor-and-banshees-of-inisherin-star-gary-lydon-dies-aged-61",
     "title": "Irish actor and Banshees of Inisherin star Gary Lydon dies aged 61",
-    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland\u2019s film and television community.",
+    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland’s film and television community.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -245,8 +245,8 @@
   },
   {
     "slug": "2026-05-04-how-7-looks-for-the-devil-wears-prada-2-came-together",
-    "title": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together",
-    "description": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
+    "title": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together",
+    "description": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -310,7 +310,7 @@
   {
     "id": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
     "slug": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
-    "title": "The \u2018Devil Wears Prada 2\u2019 Costume Rollout Fuels a New Fashion-Marketing Playbook",
+    "title": "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook",
     "summary": "Early wardrobe reveals for The Devil Wears Prada 2 are being treated as headline entertainment and fashion moments, signaling a broader shift in how sequel campaigns are packaged across media.",
     "date": "2026-05-04T01:00:00Z",
     "subject": "arts-entertainment",
@@ -420,7 +420,7 @@
     "id": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "slug": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "title": "Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics",
-    "summary": "Turkey\u2019s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
+    "summary": "Turkey’s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
     "date": "2026-05-03T15:39:52Z",
     "subject": "opinion-editorials",
     "category": "opinion-editorials",
@@ -447,7 +447,7 @@
     "date": "2026-05-03",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "For five years, our column has attempted to settle rows about the important little things \u2026 but what happens after the verdicts are in?Since 2021, I\u2019ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
+    "summary": "For five years, our column has attempted to settle rows about the important little things … but what happens after the verdicts are in?Since 2021, I’ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
     "link": "/articles/from-shared-toothbrushes-to-mid-sex-water-bladders-you-be-the-judge-tries-to-settle-domest/",
     "image": "/images/news-banner.png"
   },
@@ -742,8 +742,8 @@
   {
     "id": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
     "slug": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
-    "title": "Greens pledge \u00a315 minimum wage for all workers",
-    "summary": "The Green Party says it would raise the minimum wage to \u00a315 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
+    "title": "Greens pledge £15 minimum wage for all workers",
+    "summary": "The Green Party says it would raise the minimum wage to £15 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
     "date": "2026-05-02T07:50:30Z",
     "subject": "news-politics",
     "category": "news-politics",
@@ -855,8 +855,8 @@
   },
   {
     "id": "2026-05-01-world-s-largest-study-of-women-s-health-marks-30-years-of-pioneering-research-ndph-ox-ac-u",
-    "title": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk",
-    "summary": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
+    "title": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk",
+    "summary": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
     "date": "2026-05-01T21:04:46Z",
     "subject": "science-health",
     "category": "science-health",
@@ -883,8 +883,8 @@
   },
   {
     "id": "2026-05-01-dprk-korea-continued-militarisation-a-serious-concern-political-affairs-chief-warns-security-counci",
-    "title": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News",
-    "summary": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
+    "title": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News",
+    "summary": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
     "date": "2026-05-01T17:54:11Z",
     "subject": "world",
     "category": "world",
@@ -898,7 +898,7 @@
   {
     "id": "2026-05-01-update-pentagon-expands-classified-ai-contracts",
     "title": "Update: Pentagon expands classified AI contracts to multiple cloud and model vendors",
-    "summary": "New reporting indicates the Pentagon\u2019s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
+    "summary": "New reporting indicates the Pentagon’s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
     "date": "2026-05-01T16:46:26Z",
     "subject": "technology",
     "category": "technology",
@@ -982,7 +982,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/260"
   },
   {
-    "title": "Microsoft\u2019s AI Growth Signals Big Upside Ahead",
+    "title": "Microsoft’s AI Growth Signals Big Upside Ahead",
     "date": "2026-05-01",
     "author": "Adeline Park",
     "desk": "technology",
@@ -1043,13 +1043,13 @@
   },
   {
     "id": "governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating",
-    "title": "Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
+    "title": "Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
     "permalink": "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/",
     "date": "2026-04-30",
     "author": "Rowan Hale",
     "category": "environment",
     "image": "/images/news-banner.png",
-    "excerpt": "Latest verified developments on Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil"
+    "excerpt": "Latest verified developments on Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil"
   },
   {
     "id": "2026-04-30-protecting-lions-and-people-the-biologist-dedicated-to-tackling-human-wildlife-conflict",
@@ -1158,8 +1158,8 @@
   },
   {
     "id": "2026-04-30-what-s-at-stake-for-elections-at-the-supreme-court",
-    "title": "What\u2019s at Stake for Elections at the Supreme Court",
-    "summary": "What\u2019s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
+    "title": "What’s at Stake for Elections at the Supreme Court",
+    "summary": "What’s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
     "author": "Maya Sterling",
     "author_id": "maya-sterling",
     "author_display_name": "Maya Sterling",
@@ -1194,7 +1194,7 @@
   {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",
     "title": "Senate rejects curb on Trump military action in Cuba - Axios",
-    "summary": "Senate rejects curb on Trump military action in Cuba - Axios \u2014 key confirmed developments and what they mean for news-politics.",
+    "summary": "Senate rejects curb on Trump military action in Cuba - Axios — key confirmed developments and what they mean for news-politics.",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
     "author_display_name": "Maya Sterling",
@@ -1261,7 +1261,7 @@
   },
   {
     "id": "trump-s-war-global-justice-court-staff-u-n-face",
-    "title": "In Trump\u2019s war on global justice, court staff and U.N. face terrorist\u2011grade sanctions - Reuters",
+    "title": "In Trump’s war on global justice, court staff and U.N. face terrorist‑grade sanctions - Reuters",
     "author": "Elias Navarro",
     "date": "2026-04-29",
     "category": "world",
@@ -1271,7 +1271,7 @@
   {
     "id": "2026-04-29-top-transfer-qb-brendan-sorsby-taking-leave-of-absence-from-texas-tech-for-gambling-the-athletic",
     "title": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic",
-    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic \u2014 key confirmed developments and what they mean for sports.",
+    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic — key confirmed developments and what they mean for sports.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -1308,8 +1308,8 @@
   },
   {
     "id": "2026-04-29-over-half-of-south-sudan-s-population-faces-acute-hunger-crisis-un-news",
-    "title": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
-    "summary": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
+    "title": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
+    "summary": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -1361,7 +1361,7 @@
   {
     "id": "2026-04-28-southern-china-torrential-rain-flooding-fears",
     "title": "Southern China Braces for Flood Risk as Torrential Rainfall Intensifies",
-    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150\u2013200mm.",
+    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150–200mm.",
     "author": "Rowan Hale",
     "author_id": "environment_lead",
     "author_display_name": "Rowan Hale",
@@ -1395,7 +1395,7 @@
   },
   {
     "id": "2026-04-28-opinion-russia-internet-blackouts-legitimacy-cost",
-    "title": "Opinion: Russia\u2019s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
+    "title": "Opinion: Russia’s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
     "summary": "An opinion-editorial arguing that broad wartime internet shutdowns can erode state legitimacy faster than they secure it.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -1471,7 +1471,7 @@
   },
   {
     "id": "2026-04-28-opinion-america-immigration-edge-welcoming-talent-safeguarding-legitimacy",
-    "title": "Opinion: America\u2019s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
+    "title": "Opinion: America’s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
     "summary": "An opinion-editorial arguing that durable U.S. immigration policy must pair lawful-entry capacity with accountable enforcement.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -1542,8 +1542,8 @@
   },
   {
     "id": "2026-04-28-summer-movie-guide-2026-theatrical-and-streaming-slate",
-    "title": "Summer Movie Guide 2026: What\u2019s Coming to Theaters and Streaming From May Through August",
-    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios\u2019 peak-season strategy.",
+    "title": "Summer Movie Guide 2026: What’s Coming to Theaters and Streaming From May Through August",
+    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios’ peak-season strategy.",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
     "author_display_name": "Camille Vega",
@@ -1555,8 +1555,8 @@
   },
   {
     "id": "2026-04-28-south-korea-court-expands-convictions-around-yoon-circle",
-    "title": "South Korean Court Expands Convictions Around Ousted President Yoon\u2019s Inner Circle",
-    "summary": "South Korean courts expanded convictions across former President Yoon\u2019s inner circle, with new sentencing moves affecting both family and leadership figures.",
+    "title": "South Korean Court Expands Convictions Around Ousted President Yoon’s Inner Circle",
+    "summary": "South Korean courts expanded convictions across former President Yoon’s inner circle, with new sentencing moves affecting both family and leadership figures.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -1628,7 +1628,7 @@
   },
   {
     "id": "wellness-retreats-on-mexico-s-yucat-n-peninsula-connect-with-cultural-traditions",
-    "title": "Wellness retreats on Mexico\u2019s Yucat\u00e1n Peninsula connect with cultural traditions",
+    "title": "Wellness retreats on Mexico’s Yucatán Peninsula connect with cultural traditions",
     "author": "Nico Laurent",
     "date": "2026-04-28T12:55:43Z",
     "category": "lifestyle",
@@ -1637,7 +1637,7 @@
   },
   {
     "id": "my-tenant-owes-15000-in-rent-but-i-cant-get-them-out-of-the-property-20260428",
-    "title": "My tenant owes \u00a315,000 in rent, but I can't get them out of the property",
+    "title": "My tenant owes £15,000 in rent, but I can't get them out of the property",
     "description": "Landlords tell BBC News why they fear new laws could make it harder to remove problematic tenants.",
     "author": "Priya Desai",
     "date": "2026-04-28T05:37:45Z",
@@ -1700,7 +1700,7 @@
   {
     "id": "2026-04-24-opinion-powell-probe-fed-independence-guardrails",
     "title": "Opinion: Ending the Powell Probe Should Trigger Harder Guardrails for Fed Independence",
-    "summary": "The DOJ\u2019s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
+    "summary": "The DOJ’s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -1752,7 +1752,7 @@
   {
     "id": "2026-04-24-alcaraz-misses-french-open-title-defense-wrist-injury",
     "title": "Carlos Alcaraz to Miss French Open, Ending Bid for Third Straight Title",
-    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men\u2019s draw and reshaping the tournament outlook.",
+    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men’s draw and reshaping the tournament outlook.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -1764,7 +1764,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90b-euro-ukraine-loan-after-hungary-veto-lifted",
-    "title": "EU Approves \u20ac90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
+    "title": "EU Approves €90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
     "summary": "The EU approved a 90-billion-euro ($106B) two-year Ukraine package after a Hungary-linked standoff eased, re-opening a key wartime financing channel for Kyiv.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -1876,7 +1876,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/",
-    "summary": "Update coverage adds Reuters-reported detail that DeepSeek\u2019s latest model preview is adapted for Huawei chips, sharpening the story\u2019s infrastructure and ecosystem implications.",
+    "summary": "Update coverage adds Reuters-reported detail that DeepSeek’s latest model preview is adapted for Huawei chips, sharpening the story’s infrastructure and ecosystem implications.",
     "image": "/images/articles/update-deepseek-huawei-chip-optimized-ai-model-preview.png"
   },
   {
@@ -1889,7 +1889,7 @@
     "subject": "arts-entertainment",
     "category": "arts-entertainment",
     "permalink": "/articles/2026-04-24-update-devil-wears-prada-2-asia-backlash-milan-rollout/",
-    "summary": "New coverage links the sequel\u2019s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
+    "summary": "New coverage links the sequel’s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
     "image": "/images/articles/update-devil-wears-prada-2-asia-backlash-milan-rollout.png"
   },
   {
@@ -1928,7 +1928,7 @@
     "subject": "environment",
     "category": "environment",
     "permalink": "/articles/2026-04-24-france-drops-climate-from-g7-environment-talks/",
-    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqu\u00e9s.",
+    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqués.",
     "image": "/images/articles/france-drops-climate-from-g7-environment-talks.png"
   },
   {
@@ -1954,7 +1954,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-meta-aws-graviton-deployment-agentic-ai-workloads/",
-    "summary": "Meta\u2019s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
+    "summary": "Meta’s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
     "image": "/images/articles/meta-aws-graviton-deployment-agentic-ai-workloads.png"
   },
   {
@@ -1972,7 +1972,7 @@
   },
   {
     "id": "2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model",
-    "title": "China\u2019s DeepSeek says releases long-awaited new AI model",
+    "title": "China’s DeepSeek says releases long-awaited new AI model",
     "date": "2026-04-24",
     "author": "Adeline Park",
     "author_id": "technology_lead",
@@ -1980,7 +1980,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/",
-    "summary": "China\u2019s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China\u2019s fast-moving model race.",
+    "summary": "China’s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China’s fast-moving model race.",
     "image": "/images/news-banner.png"
   },
   {
@@ -1998,7 +1998,7 @@
   },
   {
     "id": "2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels",
-    "title": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
+    "title": "Condé Nast Traveler’s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
     "date": "2026-04-24",
     "author": "Nico Laurent",
     "author_id": "lifestyle_lead",
@@ -2006,7 +2006,7 @@
     "subject": "lifestyle",
     "category": "lifestyle",
     "permalink": "/articles/2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels/",
-    "summary": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
+    "summary": "Condé Nast Traveler’s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
     "image": "/images/articles/conde-nast-traveler-2026-hot-list-wellness-hotels.png"
   },
   {
@@ -2097,7 +2097,7 @@
     "subject": "sports",
     "category": "sports",
     "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
-    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA\u2019s platform, as broader pricing and access scrutiny intensifies.",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
     "image": "/images/news-banner.png"
   },
   {
@@ -2176,7 +2176,7 @@
     "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
-    "excerpt": "Spain\u2019s PM, Pedro S\u00e1nchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
+    "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },
   {
     "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
@@ -2219,7 +2219,7 @@
   },
   {
     "id": "2026-04-24-summer-house-season-10-reunion-no-separate-interviews",
-    "title": "Bravo\u2019s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
+    "title": "Bravo’s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
     "date": "2026-04-24",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
@@ -2258,7 +2258,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
-    "title": "EU Formally Approves \u20ac90 Billion Ukraine Loan and New Russia Sanctions",
+    "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -2266,7 +2266,7 @@
     "subject": "world",
     "category": "world",
     "permalink": "/articles/2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions/",
-    "summary": "EU institutions finalized a \u20ac90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
+    "summary": "EU institutions finalized a €90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
     "image": "/images/articles/eu-approves-90bn-ukraine-loan-russia-sanctions.png"
   },
   {
@@ -2310,7 +2310,7 @@
   },
   {
     "id": "2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama",
-    "title": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?",
+    "title": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?",
     "date": "2026-04-23",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
@@ -2318,7 +2318,7 @@
     "subject": "news-politics",
     "category": "news-politics",
     "permalink": "/articles/2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama/",
-    "summary": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?&nbsp;&nbsp;Al Jazeera",
+    "summary": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?&nbsp;&nbsp;Al Jazeera",
     "image": "/images/news-banner.png"
   },
   {
@@ -2555,7 +2555,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",
@@ -2675,6 +2675,17 @@
     "subject": "environment",
     "category": "environment",
     "permalink": "/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding/",
+    "image": "/images/news-banner.png"
+  },
+  {
+    "id": "2026-05-05-norway-fish-farm-waste-fjords-pollution-report",
+    "title": "Norway fish-farm waste report raises pressure over fjord pollution",
+    "summary": "A new analysis cited by The Guardian says waste from Norwegian salmon aquaculture is adding nutrient loads to coastal waters on a scale likened to untreated sewage, intensifying pressure on fjord ecosystems and regulation debates.",
+    "author": "Rowan Hale",
+    "date": "2026-05-05",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/2026-05-05-norway-fish-farm-waste-fjords-pollution-report/",
     "image": "/images/news-banner.png"
   }
 ]

--- a/content/articles/2026-05-05-norway-fish-farm-waste-fjords-pollution-report.md
+++ b/content/articles/2026-05-05-norway-fish-farm-waste-fjords-pollution-report.md
@@ -1,0 +1,23 @@
+---
+title: "Norway fish-farm waste report raises pressure over fjord pollution"
+date: "2026-05-05T12:38:25Z"
+author: "Rowan Hale"
+desk: "environment"
+summary: "A new analysis cited by The Guardian says waste from Norwegian salmon aquaculture is adding nutrient loads to coastal waters on a scale likened to untreated sewage, intensifying pressure on fjord ecosystems and regulation debates."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+Norway’s aquaculture sector is facing renewed scrutiny after a new analysis, cited in recent reporting, argued that waste discharges from fish farms are placing growing nutrient pressure on coastal fjord systems.
+
+The report’s framing compares aggregate nutrient loading from aquaculture waste to untreated sewage at national-population scale, sharpening debate over whether existing controls and monitoring are keeping pace with industry growth.
+
+Why it matters: Norway is one of the world’s largest salmon exporters, and any tightening of environmental requirements can ripple through permits, production costs, and supply expectations across global seafood markets.
+
+What to watch next:
+- Whether Norwegian regulators announce stricter discharge limits, monitoring, or site-density rules.
+- How producers respond on waste capture, feed efficiency, and closed or semi-closed containment systems.
+- Whether independent water-quality datasets corroborate or narrow the report’s headline comparison.
+
+Source:
+- https://www.theguardian.com/world/2026/may/04/norwegian-fish-farms-polluting-fjords-with-waste-likened-to-raw-sewage-of-millions-of-people

--- a/content/articles/2026-05-05-norway-fish-farm-waste-fjords-pollution-report.md
+++ b/content/articles/2026-05-05-norway-fish-farm-waste-fjords-pollution-report.md
@@ -5,7 +5,7 @@ author: "Rowan Hale"
 desk: "environment"
 summary: "A new analysis cited by The Guardian says waste from Norwegian salmon aquaculture is adding nutrient loads to coastal waters on a scale likened to untreated sewage, intensifying pressure on fjord ecosystems and regulation debates."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/384"
 ---
 
 Norway’s aquaculture sector is facing renewed scrutiny after a new analysis, cited in recent reporting, argued that waste discharges from fish farms are placing growing nutrient pressure on coastal fjord systems.


### PR DESCRIPTION
## Summary
Publishes one environment-desk article on reported pollution pressure from Norwegian fish-farm waste in fjords.

## OFF-RECORD: Claim matrix
- Claim: A newly published analysis/report says fish-farm waste nutrient load in Norwegian fjords is severe and comparable (in framing) to untreated sewage at very large population scale.
  - Source: https://www.theguardian.com/world/2026/may/04/norwegian-fish-farms-polluting-fjords-with-waste-likened-to-raw-sewage-of-millions-of-people
  - Confidence: Medium (single published report coverage; needs multi-source technical corroboration)
- Claim: Issue could influence regulatory and production decisions in aquaculture.
  - Source: sector context + current reporting framing
  - Confidence: Medium

## OFF-RECORD: Source discovery and bias-check log
- Desk-fit discovery path: environment-specific RSS candidates were reviewed; selected topic is directly environmental (aquaculture pollution/ecosystem impact).
- Source quality note: Primary publishable source in this run is The Guardian reporting of the cited analysis. Marked as medium confidence due to single-source dependency.
- Bias check: Avoided partisan framing; article uses attribution language ("report says", "cited in reporting").

## OFF-RECORD: Editorial rationale and safety checks
- Topic is desk-consistent: environment/ecosystem pollution and marine impacts.
- No unverifiable casualty/medical/security claims included.
- Article body excludes internal process logs and meta notes.

## Checklist
- [x] Article frontmatter includes image and published_pr_url placeholder
- [x] assets/data/articles.json updated with matching image path
- [x] Staff discussion comments posted with feedback loop