### PR TITLE
Environment Desk: Alaska megatsunami study raises climate-era risk warnings for glacier fjords

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "environment",
     "permalink": "/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/465"
   },
   {
     "id": "update-why-regenerative-farming-is-the-latest-wellness-travel-trend",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords",
+    "title": "Alaska megatsunami study raises climate-era risk warnings for glacier fjords",
+    "summary": "New reporting on a massive Alaska fjord wave says glacier retreat and slope instability are increasing the probability of rare but high-impact megatsunami hazards in coastal channels.",
+    "author": "Rowan Hale",
+    "date": "2026-05-08T08:56:37Z",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "update-why-regenerative-farming-is-the-latest-wellness-travel-trend",
     "title": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend",
     "summary": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend — key verified developments and why they matter for lifestyle readers.",

--- a/content/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords.md
+++ b/content/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords.md
@@ -1,0 +1,24 @@
+---
+title: "Alaska megatsunami study raises climate-era risk warnings for glacier fjords"
+date: "2026-05-08T08:56:37Z"
+author: "Rowan Hale"
+desk: "environment"
+summary: "New reporting on a massive Alaska fjord wave says glacier retreat and slope instability are increasing the probability of rare but high-impact megatsunami hazards in coastal channels."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+A new analysis of a major Alaska fjord wave event is refocusing attention on how warming-driven glacier retreat can amplify landslide and tsunami risk in steep coastal terrain.
+
+BBC reporting on the study describes the event as the second-largest recorded megatsunami and links growing hazard exposure to changing glacier conditions in Alaska fjord systems.
+
+Why it matters: For the environment desk, this is a climate-risk story with direct implications for coastal safety planning, marine traffic, and tourism in glacier regions where unstable slopes and narrow waterways can turn localized collapses into extreme waves.
+
+What to watch next:
+- Updated hazard maps from Alaska and U.S. geological agencies for glacier-adjacent fjords.
+- Changes in vessel routing guidance during high-risk periods.
+- Follow-up studies quantifying how glacier retreat shifts landslide probabilities over the next decade.
+
+Sources:
+- https://www.bbc.com/news/articles/c1m253033m4o
+- https://feeds.bbci.co.uk/news/science_and_environment/rss.xml

--- a/content/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords.md
+++ b/content/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords.md
@@ -5,7 +5,7 @@ author: "Rowan Hale"
 desk: "environment"
 summary: "New reporting on a massive Alaska fjord wave says glacier retreat and slope instability are increasing the probability of rare but high-impact megatsunami hazards in coastal channels."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/465"
 ---
 
 A new analysis of a major Alaska fjord wave event is refocusing attention on how warming-driven glacier retreat can amplify landslide and tsunami risk in steep coastal terrain.


### PR DESCRIPTION
## Summary
- Adds one environment desk article on Alaska megatsunami risk and glacier-retreat hazard context.
- Updates assets/data/articles.json index entry.

## Claim matrix (off-record)
1) A study characterized the Alaska event as among the largest recorded megatsunamis. Source: BBC report.
2) Glacier retreat can increase slope-instability hazards in fjord terrain. Source: BBC framing plus desk synthesis.
3) Topic fit is environmental risk and cryosphere change.

## Source discovery and bias-check log (off-record)
- Checked BBC Science and Environment feed and desk-specific candidates.
- Selected this event for direct environment relevance.
- Avoided casualty speculation and kept attribution explicit.

## Editorial rationale and safety checks (off-record)
- Claims kept conservative and attributed.
- No internal process material appears in article body.
