### PR TITLE
technology: Google DeepMind UK staff vote to unionize over military AI contracts

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "technology",
     "permalink": "/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/386"
   },
   {
     "id": "white-house-news-latest-updates-and-video-on-us-politics-and-government",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts",
+    "title": "Google DeepMind UK staff vote to unionize over military AI contracts",
+    "summary": "Employees at Google DeepMind in the UK have voted to unionize after concerns over the company's defense-related AI work, escalating a labor-rights flashpoint in the AI sector.",
+    "author": "Adeline Park",
+    "date": "2026-05-05",
+    "subject": "technology",
+    "category": "technology",
+    "permalink": "/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "white-house-news-latest-updates-and-video-on-us-politics-and-government",
     "title": "White House News: Latest Updates and Video on U.S. Politics and Government",
     "summary": "White House News: Latest Updates and Video on U.S. Politics and Government — key verified developments and why they matter for the news politics desk.",

--- a/content/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts.md
+++ b/content/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts.md
@@ -6,7 +6,7 @@ desk: "technology"
 summary: "Employees at Google DeepMind in the UK have voted to unionize after concerns over the company's defense-related AI work, escalating a labor-rights flashpoint in the AI sector."
 image: "/images/news-banner.png"
 source_url: "https://www.wired.com/story/google-deepmind-workers-vote-to-unionize-over-military-ai-deals/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/386"
 ---
 
 # Google DeepMind UK staff vote to unionize over military AI contracts

--- a/content/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts.md
+++ b/content/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts.md
@@ -1,0 +1,32 @@
+---
+title: "Google DeepMind UK staff vote to unionize over military AI contracts"
+date: "2026-05-05 13:42 UTC"
+author: "Adeline Park"
+desk: "technology"
+summary: "Employees at Google DeepMind in the UK have voted to unionize after concerns over the company's defense-related AI work, escalating a labor-rights flashpoint in the AI sector."
+image: "/images/news-banner.png"
+source_url: "https://www.wired.com/story/google-deepmind-workers-vote-to-unionize-over-military-ai-deals/"
+published_pr_url: ""
+---
+
+# Google DeepMind UK staff vote to unionize over military AI contracts
+
+Google DeepMind employees in the UK have voted to unionize, with organizing momentum tied to concerns about the company’s AI work linked to military and defense contracts.
+
+## What happened
+- WIRED reported that UK-based DeepMind staff backed unionization efforts tied to concerns over military AI partnerships.
+- Follow-on coverage from The Guardian and The Verge describes the vote as part of a broader worker push for greater say over high-stakes AI deployment.
+- The development revives a familiar tension in big tech: rapid commercialization of frontier AI versus employee demands for clearer ethical guardrails.
+
+## Why this matters
+The vote underscores that AI governance is no longer only a regulatory and board-level issue. Workforce pressure is becoming a practical constraint on how quickly major labs can expand sensitive defense programs.
+
+## What to watch
+- Whether Google formally recognizes and negotiates with the unionized group.
+- Whether similar organizing spreads to other AI labs working on government and defense contracts.
+- Whether the dispute changes disclosure practices around military AI use cases.
+
+## Sources
+- WIRED: https://www.wired.com/story/google-deepmind-workers-vote-to-unionize-over-military-ai-deals/
+- The Guardian: https://www.theguardian.com/technology/2026/may/05/google-deepmind-workers-in-uk-vote-to-unionize-amid-deal-with-us-military
+- The Verge: https://www.theverge.com/2026/5/5/google-deepmind-workers-unionizing-military-ai-contracts


### PR DESCRIPTION
## Summary
Publish technology desk article on DeepMind UK unionization vote and military AI contract concerns.

## Off-record editorial package
### Claim matrix
1. UK DeepMind staff voted to unionize. (WIRED, Guardian, The Verge)
2. Driver includes concern about military/defense AI engagements. (WIRED, Guardian)
3. Event reflects broader labor-governance pressure in frontier AI labs. (cross-source synthesis)

### Source discovery and bias-check log
- Primary discovery: desk-fit tech RSS (WIRED + Verge) and Google News aggregation.
- Corroboration: matched event framing across WIRED and The Guardian; Verge used as additional confirmation.
- Bias checks: avoided single-source claims beyond union vote + defense-contract concern; no casualty/safety allegations included.

### Editorial rationale and safety checks
- Desk fit: technology labor-governance and AI deployment policy.
- Harm check: no personal data, no unverifiable allegations.
- Scope check: framed as labor/AI governance development, not legal conclusion.
