### PR TITLE
Environment: Malaysia-India biodiversity and sustainability cooperation brief

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "environment",
     "permalink": "/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/441"
   },
   {
     "id": "2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation",
+    "title": "Malaysia and India Expand Biodiversity and Sustainability Cooperation",
+    "summary": "Malaysia and India announced expanded cooperation on biodiversity conservation and sustainability, signaling deeper integration of environmental priorities in bilateral policy talks.",
+    "author": "Rowan Hale",
+    "date": "2026-05-07",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne",
     "title": "F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe - The New York Times",
     "summary": "F.D.A. Blocked Publication of Research Finding Covid and Shingles Vaccines Were Safe&nbsp;&nbsp;The New York Times",

--- a/content/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation.md
+++ b/content/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation.md
@@ -5,7 +5,7 @@ desk: "environment"
 author: "Rowan Hale"
 date: "2026-05-07"
 image: "/images/news-banner.png"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/441"
 ---
 
 Malaysia and India announced expanded bilateral cooperation on biodiversity conservation and sustainability, adding environmental priorities to a broader set of cross-border economic and strategic talks.

--- a/content/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation.md
+++ b/content/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation.md
@@ -1,0 +1,27 @@
+---
+title: "Malaysia and India Expand Biodiversity and Sustainability Cooperation"
+slug: "2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation"
+desk: "environment"
+author: "Rowan Hale"
+date: "2026-05-07"
+image: "/images/news-banner.png"
+published_pr_url: "TBD"
+---
+
+Malaysia and India announced expanded bilateral cooperation on biodiversity conservation and sustainability, adding environmental priorities to a broader set of cross-border economic and strategic talks.
+
+According to *Malay Mail*’s reporting on May 7, officials framed the cooperation around biodiversity protection, sustainability goals, and coordination in adjacent sectors including rare-earths development. The environmental significance is the formal inclusion of conservation and sustainability language in an intergovernmental cooperation track.
+
+## Why this matters
+
+For the environment desk, this development highlights how biodiversity policy is increasingly being negotiated alongside industrial strategy. That creates both opportunity and risk: cross-country coordination can accelerate conservation funding and standards, but outcomes depend on implementation details, transparency, and how environmental safeguards are enforced when economic priorities compete.
+
+## What to watch next
+
+- Whether either government releases a detailed joint framework with measurable biodiversity targets.
+- Whether safeguards and monitoring rules are published for projects tied to resource extraction.
+- Whether follow-on meetings produce timelines, financing commitments, or reporting requirements.
+
+## Source
+
+- Malay Mail (syndicated via Google News): https://news.google.com/rss/articles/CBMi9wFBVV95cUxQRnBjeGUtM3Z3d25hS2otOHBvVTY3bVhRczVwNXBTeVJmUGRTNmxodDI2dXl4RGMwa3ZvUGhHOEhUVWtjVHZoS1RlbEUyQ3hiZFNTalRfVm9nRzlVN3JsUEhpX3hCb2FhZ2VYT0daRkRCclVPWnB6cjNOYzhIN3lDRXd2NDM2TDNwMG9GQmtmTWw2LVZJaVhNNFdFeFROQVYwenBvUERHMWRFNG5BYzdTd2E3Yk1ZRHRrcHdaZzNiRG5xVTlwU2tXek5ZV1N3cm9hNWtJZ0t2RDYxZEJqSUMwSnRsWU1wTGpBMlpDWFJveHhUZC1LN3o40gH8AUFVX3lxTE5iLVZpRDAtcHF6S1NPc25uQUZDUzdELV9oU3l3b2Ewb0ozMWQ3djJEWWZCWUpZbVVLUzNid2RGcFU0MDNNZzhjN3JoR3VWTHJ6aFRzZUg5aktCZ185OFZHZTEtdjdDLUFHNG1pZTVwaFVFNjdCRUdmRF95SjJVcnpqMDhuelUwTGxHY2dvV21jOG9pbXdMbGdOMUJ1SDhQZ0dLakRHOVFqLWFqclQwbU9oX2FUUndpcmVEUTlaemNiVnQwdHpabm5VT3FacmlXTURuYXo3bzhsTmx1UmVHejg3S0dpc3dTVENlRENiQ1dqS0N1SWdWWEhCWUZTcw?oc=5


### PR DESCRIPTION
## Summary
Adds one environment-desk brief on Malaysia-India cooperation on biodiversity and sustainability.

## Off-record editorial packet
### Claim matrix
1. Malaysia and India expanded bilateral cooperation language to include biodiversity conservation and sustainability.  
   - Source: Malay Mail syndication item (Google News RSS link in article)
2. The same reporting ties the environment track to broader cooperation including rare-earths industry discussion.  
   - Source: same as above.

### Source discovery and bias-check log
- Try 1 (UNEP/WHO/CarbonBrief feeds): inaccessible or malformed in runner.
- Try 2 (NASA/NOAA/UN climate feeds): inaccessible in runner.
- Try 3 (Google News RSS desk-focused queries): produced environment-fit candidates; selected the most current policy/environment item.
- Bias check: selected source is a single publication item routed through Google News syndication URL. Copy avoids unverifiable specifics and attributes claims directly to source.

### Editorial rationale and safety checks
- Desk fit: environment (biodiversity + sustainability policy content).
- Scope control: only publishable content included in article; internal process retained in PR only.
- No sensitive personal data; no medical/legal instructions; neutral explanatory framing.
