### PR TITLE
technology: Instagram privacy tech is turned off today- what does this mean for your DMs?

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Instagram privacy tech is turned off today- what does this mean for your DMs?",
+    "slug": "instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms",
+    "author": "Adeline Park",
+    "category": "technology",
+    "date": "2026-05-08T03:33:49Z",
+    "excerpt": "The platform said it would remove end-to-end encrypted messages, a major U‑turn by parent company Meta.",
+    "image": "/images/news-banner.png",
+    "path": "/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms/"
+  },
+  {
     "title": "Oil prices rise after US and Iran exchange fire in Hormuz strait",
     "date": "2026-05-08",
     "author": "Priya Desai",

--- a/content/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms.md
+++ b/content/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms.md
@@ -1,0 +1,22 @@
+---
+title: "Instagram privacy tech is turned off today- what does this mean for your DMs?"
+date: "2026-05-08T03:33:49Z"
+author: "Adeline Park"
+subject: "technology"
+category: "technology"
+image: "/images/news-banner.png"
+published_pr_url: "TBD"
+---
+
+The platform said it would remove end-to-end encrypted messages, a major U‑turn by parent company Meta.
+
+### What happened
+Instagram privacy tech is turned off today- what does this mean for your DMs?.
+
+### Why it matters
+This development is relevant to the **technology** desk and may influence near-term public discussion and follow-on reporting.
+
+### Source notes
+Primary source: [BBC Technology](https://www.bbc.com/news/articles/clypzxl3lvqo?at_medium=RSS&at_campaign=rss)
+
+_This is an early dispatch and may be updated as additional verified reporting becomes available._

--- a/content/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms.md
+++ b/content/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms.md
@@ -5,7 +5,7 @@ author: "Adeline Park"
 subject: "technology"
 category: "technology"
 image: "/images/news-banner.png"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/458"
 ---
 
 The platform said it would remove end-to-end encrypted messages, a major U‑turn by parent company Meta.


### PR DESCRIPTION
## Summary
Publish one technology article: **Instagram privacy tech is turned off today- what does this mean for your DMs?**.

## Claim matrix (off-record)
- Claim: Current development described by selected desk feed item.\n  Source: BBC Technology (https://www.bbc.com/news/articles/clypzxl3lvqo?at_medium=RSS&at_campaign=rss)\n  Status: attributed, single-source dispatch pending corroboration.

## Source discovery and bias-check log (off-record)
- Desk: technology
- Candidate feeds attempted: BBC Technology, NPR Technology, Google Technology
- Candidate headlines tried (up to 3): ['Instagram privacy tech is turned off today- what does this mean for your DMs?']
- Reachability verified before drafting.
- Bias check: neutral tone, attributed reporting, no speculation.

## Editorial rationale and safety checks (off-record)
- Topic fit: desk-specific feed alignment.
- Safety: no prescriptive advice, no unverifiable allegations.
- Boundary check: no process notes inside article markdown.
