### PR TITLE
[arts-entertainment] Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
+    "title": "Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award",
+    "slug": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
+    "summary": "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d’Onore award, signaling a high-profile addition to this year’s festival lineup.",
+    "author": "Camille Vega",
+    "date": "2026-05-06T11:56:26Z",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "title": "Labour’s nationwide collapse risks making Nigel Farage the face of the UK’s fragile union",
     "date": "2026-05-06",
     "author": "Simone Hart",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -10,7 +10,7 @@
     "category": "arts-entertainment",
     "permalink": "/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/411"
   },
   {
     "title": "Labour’s nationwide collapse risks making Nigel Farage the face of the UK’s fragile union",

--- a/content/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award.md
+++ b/content/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award.md
@@ -1,0 +1,32 @@
+---
+title: "Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award"
+date: 2026-05-06
+desk: arts-entertainment
+author: "Camille Vega"
+summary: "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d’Onore award, signaling a high-profile addition to this year’s festival lineup."
+image: "/images/news-banner.png"
+tags:
+  - arts-entertainment
+source_url: "https://www.screendaily.com/news/darren-aronofsky-to-receive-locarno-film-festivals-pardo-donore-award/5204427.article"
+published_pr_url: ""
+---
+
+Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award
+
+Locarno Film Festival organizers announced that director Darren Aronofsky will receive the festival’s Pardo d’Onore (Honorary Leopard), a career-recognition award presented to influential filmmakers.
+
+Why it matters: The honor positions Aronofsky as one of the marquee names in this year’s Locarno program and can shape industry attention around premieres, retrospectives, and acquisition conversations tied to the festival circuit.
+
+What we know:
+
+- Trade reporting says Locarno selected Aronofsky for a top honorary distinction associated with the festival’s international profile.
+- Locarno’s official channels have published 2026 festival updates and programming announcements, indicating active rollout of this year’s slate.
+
+What to watch next:
+
+- The festival’s detailed schedule, including any retrospective or masterclass tied to the award.
+- Additional jury, competition, and premiere announcements that clarify the full 2026 lineup.
+
+Sources:
+- Screen Daily: https://www.screendaily.com/news/darren-aronofsky-to-receive-locarno-film-festivals-pardo-donore-award/5204427.article
+- Locarno Film Festival: https://www.locarnofestival.ch/

--- a/content/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award.md
+++ b/content/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award.md
@@ -8,7 +8,7 @@ image: "/images/news-banner.png"
 tags:
   - arts-entertainment
 source_url: "https://www.screendaily.com/news/darren-aronofsky-to-receive-locarno-film-festivals-pardo-donore-award/5204427.article"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/411"
 ---
 
 Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award


### PR DESCRIPTION
## Summary
- Add one arts-entertainment story on Locarno honoring Darren Aronofsky
- Update article index metadata

## Off-record editorial packet
### Claim matrix
1) Locarno selected Darren Aronofsky for Pardo d’Onore award — supported by trade report and festival channel context.
2) This award elevates festival visibility and industry attention — analysis statement, not factual overclaim.

### Source discovery + bias check
- Primary discovery: Google News RSS arts query.
- Source used: Screen Daily trade report.
- Corroboration context: Locarno official site for ongoing festival communications.
- Bias note: trade outlet may emphasize industry framing; article language kept cautious and attributed.

### Editorial rationale and safety checks
- Desk fit confirmed: film festival honors and programming are arts-entertainment.
- No sensitive personal data.
- No legal/medical/financial advice.
- Article excludes internal process notes.
