### PR TITLE
Environment: Amazon deforestation study raises rainfall-risk concerns

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-07-amazon-deforestation-rainfall-risk-study",
+    "title": "New Research Warns Amazon Deforestation Could Sharply Reduce Regional Rainfall",
+    "summary": "New reporting highlights evidence that continued Amazon deforestation can reduce regional rainfall, with researchers warning climate change may amplify the effect.",
+    "author": "Rowan Hale",
+    "date": "2026-05-07",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/2026-05-07-amazon-deforestation-rainfall-risk-study/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "environment-climate-change-fuels-wildfire-threats-across-appal-2026-05-07",
     "title": "Climate change fuels wildfire threats across Appalachia",
     "summary": "Climate change fuels wildfire threats across Appalachia",
@@ -50,13 +62,13 @@
     "date": "2026-05-07",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "A Bon App\u00e9tit report spotlights how Riviera Nayarit\u2019s Rosewood Mandarina is centering local sourcing and agave-led beverage culture in luxury travel experiences.",
+    "summary": "A Bon Appétit report spotlights how Riviera Nayarit’s Rosewood Mandarina is centering local sourcing and agave-led beverage culture in luxury travel experiences.",
     "link": "/articles/sun-sand-and-spirits-in-mexicos-riviera-nayarit/",
     "image": "/images/news-banner.png"
   },
   {
-    "title": "Why Google, Microsoft and xAI\u2019s U.S. AI deal matters",
-    "summary": "Why Google, Microsoft and xAI\u2019s U.S. AI deal matters. This is a developing technology story with details still emerging.",
+    "title": "Why Google, Microsoft and xAI’s U.S. AI deal matters",
+    "summary": "Why Google, Microsoft and xAI’s U.S. AI deal matters. This is a developing technology story with details still emerging.",
     "link": "/articles/why-google-microsoft-and-xai-s-u-s-ai-deal-matters/",
     "image": "/images/news-banner.png",
     "date": "2026-05-07",
@@ -64,7 +76,7 @@
   },
   {
     "id": "2026-05-07-melissa-barrera-questions-scream-7-box-office-claims",
-    "title": "Melissa Barrera Questions \u2018Scream 7\u2019 Box-Office Claims After Exit From Franchise",
+    "title": "Melissa Barrera Questions ‘Scream 7’ Box-Office Claims After Exit From Franchise",
     "summary": "The actor says she doubts widely cited claims about Scream 7 performance, highlighting ongoing debate over franchise-era box-office narratives.",
     "author": "Camille Vega",
     "date": "2026-05-07",
@@ -98,7 +110,7 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "TikTok Has Discovered Tae Bo, the Beloved \u201990s Workout",
+    "title": "TikTok Has Discovered Tae Bo, the Beloved ’90s Workout",
     "slug": "tiktok-has-discovered-tae-bo-the-beloved-90s-workout",
     "date": "2026-05-07",
     "author": "Nico Laurent",
@@ -109,7 +121,7 @@
   },
   {
     "id": "2026-05-07-nba-stars-playing-in-europe-instead-of-u-s-that-s-what-soccer-giants-want",
-    "title": "NBA stars playing in Europe instead of U.S.? That\u2019s what soccer giants want",
+    "title": "NBA stars playing in Europe instead of U.S.? That’s what soccer giants want",
     "permalink": "/2026-05-07/nba-stars-playing-in-europe-instead-of-u-s-that-s-what-soccer-giants-want",
     "date": "2026-05-07",
     "author_id": "sports_lead",
@@ -139,8 +151,8 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "Does This Feel Like a \u2018Catholic Moment\u2019?",
-    "summary": "Readers respond to an Opinion guest essay by Christine Emba about a possible Catholic revival. Also: A woman\u2019s face.",
+    "title": "Does This Feel Like a ‘Catholic Moment’?",
+    "summary": "Readers respond to an Opinion guest essay by Christine Emba about a possible Catholic revival. Also: A woman’s face.",
     "link": "/articles/2026-05-06-does-this-feel-like-a-catholic-moment/",
     "date": "2026-05-06",
     "author": "Simone Hart",
@@ -165,7 +177,7 @@
     "date": "2026-05-06",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "Guests at the Met Gala had different interpretations of the night\u2019s dress code.",
+    "summary": "Guests at the Met Gala had different interpretations of the night’s dress code.",
     "link": "/articles/was-it-art-was-it-fashion-was-it-good/",
     "image": "/images/news-banner.png"
   },
