### PR TITLE
Arts desk: Zee v Nykaa copyright-reels suit (Reuters)

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -10,7 +10,7 @@
     "category": "arts-entertainment",
     "permalink": "/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/418"
   },
   {
     "title": "Was It Art? Was It Fashion? Was It Good?",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels",
+    "title": "India's Zee sues Nykaa over alleged copyright misuse of songs on Instagram reels",
+    "slug": "2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels",
+    "summary": "Indian broadcaster Zee Entertainment has sued beauty and lifestyle platform Nykaa over alleged unauthorized use of songs in Instagram reels, according to a Reuters report.",
+    "author": "Camille Vega",
+    "date": "2026-05-06T18:16:19Z",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "title": "Was It Art? Was It Fashion? Was It Good?",
     "date": "2026-05-06",
     "author": "Nico Laurent",

--- a/content/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels.md
+++ b/content/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels.md
@@ -10,7 +10,7 @@ tags:
   - media
   - copyright
 source_url: "https://news.google.com/rss/articles/CBMitgFBVV95cUxPUnFoSzl1VGhLVXV0UUJTZHlaVW01Y3ZUSFdTNjFyTXRzMXBVbV9Cd1BzLTl3ZFBXSzVLRnE2QU9QTkc1UmJjbzNKYlZfNkk0ejJIS1FUeW4tajlUYTc0bEhJUHRFbi05WHd0SFJXam9rZEJlaDdnUGE0Z18xTlRjLVNvVTJBMXlOTER2d2hid2duY0tRUDZ0YUFzS1ZCSUJ3dEtxR1BXcXFXYzdNaUlQXzVSVjFiUQ?oc=5"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/418"
 ---
 
 India's Zee sues Nykaa over alleged copyright misuse of songs on Instagram reels

--- a/content/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels.md
+++ b/content/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels.md
@@ -1,0 +1,35 @@
+---
+title: "India's Zee sues Nykaa over alleged copyright misuse of songs on Instagram reels"
+date: 2026-05-06
+desk: arts-entertainment
+author: "Camille Vega"
+summary: "Indian broadcaster Zee Entertainment has sued beauty and lifestyle platform Nykaa over alleged unauthorized use of songs in Instagram reels, according to a Reuters report."
+image: "/images/news-banner.png"
+tags:
+  - arts-entertainment
+  - media
+  - copyright
+source_url: "https://news.google.com/rss/articles/CBMitgFBVV95cUxPUnFoSzl1VGhLVXV0UUJTZHlaVW01Y3ZUSFdTNjFyTXRzMXBVbV9Cd1BzLTl3ZFBXSzVLRnE2QU9QTkc1UmJjbzNKYlZfNkk0ejJIS1FUeW4tajlUYTc0bEhJUHRFbi05WHd0SFJXam9rZEJlaDdnUGE0Z18xTlRjLVNvVTJBMXlOTER2d2hid2duY0tRUDZ0YUFzS1ZCSUJ3dEtxR1BXcXFXYzdNaUlQXzVSVjFiUQ?oc=5"
+published_pr_url: ""
+---
+
+India's Zee sues Nykaa over alleged copyright misuse of songs on Instagram reels
+
+Indian media company Zee Entertainment has filed a lawsuit against Nykaa, alleging the platform used copyrighted songs in Instagram reels without authorization, according to Reuters.
+
+Why it matters: The case highlights mounting legal pressure around short-form social video music usage, where licensing obligations can be unclear across brands, creators, and platforms.
+
+What we know:
+
+- Reuters reports Zee alleges copyright misuse tied to songs appearing in Nykaa Instagram reels.
+- The dispute centers on commercial use of music assets and whether the relevant rights were properly licensed.
+- Copyright conflicts in social video increasingly affect entertainment companies monetizing catalog music.
+
+What to watch:
+
+- Court filings and any interim orders on removal, damages, or licensing terms.
+- Whether the parties move toward settlement or formal licensing arrangements.
+- Potential spillover to similar brand-led social media campaigns using commercial tracks.
+
+Source:
+- Reuters via Google News: https://news.google.com/rss/articles/CBMitgFBVV95cUxPUnFoSzl1VGhLVXV0UUJTZHlaVW01Y3ZUSFdTNjFyTXRzMXBVbV9Cd1BzLTl3ZFBXSzVLRnE2QU9QTkc1UmJjbzNKYlZfNkk0ejJIS1FUeW4tajlUYTc0bEhJUHRFbi05WHd0SFJXam9rZEJlaDdnUGE0Z18xTlRjLVNvVTJBMXlOTER2d2hid2duY0tRUDZ0YUFzS1ZCSUJ3dEtxR1BXcXFXYzdNaUlQXzVSVjFiUQ?oc=5


### PR DESCRIPTION
## Summary
Adds one arts-entertainment article on Reuters report that Zee sued Nykaa over alleged music copyright misuse in Instagram reels.

## OFF-RECORD: Claim matrix
1. **Claim:** Zee sued Nykaa over alleged unauthorized song use in Instagram reels.  
   - Source: Reuters (via Google News RSS link in article).  
   - Confidence: High (single reputable wire, legal claim attribution explicit).
2. **Claim:** Dispute concerns licensing/commercial use rights in short-form social media.  
   - Source: Framing inference from Reuters legal-dispute description.  
   - Confidence: Medium.
3. **Claim:** Case may influence brand campaign music-risk posture.  
   - Source: Editorial analysis.  
   - Confidence: Medium-low (forward-looking).

## OFF-RECORD: Source discovery + bias-check log
- Tried 3 topical discovery passes (Reuters entertainment, AP entertainment, Variety festival feed).
- Selected Reuters legal-dispute item for specificity and timeliness.
- Bias check: avoided adopting plaintiff allegations as fact; article attributes allegation to Reuters report and to Zee claim.

## OFF-RECORD: Editorial rationale and safety checks
- Desk fit: arts-entertainment because dispute concerns commercial use of songs/music rights in social media content.
- Safety: no defamation assertions beyond attributed lawsuit claim; no personal data; no medical/legal advice.
- Duplicate check: searched existing content for Zee/Nykaa/reels/copyright terms; no close duplicate found.

## OFF-RECORD: Internal process notes
- Image generation with OpenAI `gpt-image-1` attempted but OPENAI_API_KEY unavailable in runtime; used fallback `/images/news-banner.png`.
- `published_pr_url` will be backfilled post-PR creation.
