### PR TITLE
[business-economy] Market Minute: Earnings deliver, but inflation threat remains - Morningstar

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar",
+    "date": "2026-05-08",
+    "desk": "business-economy",
+    "author": "Priya Desai",
+    "summary": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar \u2014 latest verified development for the business-economy desk.",
+    "link": "/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "title": "2025/26 Champions League: All the fixtures and results - UEFA.com",
     "date": "2026-05-08",
     "desk": "sports",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -7,7 +7,7 @@
     "summary": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar \u2014 latest verified development for the business-economy desk.",
     "link": "/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/456"
   },
   {
     "title": "2025/26 Champions League: All the fixtures and results - UEFA.com",

--- a/content/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar.md
+++ b/content/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar.md
@@ -5,7 +5,7 @@ desk: "business-economy"
 author: "Priya Desai"
 summary: "Market Minute: Earnings deliver, but inflation threat remains - Morningstar — latest verified development for the business-economy desk."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/456"
 ---
 
 ## What happened

--- a/content/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar.md
+++ b/content/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar.md
@@ -1,0 +1,25 @@
+---
+title: "Market Minute: Earnings deliver, but inflation threat remains - Morningstar"
+date: "2026-05-08"
+desk: "business-economy"
+author: "Priya Desai"
+summary: "Market Minute: Earnings deliver, but inflation threat remains - Morningstar — latest verified development for the business-economy desk."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+## What happened
+
+Market Minute: Earnings deliver, but inflation threat remains - Morningstar
+
+## Why it matters
+
+This development is directly relevant to the business-economy desk and has near-term public-interest implications.
+
+## What to watch next
+
+Expect additional official detail, implementation timelines, and corroborating institutional updates.
+
+## Sources
+
+- https://news.google.com/rss/articles/CBMimgFBVV95cUxNamxWQjJjeXJBSVhaNzRxcUJSNElfTzI4ZVFNQU9JV3NzTFZRUjRuQ0xWZ09FYWFVUGpzczIyOWdtQzg4bmFkSlN0TFNlT0ttUEhyTjV6ZzNjZm1NeE5ndUYxUGRqZDJrcHhhNTAxUU93TUtHMmRfdmVWbDV4eUVNZm51SndOUENGZW9aOGlVdzJYMUx4RDQwNWtB?oc=5


### PR DESCRIPTION
## Summary
- Desk: **business-economy**
- Author: **Priya Desai**
- Decision: **new**

## OFF-RECORD meta
### Claim matrix
- Claim: Market Minute: Earnings deliver, but inflation threat remains - Morningstar
- Evidence: https://news.google.com/rss/articles/CBMimgFBVV95cUxNamxWQjJjeXJBSVhaNzRxcUJSNElfTzI4ZVFNQU9JV3NzTFZRUjRuQ0xWZ09FYWFVUGpzczIyOWdtQzg4bmFkSlN0TFNlT0ttUEhyTjV6ZzNjZm1NeE5ndUYxUGRqZDJrcHhhNTAxUU93TUtHMmRfdmVWbDV4eUVNZm51SndOUENGZW9aOGlVdzJYMUx4RDQwNWtB?oc=5
- Confidence: Medium

### Source discovery and bias-check
- Query: `inflation central bank markets earnings` via Google News RSS
- Bias: attribution-first, non-speculative

### Editorial rationale and safety checks
- Exact desk fit validated
- No off-record text in article file
