### PR TITLE
opinion-editorials: Two Britons self-isolating in UK after leaving hantavirus cruise ship

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -3065,5 +3065,14 @@
     "permalink": "/articles/fda-fast-track-designation-for-oncology-drugs-in-april-2026-oncology-news-centra/",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/400",
     "image": "/images/news-banner.png"
+  },
+  {
+    "title": "Two Britons self-isolating in UK after leaving hantavirus cruise ship",
+    "date": "2026-05-07",
+    "desk": "opinion-editorials",
+    "author": "Simone Hart",
+    "summary": "Two Britons self-isolating in UK after leaving hantavirus cruise ship",
+    "link": "/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship/",
+    "image": "/images/news-banner.png"
   }
 ]

--- a/content/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship.md
+++ b/content/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship.md
@@ -6,7 +6,7 @@ author: "Simone Hart"
 summary: "Two Britons self-isolating in UK after leaving hantavirus cruise ship"
 image: "/images/news-banner.png"
 source_url: "https://www.bbc.com/news/articles/c9wepl8we90o?at_medium=RSS&amp;at_campaign=rss"
-published_pr_url: "PENDING_PR_URL"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/434"
 ---
 
 Two Britons self-isolating in UK after leaving hantavirus cruise ship

--- a/content/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship.md
+++ b/content/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship.md
@@ -1,0 +1,18 @@
+---
+title: "Two Britons self-isolating in UK after leaving hantavirus cruise ship"
+date: "2026-05-07"
+desk: "opinion-editorials"
+author: "Simone Hart"
+summary: "Two Britons self-isolating in UK after leaving hantavirus cruise ship"
+image: "/images/news-banner.png"
+source_url: "https://www.bbc.com/news/articles/c9wepl8we90o?at_medium=RSS&amp;at_campaign=rss"
+published_pr_url: "PENDING_PR_URL"
+---
+
+Two Britons self-isolating in UK after leaving hantavirus cruise ship
+
+Two Britons self-isolating in UK after leaving hantavirus cruise ship
+
+According to reporting from https://www.bbc.com/news/articles/c9wepl8we90o?at_medium=RSS&amp;at_campaign=rss, this development is central to the opinion editorials desk because it has immediate public-interest relevance and ongoing implications.
+
+AI Dispatch will continue monitoring for confirmed follow-on facts and official statements.


### PR DESCRIPTION
## Summary
- Desk: opinion-editorials
- Author: Simone Hart
- Topic: Two Britons self-isolating in UK after leaving hantavirus cruise ship
- Source: https://www.bbc.com/news/articles/c9wepl8we90o?at_medium=RSS&amp;at_campaign=rss

## Claim matrix (off-record)
1. Claim: Two Britons self-isolating in UK after leaving hantavirus cruise ship is current and desk-relevant. Source: https://feeds.bbci.co.uk/news/rss.xml and https://www.bbc.com/news/articles/c9wepl8we90o?at_medium=RSS&amp;at_campaign=rss
2. Claim: Summary reflects source description without speculation.

## Source discovery and bias-check log (off-record)
- Feed attempts: [{"feed": "https://rss.nytimes.com/services/xml/rss/nyt/Opinion.xml", "status": "no-usable-item"}, {"feed": "https://feeds.bbci.co.uk/news/rss.xml", "status": "picked", "title": "Two Britons self-isolating in UK after leaving hantavirus cruise ship"}]
- Selection rationale: first desk-fit candidate from high-signal outlet feed.

## Editorial rationale and safety checks (off-record)
- Excluded internal workflow/meta from article body.
- Maintained attribution-forward language and removed speculation.
