### PR TITLE
EU trade deal could force UK to curb glyphosate use, raising compliance pressure on farmers

### DIFF
--- a/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use.md
+++ b/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use.md
@@ -1,0 +1,32 @@
+---
+title: "EU trade deal could force UK to curb glyphosate use, raising compliance pressure on farmers"
+author: "Rowan Hale"
+author_id: "rowan-hale"
+author_display_name: "Rowan Hale"
+date: "2026-05-06T08:45:03Z"
+subject: "environment"
+category: "environment"
+status: "published"
+permalink: "/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use/"
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+A developing UK-EU trade alignment is likely to increase pressure on UK regulators to narrow or phase down some glyphosate uses, according to current reporting on policy discussions and standards harmonization.
+
+The debate sits at the intersection of farm productivity, food-price sensitivity, and environmental risk management. Glyphosate remains one of the most widely used herbicides in modern agriculture, but critics have long argued that precautionary restrictions should move faster where ecological and potential health concerns remain contested.
+
+If alignment terms harden into enforceable import or production rules, UK growers and supply-chain operators may face tighter recordkeeping, alternative weed-management requirements, and near-term transition costs. The practical impact will depend on final rule language, transition periods, and enforcement design.
+
+### Why this matters
+For the environment desk, this is a core policy-and-ecosystem story: pesticide standards affect soil systems, biodiversity outcomes, runoff risk, and the pace of lower-impact farming transitions.
+
+### What to watch next
+- Whether UK and EU negotiators publish a concrete compliance timetable.
+- Whether exemptions are offered for specific crops or regional conditions.
+- How retailers and importers update procurement standards ahead of any legal deadline.
+
+**Sources**
+- The Guardian: https://www.theguardian.com/environment/2026/may/06/eu-trade-deal-could-force-uk-restrict-glyphosate-weedkiller-linked-to-cancer
+- European Commission (pesticide and food-safety framework): https://food.ec.europa.eu/plants/pesticides_en
+- WHO IARC monographs overview: https://monographs.iarc.who.int/list-of-classifications

--- a/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use.md
+++ b/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use.md
@@ -9,7 +9,7 @@ category: "environment"
 status: "published"
 permalink: "/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use/"
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/407"
 ---
 
 A developing UK-EU trade alignment is likely to increase pressure on UK regulators to narrow or phase down some glyphosate uses, according to current reporting on policy discussions and standards harmonization.

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -12,7 +12,7 @@
     "category": "environment",
     "permalink": "/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/407"
   },
   {
     "id": "2026-05-06-us-to-test-new-ai-models-before-public-release-under-industry-agreement",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use",
+    "title": "EU trade deal could force UK to curb glyphosate use, raising compliance pressure on farmers",
+    "slug": "2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use",
+    "summary": "A proposed UK-EU trade alignment could tighten limits on glyphosate, setting up new compliance and cost questions for farmers while reigniting debates over environmental and health risk thresholds.",
+    "author": "Rowan Hale",
+    "author_id": "rowan-hale",
+    "author_display_name": "Rowan Hale",
+    "date": "2026-05-06T08:45:03Z",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/2026-05-06-eu-trade-deal-could-force-uk-to-restrict-glyphosate-use/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-06-us-to-test-new-ai-models-before-public-release-under-industry-agreement",
     "title": "U.S. to test new AI models before public release under industry agreement",
     "slug": "2026-05-06-us-to-test-new-ai-models-before-public-release-under-industry-agreement",


### PR DESCRIPTION
## Summary
- Publishes one environment-desk story on UK-EU glyphosate policy pressure.
- Adds article markdown + catalog entry + story image path.

## Claim matrix (off-record)
1. UK-EU trade alignment could tighten glyphosate constraints.  
   - Evidence: Guardian reporting + EU pesticide policy framework.  
   - Confidence: Medium.
2. Compliance burden likely shifts to growers/supply chains if rules harden.  
   - Evidence: regulatory design precedent + published policy frameworks.  
   - Confidence: Medium.
3. Environmental relevance includes biodiversity/runoff/soil management impacts.  
   - Evidence: desk rationale + pesticide governance context.  
   - Confidence: High.

## Source discovery and bias-check log (off-record)
- Discovery channels: BBC environment RSS, Guardian environment RSS, Google News RSS backup.
- Rejected candidates: non-environment desk drift; stale stories; inaccessible links.
- Bias check: balanced policy framing (farm economics + environmental risk), avoided definitive health-causality overclaims.

## Editorial rationale and safety checks (off-record)
- Desk fit: strict environment-policy alignment.
- No private or unverifiable claims.
- No medical/legal advice.
- Article excludes internal process notes by design.

## Internal process notes (off-record)
- RNG desk assignment followed prompt mapping.
- Image path set in both frontmatter and `assets/data/articles.json`.