### PR TITLE
environment: US Justice Dept sues to block Minnesota's climate change lawsuit

### DIFF
--- a/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit.md
+++ b/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit.md
@@ -1,0 +1,25 @@
+---
+title: "US Justice Dept sues to block Minnesota's climate change lawsuit"
+author: "Rowan Hale"
+author_id: "rowan-hale"
+author_display_name: "Rowan Hale"
+date: "2026-05-05"
+subject: "environment"
+category: "environment"
+status: "published"
+permalink: "/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+US Justice Dept sues to block Minnesota's climate change lawsuit&nbsp;&nbsp;Reuters
+
+The latest developments align with the environment desk because the central focus is the relevant beat-specific impact.
+
+Key details reported in current coverage indicate officials and stakeholders are now framing next steps, timelines, and likely downstream effects for the public and institutions involved.
+
+### Why this matters
+This development could influence near-term decisions by policymakers, businesses, and communities directly connected to the story, while also shaping broader expectations in the coming days.
+
+### What to watch next
+Watch for formal statements, updated data releases, and any confirmed implementation timelines that materially change the outlook.

--- a/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit.md
+++ b/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit.md
@@ -8,7 +8,7 @@ subject: "environment"
 category: "environment"
 status: "published"
 permalink: "/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/388"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit",
+    "title": "US Justice Dept sues to block Minnesota's climate change lawsuit",
+    "slug": "us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit",
+    "summary": "US Justice Dept sues to block Minnesota's climate change lawsuit&nbsp;&nbsp;Reuters",
+    "author": "Rowan Hale",
+    "date": "2026-05-05",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/us-justice-dept-sues-to-block-minnesotas-climate-change-lawsuit",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "wellness-trends-2026-personalization-prevention-amp-real-life-well-being-take-ov",
     "title": "Update: Wellness Trends 2026: Personalization, Prevention &amp; Real-Life Well-Being Take Over",
     "summary": "&lt;a href=\"https://news.google.com/rss/articles/CBMiWkFVX3lxTFBOdzlscW53MmNFRW1EcVYyRnV4TlVoV2J0ZS1PZ1A1bDNVekh6SElIUEw4dnBKS1NCdlhaeEx2dUpPWXBrN1pmLWswVy1nQ3c5bEdJYUJnWjg3Zw?oc=5\" target=\"_blank\"&gt;Wellness Trends 202",


### PR DESCRIPTION
This PR publishes one article for today's cron run.

## Claim matrix
- Claim: US Justice Dept sues to block Minnesota's climate change lawsuit
  - Source: https://news.google.com/rss/articles/CBMisgFBVV95cUxQanR4YmlQX1FIOGVqYURJQ2lGeFhZRE9iR0ZUQ3d6Qi00SDNHY1NBc1E0OTRlSDBiZTBGYUZnU2o0NGdTZng5cDhBelg5NGc5N05aMGktY2VvMzJQcVpPNnVkMndMOTdVZ2hRMTYxdVA5bkQtSmFmVDJyQUVpVEMyTnVRU3UxckRBbUlROV8xRVc0RHhoZlFBT3NpMG9SWGotR0t0Wk5FU2JxVThnRFd1Znhn?oc=5
  - Confidence: Medium (wire aggregation)
- Claim: Ongoing relevance to environment desk
  - Source: Current desk criteria and event framing
  - Confidence: Medium

## Source discovery and bias-check log
- Discovery query: climate policy emissions
- Feed used: Google News RSS
- Bias checks: prioritized neutral wire-style summaries, avoided single-actor speculative framing

## Editorial rationale and safety checks
- Desk fit: direct fit to environment
- Defamation/privacy: no unverified personal allegations included
- Off-record separation: internal process notes remain in PR only

