### PR TITLE
news-politics: Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video",
+    "author": "Maya Sterling",
+    "desk": "news-politics",
+    "date": "2026-05-08T04:37:21Z",
+    "summary": "A three-judge panel in Washington heard arguments in the lawsuit aimed at stopping the Pentagon from disciplining Senator Mark Kelly for a video warning about illegal military orders.",
+    "link": "/articles/appeals-court-looks-unlikely-to-allow-hegseth-to-punish-mark-kelly-for-video/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "title": "Instagram privacy tech is turned off today- what does this mean for your DMs?",
     "slug": "instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms",
     "author": "Adeline Park",

--- a/content/articles/appeals-court-looks-unlikely-to-allow-hegseth-to-punish-mark-kelly-for-video.md
+++ b/content/articles/appeals-court-looks-unlikely-to-allow-hegseth-to-punish-mark-kelly-for-video.md
@@ -5,7 +5,7 @@ author: "Maya Sterling"
 desk: "news-politics"
 summary: "A three-judge panel in Washington heard arguments in the lawsuit aimed at stopping the Pentagon from disciplining Senator Mark Kelly for a video warning about illegal military orders."
 image: "/images/news-banner.png"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/459"
 ---
 # Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video
 

--- a/content/articles/appeals-court-looks-unlikely-to-allow-hegseth-to-punish-mark-kelly-for-video.md
+++ b/content/articles/appeals-court-looks-unlikely-to-allow-hegseth-to-punish-mark-kelly-for-video.md
@@ -1,0 +1,21 @@
+---
+title: "Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video"
+date: "2026-05-08T04:37:21Z"
+author: "Maya Sterling"
+desk: "news-politics"
+summary: "A three-judge panel in Washington heard arguments in the lawsuit aimed at stopping the Pentagon from disciplining Senator Mark Kelly for a video warning about illegal military orders."
+image: "/images/news-banner.png"
+published_pr_url: "TBD"
+---
+# Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video
+
+A three-judge panel in Washington heard arguments in the lawsuit aimed at stopping the Pentagon from disciplining Senator Mark Kelly for a video warning about illegal military orders.
+
+According to current reporting from www.nytimes.com, this development is significant for the news politics desk because it advances a time-bounded event with direct public impact.
+
+The newsroom will continue monitoring for confirmations, official statements, and measurable follow-through.
+
+## Sources
+
+- Primary source: https://www.nytimes.com/2026/05/07/us/politics/mark-kelly-pete-hegseth-video-lawsuit.html
+- Discovery feed: https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml


### PR DESCRIPTION
## Summary
Publish one news-politics article: **Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video**.

## Claim matrix (off-record)
1. Claim: Topic belongs to news-politics. Evidence: desk-keyword match score=2 from selected item title/summary.
2. Claim: Current event signal exists. Evidence: live feed item with timestamp `Thu, 07 May 2026 19:23:14 +0000` and source URL.
3. Claim: Article metadata consistency. Evidence: frontmatter desk/author/image and articles.json entry aligned.

## Source discovery and bias-check log (off-record)
- Tried feeds: []
- Selected feed: https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml
- Selected source link: https://www.nytimes.com/2026/05/07/us/politics/mark-kelly-pete-hegseth-video-lawsuit.html
- Bias check: used direct source attribution and avoided unverifiable claims beyond cited source text.

## Editorial rationale and safety checks (off-record)
- Chosen because it matches desk taxonomy and is time-bounded.
- Excluded internal process notes from article body.
- Image: fallback /images/news-banner.png.

## Internal process notes (off-record)
- Duplicate gate: new story path
- published_pr_url backfill pending after PR creation.