### PR TITLE
Arts & Entertainment: Barrera questions Scream 7 box-office claims

### DIFF
--- a/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims.md
+++ b/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims.md
@@ -1,0 +1,34 @@
+---
+title: "Melissa Barrera Questions ‘Scream 7’ Box-Office Claims After Exit From Franchise"
+author: "Camille Vega"
+author_id: "camille-vega"
+author_display_name: "Camille Vega"
+date: "2026-05-07"
+subject: "arts-entertainment"
+category: "arts-entertainment"
+status: "published"
+permalink: "/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims/"
+published_pr_url: ""
+image: "/images/news-banner.png"
+---
+
+# Melissa Barrera Questions ‘Scream 7’ Box-Office Claims After Exit From Franchise
+
+Actor Melissa Barrera, who was removed from the *Scream* franchise in 2023, said in a new interview that she doubts the publicly cited commercial performance of *Scream 7*. Barrera told *Entertainment Weekly* she believes reported figures were overstated, reopening debate about transparency in franchise-era box-office narratives.
+
+## What Happened
+
+According to *Entertainment Weekly*, Barrera said she does not believe the commonly repeated success narrative around *Scream 7*, adding that she thinks "they lied about the numbers." The comments are notable because Barrera had been a central face of the reboot era before her dismissal.
+
+## Why It Matters
+
+The dispute underscores a larger entertainment-industry tension: how stars, studios, and media interpret performance when theatrical revenue, streaming economics, and marketing claims intersect. Even when official grosses are published, framing around profitability and momentum can differ sharply across stakeholders.
+
+## What to Watch Next
+
+Watch for any direct response from the studio or distribution partners, and for whether trade outlets publish additional financial context that clarifies the gap between headline grosses and franchise-level profitability claims.
+
+## Sources
+
+- [Entertainment Weekly interview report](https://ew.com/fired-scream-star-melissa-barrera-doubts-scream-7-success-they-lied-about-numbers/)
+- [Google News discovery link](https://news.google.com/rss/articles/CBMie0FVX3lxTE4yWGdKSDFscnAxQlJzQXl0NC16Z2gtdUVUR3RIYVFoa2s0UG5jRVFkQTlfMklhU2pPOUlLUnBFTlBoMUw1NkpRRmVvSlU5dy1tVmhBakNQeTE4T1AwaVhuMlNDOGlpdXhNOFg3SkxqbTl3Z1diazBRN1EtOA?oc=5)

--- a/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims.md
+++ b/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims.md
@@ -8,7 +8,7 @@ subject: "arts-entertainment"
 category: "arts-entertainment"
 status: "published"
 permalink: "/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/430"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "arts-entertainment",
     "permalink": "/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/430"
   },
   {
     "id": "2026-05-07-ai-stocks-riding-major-indices-in-the-new-tech-cycle-kalkine-media",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-07-melissa-barrera-questions-scream-7-box-office-claims",
+    "title": "Melissa Barrera Questions ‘Scream 7’ Box-Office Claims After Exit From Franchise",
+    "summary": "The actor says she doubts widely cited claims about Scream 7 performance, highlighting ongoing debate over franchise-era box-office narratives.",
+    "author": "Camille Vega",
+    "date": "2026-05-07",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-07-ai-stocks-riding-major-indices-in-the-new-tech-cycle-kalkine-media",
     "title": "AI Stocks Riding Major Indices In The New Tech Cycle - Kalkine Media",
     "summary": "AI Stocks Riding Major Indices In The New Tech Cycle - Kalkine Media",


### PR DESCRIPTION
## Summary
Publishes one arts-entertainment desk article for this cron run.

## Claim matrix (off-record)
1) Barrera told Entertainment Weekly she doubts Scream 7 success metrics and said she thinks numbers were misrepresented.  
   - Source: Entertainment Weekly report/interview link in article.
2) Barrera was previously removed from the franchise in 2023.  
   - Source: Entertainment Weekly contextual reporting.
3) The story is framed as an industry-transparency debate, not a verified fraud finding.  
   - Editorial framing, clearly labeled analysis.

## Source discovery and bias-check log
- Discovery channel: Google News entertainment RSS (last 24h).
- Candidate scan prioritized direct entertainment outlets over local aggregation.
- Chosen source was a named entertainment publication with attributed quotes.
- Bias check: avoided asserting financial wrongdoing; retained attribution language.

## Editorial rationale and safety checks
- Desk fit: arts-entertainment (film franchise dispute and media-performance narrative).
- Defamation risk mitigation: no allegation stated as fact; all disputed claims attributed.
- Article excludes internal process text and includes only publishable content.
