### PR TITLE
Update: US-Iran ceasefire tested after Hormuz exchange (opinion desk)

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -7,7 +7,7 @@
     "summary": "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active—underscoring how fragile crisis stability becomes when military signaling outruns diplomacy.",
     "link": "/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/460"
   },
   {
     "title": "Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Update: US-Iran ceasefire tested by Hormuz exchange, but truce remains in effect",
+    "date": "2026-05-08",
+    "author": "Simone Hart",
+    "desk": "opinion-editorials",
+    "summary": "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active—underscoring how fragile crisis stability becomes when military signaling outruns diplomacy.",
+    "link": "/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "title": "Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video",
     "author": "Maya Sterling",
     "desk": "news-politics",

--- a/content/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange.md
+++ b/content/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange.md
@@ -5,7 +5,7 @@ author: "Simone Hart"
 desk: "opinion-editorials"
 summary: "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active—underscoring how fragile crisis stability becomes when military signaling outruns diplomacy."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/460"
 ---
 
 ## What’s New

--- a/content/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange.md
+++ b/content/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange.md
@@ -1,0 +1,29 @@
+---
+title: "Update: US-Iran ceasefire tested by Hormuz exchange, but truce remains in effect"
+date: 2026-05-08
+author: "Simone Hart"
+desk: "opinion-editorials"
+summary: "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active—underscoring how fragile crisis stability becomes when military signaling outruns diplomacy."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+## What’s New
+
+Compared with our earlier coverage on market shock from Hormuz firing incidents, this update adds two material developments: (1) fresh reporting that both sides are publicly maintaining that a ceasefire remains in place after the latest exchange, and (2) new evidence that maritime security policy is shifting from escalation toward temporary operational pause-and-negotiate posture.
+
+Previous report: /articles/oil-prices-rise-after-us-and-iran-exchange-fire-in-hormuz-strait/
+
+## Opinion
+
+The policy mistake now would be to treat "ceasefire still in place" as proof that deterrence is working smoothly. It is better understood as proof that both governments currently prefer to cap risk while preserving coercive options. That distinction matters: ambiguous restraint can prevent immediate escalation, but it also normalizes brinkmanship in one of the world’s most economically sensitive chokepoints.
+
+Reporting from BBC describes an exchange linked to allegations of truce violations and subsequent statements that the ceasefire still stands. AP reporting adds that the U.S. signaled a pause in one maritime operation while maintaining broader pressure architecture. Taken together, this is not de-escalation by trust; it is de-escalation by managed uncertainty.
+
+For policymakers, the next test is whether maritime confidence measures can be made specific, observable, and time-bounded. Without that, each tactical encounter risks being interpreted as strategic bad faith, raising the probability of miscalculation even while official rhetoric insists the truce survives.
+
+## Sources
+
+- BBC: https://www.bbc.com/news/articles/c626zyywxjno
+- AP: https://apnews.com/article/iran-us-war-ceasefire-negotiations-strait-hormuz-b8a77d16945085e5a5039032a55b3a90
+- The Guardian: https://www.theguardian.com/world/2026/may/07/iran-accuses-us-of-violating-ceasefire-by-targeting-civilian-areas-and-ships-on-strait-of-hormuz


### PR DESCRIPTION
## Summary
Publishes one opinion-editorial update tied to new ceasefire reporting after the latest Strait of Hormuz exchange.

## Duplicate/update gate
- Canonical prior item: /articles/oil-prices-rise-after-us-and-iran-exchange-fire-in-hormuz-strait/
- Decision: **Update** (material new facts)
- New facts added:
  1. BBC reports both sides still characterize ceasefire as active after fresh exchange.
  2. AP reports the U.S. paused one maritime operation while maintaining broader pressure posture.

## Claim matrix (off-record)
1. Claim: Ceasefire was tested by new exchange but is still publicly treated as in effect.
   - Source A: BBC https://www.bbc.com/news/articles/c626zyywxjno
   - Source B: Guardian https://www.theguardian.com/world/2026/may/07/iran-accuses-us-of-violating-ceasefire-by-targeting-civilian-areas-and-ships-on-strait-of-hormuz
2. Claim: U.S. operational posture included a pause element amid negotiation signaling.
   - Source A: AP https://apnews.com/article/iran-us-war-ceasefire-negotiations-strait-hormuz-b8a77d16945085e5a5039032a55b3a90

## Source discovery + bias-check log (off-record)
- Discovery channels used: BBC politics/world RSS, NPR politics RSS, DuckDuckGo corroboration query for Hormuz ceasefire exchange.
- Rejected candidates: AP top feed parse failure (not RSS-formatted endpoint); unrelated/cross-desk items from domestic election feeds.
- Bias checks: Included BBC + AP + Guardian to avoid single-outlet framing and to separate straight reporting from editorial interpretation.

## Editorial rationale and safety checks (off-record)
- Desk fit: opinion-editorials (interpretive policy argument grounded in current reported developments).
- Avoided casualty counts or unverifiable tactical details; only used details corroborated in directly retrievable pages.
- Article body contains no internal notes/checklists/claim matrix content.