@@ -199,9 +211,9 @@
   },
   {
     "id": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
-    "title": "Darren Aronofsky to receive Locarno Film Festival\u2019s Pardo d\u2019Onore award",
+    "title": "Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award",
     "slug": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
-    "summary": "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d\u2019Onore award, signaling a high-profile addition to this year\u2019s festival lineup.",
+    "summary": "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d’Onore award, signaling a high-profile addition to this year’s festival lineup.",
     "author": "Camille Vega",
     "date": "2026-05-06T11:56:26Z",
     "subject": "arts-entertainment",
@@ -211,7 +223,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/411"
   },
   {
-    "title": "Labour\u2019s nationwide collapse risks making Nigel Farage the face of the UK\u2019s fragile union",
+    "title": "Labour’s nationwide collapse risks making Nigel Farage the face of the UK’s fragile union",
     "date": "2026-05-06",
     "author": "Simone Hart",
     "desk": "opinion-editorials",
@@ -312,8 +324,8 @@
   },
   {
     "id": "apple-reaches-250mn-settlement-over-delayed-ai-siri-financial-times",
-    "title": "Apple reaches $250mn settlement over delayed \u2018AI Siri\u2019 - Financial Times",
-    "summary": "Apple reaches $250mn settlement over delayed \u2018AI Siri\u2019&nbsp;&nbsp;Financial TimesApple Reaches $250 Million Settlement Over Claims It Misled People on A.I.&nbsp;&nbsp;The New York TimesApple settles lawsuit over late Sir",
+    "title": "Apple reaches $250mn settlement over delayed ‘AI Siri’ - Financial Times",
+    "summary": "Apple reaches $250mn settlement over delayed ‘AI Siri’&nbsp;&nbsp;Financial TimesApple Reaches $250 Million Settlement Over Claims It Misled People on A.I.&nbsp;&nbsp;The New York TimesApple settles lawsuit over late Sir",
     "author": "Adeline Park",
     "date": "2026-05-05T23:15:15Z",
     "subject": "technology",
@@ -326,7 +338,7 @@
     "title": "What to Expect in Markets This Week: Big Bank Earnings, December Inflation Data, Retail Sales, TSMC Earnings",
     "author": "Priya Desai",
     "desk": "business-economy",
-    "summary": "What to Expect in Markets This Week: Big Bank Earnings, December Inflation Data, Retail Sales, TSMC Earnings. Here\u2019s what happened, why it matters, and what to watch next.",
+    "summary": "What to Expect in Markets This Week: Big Bank Earnings, December Inflation Data, Retail Sales, TSMC Earnings. Here’s what happened, why it matters, and what to watch next.",
     "link": "/articles/2026-05-05-what-to-expect-in-markets-this-week-big-bank-earnings-december-inflati/",
     "image": "/images/news-banner.png",
     "date": "2026-05-05T22:11:00Z"
@@ -361,9 +373,9 @@
   },
   {
     "id": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
-    "title": "2026 Lower East Side Film Festival award winners include \u2018Public Access\u2019 and \u2018The Plan\u2019",
+    "title": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
     "slug": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
-    "summary": "2026 Lower East Side Film Festival award winners include \u2018Public Access\u2019 and \u2018The Plan\u2019&nbsp;&nbsp;Gold Derby",
+    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
     "author": "Camille Vega",
     "date": "2026-05-05",
     "subject": "arts-entertainment",
@@ -425,7 +437,7 @@
   {
     "id": "white-house-news-latest-updates-and-video-on-us-politics-and-government",
     "title": "White House News: Latest Updates and Video on U.S. Politics and Government",
-    "summary": "White House News: Latest Updates and Video on U.S. Politics and Government \u2014 key verified developments and why they matter for the news politics desk.",
+    "summary": "White House News: Latest Updates and Video on U.S. Politics and Government — key verified developments and why they matter for the news politics desk.",
     "author": "Maya Sterling",
     "date": "2026-05-05T11:31:47Z",
     "category": "news-politics",
@@ -436,8 +448,8 @@
   },
   {
     "id": "market-expert-says-potential-fed-rate-cuts-could-spark-one-of-the-biggest-explosions-in-us",
-    "title": "Market expert says potential Fed rate cuts could spark \u2018one of the biggest explosions\u2019 in US economy",
-    "summary": "Priya Desai reports on Market expert says potential Fed rate cuts could spark \u2018one of the biggest explosions\u2019 in US economy and why it matters for the business economy desk.",
+    "title": "Market expert says potential Fed rate cuts could spark ‘one of the biggest explosions’ in US economy",
+    "summary": "Priya Desai reports on Market expert says potential Fed rate cuts could spark ‘one of the biggest explosions’ in US economy and why it matters for the business economy desk.",
     "author": "Priya Desai",
     "date": "2026-05-05T09:27:05Z",
     "category": "business-economy",
@@ -459,7 +471,7 @@
   {
     "id": "towards-a-people-centered-regulatory-democracy",
     "title": "Towards a People-centered Regulatory Democracy",
-    "summary": "Towards a People-centered Regulatory Democracy \u2014 latest confirmed developments and what to watch next.",
+    "summary": "Towards a People-centered Regulatory Democracy — latest confirmed developments and what to watch next.",
     "author": "Simone Hart",
     "date": "2026-05-05",
     "subject": "opinion-editorials",
@@ -483,8 +495,8 @@
   },
   {
     "id": "2026-05-05-disabled-people-are-being-abandoned-by-the-g-o-p",
-    "title": "Opinion: Disabled Americans and the GOP\u2019s Policy Crossroads",
-    "summary": "A new New York Times opinion essay argues Republicans have moved away from an older bipartisan disability-rights posture, using George H.W. Bush\u2019s legacy as a benchmark for what policy support once looked like.",
+    "title": "Opinion: Disabled Americans and the GOP’s Policy Crossroads",
+    "summary": "A new New York Times opinion essay argues Republicans have moved away from an older bipartisan disability-rights posture, using George H.W. Bush’s legacy as a benchmark for what policy support once looked like.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -575,7 +587,7 @@
   },
   {
     "id": "2026-05-04-openai-google-and-microsoft-back-bill-to-fund-ai-literacy-in-schools",
-    "title": "OpenAI, Google, and Microsoft Back Bill to Fund \u2018AI Literacy\u2019 in Schools",
+    "title": "OpenAI, Google, and Microsoft Back Bill to Fund ‘AI Literacy’ in Schools",
     "permalink": "/articles/2026-05-04-openai-google-and-microsoft-back-bill-to-fund-ai-literacy-in-schools",
     "date": "2026-05-04",
     "author_id": "technology_lead",
@@ -598,7 +610,7 @@
     "title": "UK joining Ukraine loan scheme would be good for EU ties, Starmer says",
     "author": "Maya Sterling",
     "date": "2026-05-04",
-    "summary": "The UK is \"discussing participating\" in a \u00a378bn (\u20ac90bn) European Union loan scheme to support Ukraine, the prime minister says.",
+    "summary": "The UK is \"discussing participating\" in a £78bn (€90bn) European Union loan scheme to support Ukraine, the prime minister says.",
     "link": "/articles/2026-05-04-uk-joining-ukraine-loan-scheme-would-be-good-for-eu-ties-starmer-says/",
     "image": "/images/news-banner.png",
     "desk": "news-politics"
@@ -606,7 +618,7 @@
   {
     "id": "2026-05-04-what-champions-league-failure-means-for-broken-club-chelsea",
     "title": "What Champions League failure means for 'broken club' Chelsea",
-    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far\u2011reaching consequences.",
+    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far‑reaching consequences.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -659,7 +671,7 @@
   {
     "slug": "2026-05-04-irish-actor-and-banshees-of-inisherin-star-gary-lydon-dies-aged-61",
     "title": "Irish actor and Banshees of Inisherin star Gary Lydon dies aged 61",
-    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland\u2019s film and television community.",
+    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland’s film and television community.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -668,8 +680,8 @@
   },
   {
     "slug": "2026-05-04-how-7-looks-for-the-devil-wears-prada-2-came-together",
-    "title": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together",
-    "description": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
+    "title": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together",
+    "description": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -733,7 +745,7 @@
   {
     "id": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
     "slug": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
-    "title": "The \u2018Devil Wears Prada 2\u2019 Costume Rollout Fuels a New Fashion-Marketing Playbook",
+    "title": "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook",
     "summary": "Early wardrobe reveals for The Devil Wears Prada 2 are being treated as headline entertainment and fashion moments, signaling a broader shift in how sequel campaigns are packaged across media.",
     "date": "2026-05-04T01:00:00Z",
     "subject": "arts-entertainment",
@@ -843,7 +855,7 @@
     "id": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "slug": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "title": "Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics",
-    "summary": "Turkey\u2019s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
+    "summary": "Turkey’s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
     "date": "2026-05-03T15:39:52Z",
     "subject": "opinion-editorials",
     "category": "opinion-editorials",
@@ -870,7 +882,7 @@
     "date": "2026-05-03",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "For five years, our column has attempted to settle rows about the important little things \u2026 but what happens after the verdicts are in?Since 2021, I\u2019ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
+    "summary": "For five years, our column has attempted to settle rows about the important little things … but what happens after the verdicts are in?Since 2021, I’ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
     "link": "/articles/from-shared-toothbrushes-to-mid-sex-water-bladders-you-be-the-judge-tries-to-settle-domest/",
     "image": "/images/news-banner.png"
   },
@@ -1165,8 +1177,8 @@
   {
     "id": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
     "slug": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
-    "title": "Greens pledge \u00a315 minimum wage for all workers",
-    "summary": "The Green Party says it would raise the minimum wage to \u00a315 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
+    "title": "Greens pledge £15 minimum wage for all workers",
+    "summary": "The Green Party says it would raise the minimum wage to £15 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
     "date": "2026-05-02T07:50:30Z",
     "subject": "news-politics",
     "category": "news-politics",
@@ -1278,8 +1290,8 @@
   },
   {
     "id": "2026-05-01-world-s-largest-study-of-women-s-health-marks-30-years-of-pioneering-research-ndph-ox-ac-u",
-    "title": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk",
-    "summary": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
+    "title": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk",
+    "summary": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
     "date": "2026-05-01T21:04:46Z",
     "subject": "science-health",
     "category": "science-health",
@@ -1306,8 +1318,8 @@
   },
   {
     "id": "2026-05-01-dprk-korea-continued-militarisation-a-serious-concern-political-affairs-chief-warns-security-counci",
-    "title": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News",
-    "summary": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
+    "title": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News",
+    "summary": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
     "date": "2026-05-01T17:54:11Z",
     "subject": "world",
     "category": "world",
@@ -1321,7 +1333,7 @@
   {
     "id": "2026-05-01-update-pentagon-expands-classified-ai-contracts",
     "title": "Update: Pentagon expands classified AI contracts to multiple cloud and model vendors",
-    "summary": "New reporting indicates the Pentagon\u2019s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
+    "summary": "New reporting indicates the Pentagon’s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
     "date": "2026-05-01T16:46:26Z",
     "subject": "technology",
     "category": "technology",
@@ -1405,7 +1417,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/260"
   },
   {
-    "title": "Microsoft\u2019s AI Growth Signals Big Upside Ahead",
+    "title": "Microsoft’s AI Growth Signals Big Upside Ahead",
     "date": "2026-05-01",
     "author": "Adeline Park",
     "desk": "technology",
@@ -1466,13 +1478,13 @@
   },
   {
     "id": "governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating",
-    "title": "Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
+    "title": "Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
     "permalink": "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/",
     "date": "2026-04-30",
     "author": "Rowan Hale",
     "category": "environment",
     "image": "/images/news-banner.png",
-    "excerpt": "Latest verified developments on Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil"
+    "excerpt": "Latest verified developments on Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil"
   },
   {
     "id": "2026-04-30-protecting-lions-and-people-the-biologist-dedicated-to-tackling-human-wildlife-conflict",
@@ -1581,8 +1593,8 @@
   },
   {
     "id": "2026-04-30-what-s-at-stake-for-elections-at-the-supreme-court",
-    "title": "What\u2019s at Stake for Elections at the Supreme Court",
-    "summary": "What\u2019s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
+    "title": "What’s at Stake for Elections at the Supreme Court",
+    "summary": "What’s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
     "author": "Maya Sterling",
     "author_id": "maya-sterling",
     "author_display_name": "Maya Sterling",
@@ -1617,7 +1629,7 @@
   {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",
     "title": "Senate rejects curb on Trump military action in Cuba - Axios",
-    "summary": "Senate rejects curb on Trump military action in Cuba - Axios \u2014 key confirmed developments and what they mean for news-politics.",
+    "summary": "Senate rejects curb on Trump military action in Cuba - Axios — key confirmed developments and what they mean for news-politics.",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
     "author_display_name": "Maya Sterling",
@@ -1684,7 +1696,7 @@
   },
   {
     "id": "trump-s-war-global-justice-court-staff-u-n-face",
-    "title": "In Trump\u2019s war on global justice, court staff and U.N. face terrorist\u2011grade sanctions - Reuters",
+    "title": "In Trump’s war on global justice, court staff and U.N. face terrorist‑grade sanctions - Reuters",
     "author": "Elias Navarro",
     "date": "2026-04-29",
     "category": "world",
@@ -1694,7 +1706,7 @@
   {
     "id": "2026-04-29-top-transfer-qb-brendan-sorsby-taking-leave-of-absence-from-texas-tech-for-gambling-the-athletic",
     "title": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic",
-    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic \u2014 key confirmed developments and what they mean for sports.",
+    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic — key confirmed developments and what they mean for sports.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -1731,8 +1743,8 @@
   },
   {
     "id": "2026-04-29-over-half-of-south-sudan-s-population-faces-acute-hunger-crisis-un-news",
-    "title": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
-    "summary": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
+    "title": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
+    "summary": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -1784,7 +1796,7 @@
   {
     "id": "2026-04-28-southern-china-torrential-rain-flooding-fears",
     "title": "Southern China Braces for Flood Risk as Torrential Rainfall Intensifies",
-    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150\u2013200mm.",
+    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150–200mm.",
     "author": "Rowan Hale",
     "author_id": "environment_lead",
     "author_display_name": "Rowan Hale",
@@ -1818,7 +1830,7 @@
   },
   {
     "id": "2026-04-28-opinion-russia-internet-blackouts-legitimacy-cost",
-    "title": "Opinion: Russia\u2019s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
+    "title": "Opinion: Russia’s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
     "summary": "An opinion-editorial arguing that broad wartime internet shutdowns can erode state legitimacy faster than they secure it.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -1894,7 +1906,7 @@
   },
   {
     "id": "2026-04-28-opinion-america-immigration-edge-welcoming-talent-safeguarding-legitimacy",
-    "title": "Opinion: America\u2019s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
+    "title": "Opinion: America’s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
     "summary": "An opinion-editorial arguing that durable U.S. immigration policy must pair lawful-entry capacity with accountable enforcement.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -1965,8 +1977,8 @@
   },
   {
     "id": "2026-04-28-summer-movie-guide-2026-theatrical-and-streaming-slate",
-    "title": "Summer Movie Guide 2026: What\u2019s Coming to Theaters and Streaming From May Through August",
-    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios\u2019 peak-season strategy.",
+    "title": "Summer Movie Guide 2026: What’s Coming to Theaters and Streaming From May Through August",
+    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios’ peak-season strategy.",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
     "author_display_name": "Camille Vega",
@@ -1978,8 +1990,8 @@
   },
   {
     "id": "2026-04-28-south-korea-court-expands-convictions-around-yoon-circle",
-    "title": "South Korean Court Expands Convictions Around Ousted President Yoon\u2019s Inner Circle",
-    "summary": "South Korean courts expanded convictions across former President Yoon\u2019s inner circle, with new sentencing moves affecting both family and leadership figures.",
+    "title": "South Korean Court Expands Convictions Around Ousted President Yoon’s Inner Circle",
+    "summary": "South Korean courts expanded convictions across former President Yoon’s inner circle, with new sentencing moves affecting both family and leadership figures.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -2051,7 +2063,7 @@
   },
   {
     "id": "wellness-retreats-on-mexico-s-yucat-n-peninsula-connect-with-cultural-traditions",
-    "title": "Wellness retreats on Mexico\u2019s Yucat\u00e1n Peninsula connect with cultural traditions",
+    "title": "Wellness retreats on Mexico’s Yucatán Peninsula connect with cultural traditions",
     "author": "Nico Laurent",
     "date": "2026-04-28T12:55:43Z",
     "category": "lifestyle",
@@ -2060,7 +2072,7 @@
   },
   {
     "id": "my-tenant-owes-15000-in-rent-but-i-cant-get-them-out-of-the-property-20260428",
-    "title": "My tenant owes \u00a315,000 in rent, but I can't get them out of the property",
+    "title": "My tenant owes £15,000 in rent, but I can't get them out of the property",
     "description": "Landlords tell BBC News why they fear new laws could make it harder to remove problematic tenants.",
     "author": "Priya Desai",
     "date": "2026-04-28T05:37:45Z",
@@ -2123,7 +2135,7 @@
   {
     "id": "2026-04-24-opinion-powell-probe-fed-independence-guardrails",
     "title": "Opinion: Ending the Powell Probe Should Trigger Harder Guardrails for Fed Independence",
-    "summary": "The DOJ\u2019s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
+    "summary": "The DOJ’s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -2175,7 +2187,7 @@
   {
     "id": "2026-04-24-alcaraz-misses-french-open-title-defense-wrist-injury",
     "title": "Carlos Alcaraz to Miss French Open, Ending Bid for Third Straight Title",
-    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men\u2019s draw and reshaping the tournament outlook.",
+    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men’s draw and reshaping the tournament outlook.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -2187,7 +2199,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90b-euro-ukraine-loan-after-hungary-veto-lifted",
-    "title": "EU Approves \u20ac90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
+    "title": "EU Approves €90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
     "summary": "The EU approved a 90-billion-euro ($106B) two-year Ukraine package after a Hungary-linked standoff eased, re-opening a key wartime financing channel for Kyiv.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -2299,7 +2311,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/",
-    "summary": "Update coverage adds Reuters-reported detail that DeepSeek\u2019s latest model preview is adapted for Huawei chips, sharpening the story\u2019s infrastructure and ecosystem implications.",
+    "summary": "Update coverage adds Reuters-reported detail that DeepSeek’s latest model preview is adapted for Huawei chips, sharpening the story’s infrastructure and ecosystem implications.",
     "image": "/images/articles/update-deepseek-huawei-chip-optimized-ai-model-preview.png"
   },
   {
@@ -2312,7 +2324,7 @@
     "subject": "arts-entertainment",
     "category": "arts-entertainment",
     "permalink": "/articles/2026-04-24-update-devil-wears-prada-2-asia-backlash-milan-rollout/",
-    "summary": "New coverage links the sequel\u2019s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
+    "summary": "New coverage links the sequel’s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
     "image": "/images/articles/update-devil-wears-prada-2-asia-backlash-milan-rollout.png"
   },
   {
@@ -2351,7 +2363,7 @@
     "subject": "environment",
     "category": "environment",
     "permalink": "/articles/2026-04-24-france-drops-climate-from-g7-environment-talks/",
-    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqu\u00e9s.",
+    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqués.",
     "image": "/images/articles/france-drops-climate-from-g7-environment-talks.png"
   },
   {
@@ -2377,7 +2389,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-meta-aws-graviton-deployment-agentic-ai-workloads/",
-    "summary": "Meta\u2019s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
+    "summary": "Meta’s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
     "image": "/images/articles/meta-aws-graviton-deployment-agentic-ai-workloads.png"
   },
   {
@@ -2395,7 +2407,7 @@
   },
   {
     "id": "2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model",
-    "title": "China\u2019s DeepSeek says releases long-awaited new AI model",
+    "title": "China’s DeepSeek says releases long-awaited new AI model",
     "date": "2026-04-24",
     "author": "Adeline Park",
     "author_id": "technology_lead",
@@ -2403,7 +2415,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/",
-    "summary": "China\u2019s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China\u2019s fast-moving model race.",
+    "summary": "China’s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China’s fast-moving model race.",
     "image": "/images/news-banner.png"
   },
   {
@@ -2421,7 +2433,7 @@
   },
   {
     "id": "2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels",
-    "title": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
+    "title": "Condé Nast Traveler’s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
     "date": "2026-04-24",
     "author": "Nico Laurent",
     "author_id": "lifestyle_lead",
@@ -2429,7 +2441,7 @@
     "subject": "lifestyle",
     "category": "lifestyle",
     "permalink": "/articles/2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels/",
-    "summary": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
+    "summary": "Condé Nast Traveler’s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
     "image": "/images/articles/conde-nast-traveler-2026-hot-list-wellness-hotels.png"
   },
   {
@@ -2520,7 +2532,7 @@
     "subject": "sports",
     "category": "sports",
     "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
-    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA\u2019s platform, as broader pricing and access scrutiny intensifies.",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
     "image": "/images/news-banner.png"
   },
   {
@@ -2599,7 +2611,7 @@
     "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
-    "excerpt": "Spain\u2019s PM, Pedro S\u00e1nchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
+    "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },
   {
     "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
@@ -2642,7 +2654,7 @@
   },
   {
     "id": "2026-04-24-summer-house-season-10-reunion-no-separate-interviews",
-    "title": "Bravo\u2019s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
+    "title": "Bravo’s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
     "date": "2026-04-24",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
@@ -2681,7 +2693,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
-    "title": "EU Formally Approves \u20ac90 Billion Ukraine Loan and New Russia Sanctions",
+    "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -2689,7 +2701,7 @@
     "subject": "world",
     "category": "world",
     "permalink": "/articles/2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions/",
-    "summary": "EU institutions finalized a \u20ac90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
+    "summary": "EU institutions finalized a €90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
     "image": "/images/articles/eu-approves-90bn-ukraine-loan-russia-sanctions.png"
   },
   {
@@ -2733,7 +2745,7 @@
   },
   {
     "id": "2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama",
-    "title": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?",
+    "title": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?",
     "date": "2026-04-23",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
@@ -2741,7 +2753,7 @@
     "subject": "news-politics",
     "category": "news-politics",
     "permalink": "/articles/2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama/",
-    "summary": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?&nbsp;&nbsp;Al Jazeera",
+    "summary": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?&nbsp;&nbsp;Al Jazeera",
     "image": "/images/news-banner.png"
   },
   {
@@ -2978,7 +2990,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "environment",
     "permalink": "/articles/2026-05-07-amazon-deforestation-rainfall-risk-study/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/443"
   },
   {
     "id": "environment-climate-change-fuels-wildfire-threats-across-appal-2026-05-07",

--- a/content/articles/2026-05-07-amazon-deforestation-rainfall-risk-study.md
+++ b/content/articles/2026-05-07-amazon-deforestation-rainfall-risk-study.md
@@ -1,0 +1,29 @@
+---
+title: "New Research Warns Amazon Deforestation Could Sharply Reduce Regional Rainfall"
+slug: "2026-05-07-amazon-deforestation-rainfall-risk-study"
+desk: "environment"
+author: "Rowan Hale"
+date: "2026-05-07"
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+New reporting this week points to growing scientific concern that continued deforestation in the Amazon could significantly reduce rainfall across parts of South America, with downstream effects for ecosystems, farming, and water security.
+
+The New York Times climate desk reports on a new study finding that forest loss can alter atmospheric moisture flows that help sustain rainfall in and beyond the Amazon basin. A separate Phys.org science report on related research similarly describes evidence linking deforestation to reduced rainfall and warns that background warming can intensify those impacts.
+
+## Why this matters
+
+For the environment desk, this is a high-signal climate-biodiversity risk story: rainforest loss is not only a biodiversity issue, but also a hydrological and regional climate-stability issue. If rainfall reliability declines, consequences can spread from forest resilience to food systems, hydropower planning, and public health exposure during drought and heat.
+
+## What to watch next
+
+- Whether policymakers in Amazon countries announce tighter anti-deforestation enforcement or restoration targets.
+- Whether forthcoming peer-reviewed follow-ups quantify regional tipping thresholds with greater precision.
+- Whether regional agencies report early changes in dry-season intensity and river-basin stress indicators.
+
+## Sources
+
+- New York Times Climate RSS item: https://www.nytimes.com/2026/05/06/climate/amazon-rain-forest-deforestation-climate.html
+- Phys.org Earth News RSS item: https://phys.org/news/2026-05-deforestation-lessens-amazon-rainfall-climate.html
+- BBC Science & Environment context item on global forest loss trends: https://www.bbc.com/news/articles/c78q5pygn66o

--- a/content/articles/2026-05-07-amazon-deforestation-rainfall-risk-study.md
+++ b/content/articles/2026-05-07-amazon-deforestation-rainfall-risk-study.md
@@ -5,7 +5,7 @@ desk: "environment"
 author: "Rowan Hale"
 date: "2026-05-07"
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/443"
 ---
 
 New reporting this week points to growing scientific concern that continued deforestation in the Amazon could significantly reduce rainfall across parts of South America, with downstream effects for ecosystems, farming, and water security.


### PR DESCRIPTION
## Summary
Adds one environment-desk article on new reporting about Amazon deforestation and rainfall risk, plus index update.

## Off-record: claim matrix
1. Claim: New reporting says deforestation may reduce Amazon/regional rainfall.
   - Source A: NYT Climate RSS-linked article (2026-05-06)
   - Source B: Phys.org Earth News RSS-linked item on related research (2026-05-07)
   - Confidence: Medium (primary article pages partly inaccessible in runner; RSS metadata corroborated)
2. Claim: Climate warming may amplify rainfall-disruption effects.
   - Source A: Phys.org RSS title/summary language
   - Source B: BBC S&E context on forest-loss/climate stress
   - Confidence: Medium-low (contextual synthesis, attributed)

## Off-record: source discovery + bias-check log
- Desk constraint enforced: environment only.
- Tried UNEP/Mongabay/CarbonBrief/WHO feeds first; blocked/invalid in runner.
- Fallback discovery used Guardian/BBC/NYT/Phys.org RSS where available.
- Avoided promotional framing; attributed all uncertain details to outlets.

## Off-record: editorial rationale & safety checks
- Selected topic because it is a current environment-science development with policy relevance.
- Duplicate check performed against existing repo articles; no direct duplicate found.
- Article body excludes internal process notes.

## Files changed
- content/articles/2026-05-07-amazon-deforestation-rainfall-risk-study.md
- assets/data/articles.json
