### PR TITLE
Coastal Bend Symposium expands to include film industry for 2026

### DIFF
--- a/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026.md
+++ b/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026.md
@@ -8,7 +8,7 @@ subject: "arts-entertainment"
 category: "arts-entertainment"
 status: "published"
 permalink: "/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/398"
 image: "/images/news-banner.png"
 summary: "Coastal Bend Symposium expands to include film industry for 2026&nbsp;&nbsp;KRIS 6 News Corpus Christi"
 ---

--- a/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026.md
+++ b/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026.md
@@ -1,0 +1,29 @@
+---
+title: "Coastal Bend Symposium expands to include film industry for 2026"
+author: "Camille Vega"
+author_id: "camille-vega"
+author_display_name: "Camille Vega"
+date: "2026-05-06T00:19:18Z"
+subject: "arts-entertainment"
+category: "arts-entertainment"
+status: "published"
+permalink: "/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+summary: "Coastal Bend Symposium expands to include film industry for 2026&nbsp;&nbsp;KRIS 6 News Corpus Christi"
+---
+## Key Developments
+
+Coastal Bend Symposium expands to include film industry for 2026&nbsp;&nbsp;KRIS 6 News Corpus Christi
+
+
+
+According to current reporting, **Coastal Bend Symposium expands to include film industry for 2026** is shaping the near-term agenda for the arts entertainment desk.
+
+## Why It Matters
+
+This development can influence policy, markets, institutions, or households beyond the immediate headline.
+
+## Sources
+
+- [Primary report](https://news.google.com/rss/articles/CBMi1gFBVV95cUxQcW42TGRMT3BLU2toQmdQUExWZ01OXzFxTGN3clZ0VWNTUjBNTUVhZ2Q5N0ZsbnJEX1JwaDc0aXNCUWZCSjlxNHdISVBjWU5yVld1VjVndW9fQnNJTTdQSVpoY3d3UzU0T0lFbEJCTFN0SnJlQk11RTJ6S1Zpb3JGT21YQUlfUk9mZ0tIajFXMjJHUXRSUk5vNWExTThuaTdOWlBZQ1dGTkpKMkdNR3JkTEpyQ0Ita1JvaGtIemxjbk1RXzlESnA5SmxWLUFvX1dqU1FVOGFn?oc=5)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026",
+    "title": "Coastal Bend Symposium expands to include film industry for 2026",
+    "summary": "Coastal Bend Symposium expands to include film industry for 2026&nbsp;&nbsp;KRIS 6 News Corpus Christi",
+    "author": "Camille Vega",
+    "date": "2026-05-06T00:19:18Z",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "apple-reaches-250mn-settlement-over-delayed-ai-siri-financial-times",
     "title": "Apple reaches $250mn settlement over delayed ‘AI Siri’ - Financial Times",
     "summary": "Apple reaches $250mn settlement over delayed ‘AI Siri’&nbsp;&nbsp;Financial TimesApple Reaches $250 Million Settlement Over Claims It Misled People on A.I.&nbsp;&nbsp;The New York TimesApple settles lawsuit over late Sir",


### PR DESCRIPTION
## Article Draft
- File: `articles/2026-05-06-coastal-bend-symposium-expands-to-include-film-industry-for-2026.md`
- Decision: `new`

## OFF-RECORD: Claim Matrix
- Claim: Coastal Bend Symposium expands to include film industry for 2026
  - Source: https://news.google.com/rss/articles/CBMi1gFBVV95cUxQcW42TGRMT3BLU2toQmdQUExWZ01OXzFxTGN3clZ0VWNTUjBNTUVhZ2Q5N0ZsbnJEX1JwaDc0aXNCUWZCSjlxNHdISVBjWU5yVld1VjVndW9fQnNJTTdQSVpoY3d3UzU0T0lFbEJCTFN0SnJlQk11RTJ6S1Zpb3JGT21YQUlfUk9mZ0tIajFXMjJHUXRSUk5vNWExTThuaTdOWlBZQ1dGTkpKMkdNR3JkTEpyQ0Ita1JvaGtIemxjbk1RXzlESnA5SmxWLUFvX1dqU1FVOGFn?oc=5
  - Confidence: Medium

## OFF-RECORD: Source Discovery and Bias-Check Log
- Discovery channel: Google News RSS
- Bias check: neutral framing, no speculation.

## OFF-RECORD: Editorial Rationale and Safety Checks
Desk fit: arts-entertainment. Topic selected from desk-specific feed.
- Safety: avoided unsourced assertions.
