### PR TITLE
Sports: Why resolute Arsenal will believe prolific PSG can be beaten in final

### DIFF
--- a/content/articles/why-resolute-arsenal-will-believe-prolific-psg-can-be-beaten-in-final.md
+++ b/content/articles/why-resolute-arsenal-will-believe-prolific-psg-can-be-beaten-in-final.md
@@ -1,0 +1,22 @@
+---
+title: "Why resolute Arsenal will believe prolific PSG can be beaten in final"
+slug: "why-resolute-arsenal-will-believe-prolific-psg-can-be-beaten-in-final"
+date: "2026-05-06"
+author: "Jordan Reeves"
+desk: "sports"
+summary: "With Paris St-Germain waiting in the Champions League final, will Arsenal withstand the firepower of one of Europe's most formidable attacks and lift the trophy for the first time?"
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+Why resolute Arsenal will believe prolific PSG can be beaten in final
+
+With Paris St-Germain waiting in the Champions League final, will Arsenal withstand the firepower of one of Europe's most formidable attacks and lift the trophy for the first time?
+
+Arsenal's route to the final has reinforced belief that it can handle elite attacking pressure, while Paris Saint-Germain enters with one of Europe's most productive forward lines. The matchup turns on whether Arsenal can control transitions and limit high-quality chances over 90 minutes.
+
+For the sports desk, this is a high-impact pre-final storyline because it directly frames tactical expectations, fan sentiment, and coaching decisions ahead of one of club football's biggest fixtures.
+
+What to watch next: confirmed lineups, injury updates, and in-match adjustments that could shift control of the final.
+
+Source: https://www.bbc.com/sport/football/articles/ckgpxp9q8yno?at_medium=RSS&at_campaign=rss

--- a/content/articles/why-resolute-arsenal-will-believe-prolific-psg-can-be-beaten-in-final.md
+++ b/content/articles/why-resolute-arsenal-will-believe-prolific-psg-can-be-beaten-in-final.md
@@ -6,7 +6,7 @@ author: "Jordan Reeves"
 desk: "sports"
 summary: "With Paris St-Germain waiting in the Champions League final, will Arsenal withstand the firepower of one of Europe's most formidable attacks and lift the trophy for the first time?"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/423"
 ---
 
 Why resolute Arsenal will believe prolific PSG can be beaten in final


### PR DESCRIPTION
## Summary
Publishes one sports-desk article based on a current BBC Sport pre-final analysis topic.

## Off-record editorial packet
### Claim matrix
- Claim: Arsenal can beat PSG in final. Evidence: BBC Sport pre-final analysis (https://www.bbc.com/sport/football/articles/ckgpxp9q8yno?at_medium=RSS&at_campaign=rss). Confidence: Medium (pre-match analytical framing).

### Source discovery and bias-check log
- Primary source: BBC Sport RSS/article.
- Bias check: analysis framing can be subjective; avoided deterministic predictions; presented tactical contingencies.

### Editorial rationale and safety checks
- Desk fit validated as sports (Champions League final tactical preview).
- No unverifiable or fabricated statistics added.
- Article body excludes internal process metadata.

### Internal process notes
- RNG desk routing selected sports (N=8).
- Image generation failed; fallback used.
