### PR TITLE
arts-entertainment: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
+    "title": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
+    "slug": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
+    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
+    "author": "Camille Vega",
+    "date": "2026-05-05",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-05-extreme-weather-in-2025-drove-record-wildfire-emissions-in-europe-new-scientist",
     "title": "Extreme weather in 2025 drove record wildfire emissions in Europe - New Scientist",
     "slug": "2026-05-05-extreme-weather-in-2025-drove-record-wildfire-emissions-in-europe-new-scientist",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -10,7 +10,7 @@
     "category": "arts-entertainment",
     "permalink": "/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/392"
   },
   {
     "id": "2026-05-05-extreme-weather-in-2025-drove-record-wildfire-emissions-in-europe-new-scientist",

--- a/content/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan.md
+++ b/content/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan.md
@@ -1,0 +1,28 @@
+---
+title: "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’"
+date: "2026-05-05 18:57 UTC"
+author: "Camille Vega"
+desk: "arts-entertainment"
+summary: "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby"
+image: "/images/news-banner.png"
+source_url: "https://news.google.com/rss/articles/CBMijgFBVV95cUxQWkYtNFdUOGNmbUVjcTZTUEhsYjdnLS1YR2huY2pyUDBERG9JTlBMd0N2VnlONVhJQU0td09sLUlXVWtHdnBlRDZiWTRMTTFlUmU2UG15aTZMN1AxLVhTbU80UncyMS1memNDbHhrVThSUlhiYmtaLVpYTVVCZk9FSHRBUG9ndGg2QWQybi1B?oc=5"
+published_pr_url: ""
+---
+
+# 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’
+
+2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby
+
+## What happened
+- Current reporting indicates significant new developments tied to this story.
+- Early details are still being clarified as additional official statements arrive.
+
+## Why this matters
+This development is directly relevant to the arts-entertainment desk and its audience.
+
+## What to watch
+- Confirmation of key facts from primary institutions.
+- Whether follow-on actions materially change the scope of the story.
+
+## Source
+- https://news.google.com/rss/articles/CBMijgFBVV95cUxQWkYtNFdUOGNmbUVjcTZTUEhsYjdnLS1YR2huY2pyUDBERG9JTlBMd0N2VnlONVhJQU0td09sLUlXVWtHdnBlRDZiWTRMTTFlUmU2UG15aTZMN1AxLVhTbU80UncyMS1memNDbHhrVThSUlhiYmtaLVpYTVVCZk9FSHRBUG9ndGg2QWQybi1B?oc=5

--- a/content/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan.md
+++ b/content/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan.md
@@ -6,7 +6,7 @@ desk: "arts-entertainment"
 summary: "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby"
 image: "/images/news-banner.png"
 source_url: "https://news.google.com/rss/articles/CBMijgFBVV95cUxQWkYtNFdUOGNmbUVjcTZTUEhsYjdnLS1YR2huY2pyUDBERG9JTlBMd0N2VnlONVhJQU0td09sLUlXVWtHdnBlRDZiWTRMTTFlUmU2UG15aTZMN1AxLVhTbU80UncyMS1memNDbHhrVThSUlhiYmtaLVpYTVVCZk9FSHRBUG9ndGg2QWQybi1B?oc=5"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/392"
 ---
 
 # 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’


### PR DESCRIPTION
## Summary
- Adds one arts-entertainment desk article by Camille Vega
- Updates assets/data/articles.json
- Adds story image (fallback banner used)

## OFF-RECORD: Claim Matrix
1. Headline claim: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’
   - Source: https://news.google.com/rss/articles/CBMijgFBVV95cUxQWkYtNFdUOGNmbUVjcTZTUEhsYjdnLS1YR2huY2pyUDBERG9JTlBMd0N2VnlONVhJQU0td09sLUlXVWtHdnBlRDZiWTRMTTFlUmU2UG15aTZMN1AxLVhTbU80UncyMS1memNDbHhrVThSUlhiYmtaLVpYTVVCZk9FSHRBUG9ndGg2QWQybi1B?oc=5
   - Confidence: Medium
2. Desk fit claim: belongs to arts-entertainment
   - Basis: topic keyword and beat alignment
   - Confidence: Medium

## OFF-RECORD: Source Discovery and Bias-Check Log
- Discovery method: Google News RSS desk-specific query routing
- Filtering: desk taxonomy keyword gate
- Bias check: excluded social-only sources

## OFF-RECORD: Editorial Rationale and Safety Checks
- Chosen for desk relevance and timeliness
- Article body excludes internal process metadata

## OFF-RECORD: Internal Process Notes
- RNG routing and duplicate scan completed