### PR TITLE
Technology: Perplexity opens Personal Computer app to all Mac users

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "technology",
     "permalink": "/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/449"
   },
   {
     "id": "2026-05-07-a-new-era-for-your-health-and-wellness-blog-google",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users",
+    "title": "Perplexity opens its Personal Computer app to all Mac users",
+    "summary": "Perplexity has opened its Personal Computer app to all Mac users, expanding desktop access to its AI assistant workflow as competition intensifies in productivity-focused AI tools.",
+    "author": "Adeline Park",
+    "date": "2026-05-07T19:59:49Z",
+    "subject": "technology",
+    "category": "technology",
+    "permalink": "/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-07-a-new-era-for-your-health-and-wellness-blog-google",
     "title": "A new era for your health and wellness - blog.google",
     "summary": "Dr. Lena Okafor reports on the latest science health development: A new era for your health and wellness - blog.google.",

--- a/content/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users.md
+++ b/content/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users.md
@@ -1,0 +1,23 @@
+---
+title: "Perplexity opens its Personal Computer app to all Mac users"
+date: "2026-05-07T19:59:49Z"
+author: "Adeline Park"
+subject: "technology"
+category: "technology"
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+Perplexity said its "Personal Computer" app is now available to all users on macOS, broadening access to its desktop AI workflow beyond earlier limited availability.
+
+According to TechCrunch's report, the rollout positions the Mac app as a hub for combining search, summarization, and writing tasks in a single desktop interface. The expansion comes as AI assistant vendors race to move from browser tabs into always-on desktop tools.
+
+Why it matters: desktop availability can increase daily usage by reducing friction for knowledge work, especially for users who want persistent assistant context while switching between documents, web research, and messaging apps.
+
+What to watch next:
+
+- Whether Perplexity ships a Windows version on a similar timeline.
+- How rivals respond with deeper OS-level integrations and enterprise controls.
+- Whether broader availability changes pricing, usage caps, or feature tiers over the next quarter.
+
+Source: TechCrunch (May 7, 2026) — https://techcrunch.com/2026/05/07/perplexitys-personal-computer-is-now-available-everyone-on-mac/

--- a/content/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users.md
+++ b/content/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users.md
@@ -5,7 +5,7 @@ author: "Adeline Park"
 subject: "technology"
 category: "technology"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/449"
 ---
 
 Perplexity said its "Personal Computer" app is now available to all users on macOS, broadening access to its desktop AI workflow beyond earlier limited availability.


### PR DESCRIPTION
## Summary
Publishes one technology-desk article on Perplexity opening its Personal Computer app to all Mac users on macOS.

## Off-record editorial package
### Claim matrix
1. Perplexity opened the Personal Computer app to all Mac users.  
   - Source: TechCrunch (https://techcrunch.com/2026/05/07/perplexitys-personal-computer-is-now-available-everyone-on-mac/)
2. Rollout broadens access beyond prior limited availability.  
   - Source: TechCrunch report language and product-rollout framing.
3. Competitive significance: desktop AI-assistant distribution race is intensifying.  
   - Source: synthesis from current AI product-launch pattern (analysis clearly labeled as context, not a direct claim).

### Source discovery + bias-check log
- Discovery feeds checked: The Verge RSS, TechCrunch RSS, Ars Technica RSS, MIT Technology Review RSS.
- Candidate triage prioritized desk fit (technology product rollout) and recency (same-day publication).
- Bias check: primary source is a single outlet; article language kept conservative, attributed explicitly, and avoids unverifiable extra claims.

### Editorial rationale and safety checks
- Desk fit: pure technology product/access expansion story.
- Harm check: no medical/legal/financial advice.
- Accuracy check: all factual assertions are source-attributed.
- Off-record process notes intentionally kept in PR only.

## Internal discussion seed
Author requests editor scrutiny on: (1) whether headline should emphasize "Mac users" vs "desktop rollout" and (2) whether to add explicit caveat about single-source confirmation in body.
