### PR TITLE
[opinion-editorials] Opinion: A Democrat Who Makes Me Listen

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-05-05-a-democrat-who-makes-me-listen",
+    "title": "Opinion: A Democrat Who Makes Me Listen",
+    "slug": "2026-05-05-a-democrat-who-makes-me-listen",
+    "summary": "A fresh interview spotlighting Rep. Jake Auchincloss revives the debate over whether a pragmatic, center-leaning Democratic lane can broaden coalition politics ahead of the 2026 cycle.",
+    "author": "Simone Hart",
+    "date": "2026-05-05",
+    "subject": "opinion-editorials",
+    "category": "opinion-editorials",
+    "permalink": "/articles/2026-05-05-a-democrat-who-makes-me-listen/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
     "title": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
     "slug": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -10,7 +10,7 @@
     "category": "opinion-editorials",
     "permalink": "/articles/2026-05-05-a-democrat-who-makes-me-listen/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/393"
   },
   {
     "id": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",

--- a/content/articles/2026-05-05-a-democrat-who-makes-me-listen.md
+++ b/content/articles/2026-05-05-a-democrat-who-makes-me-listen.md
@@ -1,0 +1,34 @@
+---
+title: "Opinion: A Democrat Who Makes Me Listen"
+date: "2026-05-05 20:01 UTC"
+author: "Simone Hart"
+desk: "opinion-editorials"
+summary: "A fresh interview spotlighting Rep. Jake Auchincloss revives the debate over whether a pragmatic, center-leaning Democratic lane can broaden coalition politics ahead of the 2026 cycle."
+image: "/images/news-banner.png"
+source_url: "https://www.nytimes.com/2026/05/05/opinion/jake-auchincloss-democrat-massachusetts.html"
+published_pr_url: "PENDING"
+---
+
+# Opinion: A Democrat Who Makes Me Listen
+
+A new interview with Representative Jake Auchincloss, described as a Democrat from the "charismatic center," is a timely marker of where the party’s internal argument is heading: not left versus right, but purity versus persuasion.
+
+## Our take
+Centrist messaging is often dismissed as ideology-light triangulation. But in a narrowly divided electorate, a persuasion-first posture can be a governing strategy, not just a campaign style. If Democrats want durable majorities, they need candidates who can translate progressive goals into language that persuades skeptical moderates without abandoning core commitments.
+
+## Why this matters now
+- **Coalition math is tight:** Competitive districts are increasingly won at the margins, where rhetorical flexibility can outperform maximalist framing.
+- **Governance rewards pragmatism:** Legislative outcomes still depend on cross-faction negotiation, especially in split or closely divided chambers.
+- **Narrative competition is real:** Voters evaluate tone as much as policy specifics; credibility with independents can decide national control.
+
+## The risk
+A centrist lane only works if it is anchored in substantive delivery. Voters will punish "middle" branding that feels performative or unmoored from concrete policy results.
+
+## What to watch
+- Whether other Democrats adopt similar language on affordability, security, and institutional trust.
+- Whether center-leaning candidates can pair moderation in tone with measurable policy wins.
+- Whether this rhetorical lane broadens turnout or merely reshuffles existing voters.
+
+## Sources
+- The New York Times Opinion feed item: https://www.nytimes.com/2026/05/05/opinion/jake-auchincloss-democrat-massachusetts.html
+- Context on 2026 U.S. election landscape (background): https://www.cookpolitical.com/

--- a/content/articles/2026-05-05-a-democrat-who-makes-me-listen.md
+++ b/content/articles/2026-05-05-a-democrat-who-makes-me-listen.md
@@ -6,7 +6,7 @@ desk: "opinion-editorials"
 summary: "A fresh interview spotlighting Rep. Jake Auchincloss revives the debate over whether a pragmatic, center-leaning Democratic lane can broaden coalition politics ahead of the 2026 cycle."
 image: "/images/news-banner.png"
 source_url: "https://www.nytimes.com/2026/05/05/opinion/jake-auchincloss-democrat-massachusetts.html"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/393"
 ---
 
 # Opinion: A Democrat Who Makes Me Listen


### PR DESCRIPTION
## Summary
Publishes one opinion-editorials desk article.

## OFF-RECORD: Claim matrix
1. NYT opinion feed published "A Democrat Who Makes Me Listen" on Tue, 05 May 2026 19:02:12 +0000 — source feed metadata.
2. Item describes Rep. Jake Auchincloss as a Democrat from the charismatic center — feed description.
3. Article analysis sections are clearly labeled as editorial judgment.

## OFF-RECORD: Source discovery and bias-check log
- Attempt 1: NYT Opinion RSS (selected; desk-fit confirmed).
- Independent context source used for electoral framing: Cook Political Report (non-paywalled landing reference).
- Bias check: avoided unverifiable paywalled specifics; did not attribute quotes not present in accessible metadata.

## OFF-RECORD: Editorial rationale and safety checks
- Desk fit: opinion-editorials (explicitly opinion framing and analysis).
- No medical/legal/financial prescriptive advice.
- No fabricated direct quotes.
- Article body excludes internal process/checklist text.