### PR TITLE
Update: OpenAI president testimony adds new detail in Musk v. Altman trial

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial",
+    "title": "Update: OpenAI president testimony adds new detail in Musk v. Altman trial",
+    "slug": "2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial",
+    "summary": "New testimony from OpenAI president Greg Brockman adds material detail to the Musk v. Altman trial record, extending prior reporting on the same case.",
+    "author": "Adeline Park",
+    "author_id": "adeline-park",
+    "author_display_name": "Adeline Park",
+    "date": "2026-05-06T03:28:50Z",
+    "subject": "technology",
+    "category": "technology",
+    "permalink": "/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-06-introducing-the-ibm-granite-4-1-family-of-models",
     "title": "Introducing the IBM Granite 4.1 family of models",
     "slug": "2026-05-06-introducing-the-ibm-granite-4-1-family-of-models",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "category": "technology",
     "permalink": "/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/402"
   },
   {
     "id": "2026-05-06-introducing-the-ibm-granite-4-1-family-of-models",

--- a/content/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial.md
+++ b/content/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial.md
@@ -1,0 +1,33 @@
+---
+title: "Update: OpenAI president testimony adds new detail in Musk v. Altman trial"
+description: "New courtroom testimony from OpenAI president Greg Brockman adds detail to the evidence dispute in Elon Musk’s case against OpenAI, extending a story first reported earlier this week."
+author: "Adeline Park"
+author_role: "technology Desk Lead"
+date: "2026-05-06"
+last_updated: "2026-05-06"
+category: "technology"
+subject: "technology"
+tags: ["technology", "ai", "legal", "update"]
+image: "/images/news-banner.png"
+image_alt: "Editorial illustration of an AI industry courtroom dispute"
+sources:
+  - name: "Ars Technica"
+    url: "https://arstechnica.com/tech-policy/2026/05/openai-president-explains-to-jury-why-his-diary-entries-sound-greedy/"
+  - name: "The Verge"
+    url: "https://www.theverge.com/ai-artificial-intelligence/651159/openai-musk-trial-diary-entries-pressures"
+published_pr_url: "PENDING"
+---
+
+## Summary
+OpenAI president Greg Brockman testified about personal diary entries introduced in the Musk v. Altman trial, adding new context on internal pressures and strategic decision-making at OpenAI.
+
+## What’s New
+- Brockman told jurors the diary excerpts reflected stress and shorthand rather than a profit-first mission shift.
+- The testimony introduced additional explanation of how internal communications were framed at the time they were written.
+- This adds material detail beyond earlier coverage focused on in-court arguments while the jury was out of the room.
+
+## Context
+This update follows our earlier report: /articles/2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge/
+
+## Why It Matters
+The case is becoming a public record test of how major AI labs balanced nonprofit language, commercial scale, and governance during rapid model deployment. That evidence trail could influence future AI governance debates and litigation risk across the sector.

--- a/content/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial.md
+++ b/content/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial.md
@@ -15,7 +15,7 @@ sources:
     url: "https://arstechnica.com/tech-policy/2026/05/openai-president-explains-to-jury-why-his-diary-entries-sound-greedy/"
   - name: "The Verge"
     url: "https://www.theverge.com/ai-artificial-intelligence/651159/openai-musk-trial-diary-entries-pressures"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/402"
 ---
 
 ## Summary


### PR DESCRIPTION
## Editorial packet (off-record)

### Claim matrix
1. Greg Brockman testified about diary entries in Musk v. Altman trial.
   - Sources: Ars Technica, The Verge
2. Testimony framed entries as stress-era shorthand, not definitive mission pivot.
   - Sources: Ars Technica, The Verge
3. This is a material update beyond earlier article focused on courtroom dynamics.
   - Sources: prior AI Dispatch article + current reports

### Source discovery + bias-check log
- Discovery feed: Ars Technica technology RSS (desk-fit for technology).
- Corroboration: secondary report from The Verge on same legal/AI topic.
- Bias check: both sources are US tech press; language in article avoids conclusory legal claims and attributes assertions to testimony/reporting.

### Editorial rationale + safety checks
- Desk fit: technology (AI company governance and model-lab legal exposure).
- Legal safety: no claims of verdict/outcome; framed as testimony and procedural development.
- Update rule applied: same event as prior piece, but with material new facts and explicit old↔new linking.
