### PR TITLE
science-health: F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times

### DIFF
--- a/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne.md
+++ b/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne.md
@@ -8,7 +8,7 @@ subject: "science-health"
 category: "science-health"
 status: "published"
 permalink: "/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/438"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne.md
+++ b/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne.md
@@ -1,0 +1,27 @@
+---
+title: "F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times"
+author: "Dr. Lena Okafor"
+author_id: "lena_okafor"
+author_display_name: "Dr. Lena Okafor"
+date: "2026-05-07"
+subject: "science-health"
+category: "science-health"
+status: "published"
+permalink: "/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe&nbsp;&nbsp;The New York Times
+
+## What happened
+F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times is now in focus on the science-health desk, based on current reporting.
+
+## Why it matters
+This development may influence near-term coverage on the science-health beat.
+
+## What to watch next
+- Direct confirmation from primary parties.
+- Additional verified details that materially change the picture.
+
+**Primary source:** [F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times](https://news.google.com/rss/articles/CBMigwFBVV95cUxQTlVFZjI5enpNUFY2S003Mmd4djctbnVWZTBLdEdsOGotcGk0WjcwU2RRNEhVWHRhSGFueDI4VWFkM094a1hVdGRubm1uVC1xeE1nbHJtMHg2cnlmdzBPV0pYT1k0azZmM2dlZlRwNWNSWjFtY2w3aGtiMkJaTGYxRlF2SQ?oc=5)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "science-health",
     "permalink": "/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/438"
   },
   {
     "title": "Synflux Wins the 2026 Trailblazer Award",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne",
+    "title": "F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times",
+    "summary": "F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe&nbsp;&nbsp;The New York Times",
+    "author": "Dr. Lena Okafor",
+    "date": "2026-05-07",
+    "subject": "science-health",
+    "category": "science-health",
+    "permalink": "/articles/2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "title": "Synflux Wins the 2026 Trailblazer Award",
     "slug": "synflux-wins-the-2026-trailblazer-award",
     "date": "2026-05-07",


### PR DESCRIPTION
## Summary
Publish one science-health desk article.

## Claim matrix (off-record)
- Claim: F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times
  - Source: https://news.google.com/rss/articles/CBMigwFBVV95cUxQTlVFZjI5enpNUFY2S003Mmd4djctbnVWZTBLdEdsOGotcGk0WjcwU2RRNEhVWHRhSGFueDI4VWFkM094a1hVdGRubm1uVC1xeE1nbHJtMHg2cnlmdzBPV0pYT1k0azZmM2dlZlRwNWNSWjFtY2w3aGtiMkJaTGYxRlF2SQ?oc=5
  - Confidence: medium

## Source discovery and bias-check log (off-record)
- Discovery: Google News RSS for science-health
- Bias check: neutral framing, explicit attribution.

## Editorial rationale and safety checks (off-record)
- Desk fit validated.
- Article body excludes internal process notes.
