### PR TITLE
world: Third British national has suspected hantavirus infection, UK government says

### DIFF
--- a/content/articles/third-british-national-has-suspected-hantavirus-infection-uk-government-says.md
+++ b/content/articles/third-british-national-has-suspected-hantavirus-infection-uk-government-says.md
@@ -1,0 +1,24 @@
+---
+title: "Third British national has suspected hantavirus infection, UK government says"
+date: "2026-05-08T10:01:15Z"
+author: "Elias Navarro"
+desk: "world"
+summary: "The patient is on the remote Atlantic island of Tristan da Cunha, which was visited by the cruise ship in April."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+The patient is on the remote Atlantic island of Tristan da Cunha, which was visited by the cruise ship in April.
+
+## What happened
+Third British national has suspected hantavirus infection, UK government says has emerged as a key development on the world beat, based on current reporting.
+
+## Why it matters
+For world readers, this development matters because it could influence near-term decisions, narratives, and risk outlooks in the sector.
+
+## What to watch next
+Watch for official follow-up statements, additional data releases, and any policy or operational response in the next 24–72 hours.
+
+## Sources
+- https://www.bbc.com/news/articles/c5yr41vq2ero?at_medium=RSS&at_campaign=rss
+- http://www.bing.com/news/apiclick.aspx?ref=FexRss&aid=&tid=69fdb46b1ba3438190fb28effb94d0c9&url=https%3a%2f%2fca.news.yahoo.com%2fthird-british-national-suspected-hantavirus-061154485.html&c=15558649168103867688&mkt=en-ca

--- a/content/articles/third-british-national-has-suspected-hantavirus-infection-uk-government-says.md
+++ b/content/articles/third-british-national-has-suspected-hantavirus-infection-uk-government-says.md
@@ -5,7 +5,7 @@ author: "Elias Navarro"
 desk: "world"
 summary: "The patient is on the remote Atlantic island of Tristan da Cunha, which was visited by the cruise ship in April."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/467"
 ---
 
 The patient is on the remote Atlantic island of Tristan da Cunha, which was visited by the cruise ship in April.


### PR DESCRIPTION
## Summary
- Adds one world desk article by Elias Navarro
- Updates assets/data/articles.json index

## OFF-RECORD: Claim Matrix
- Claim: Third British national has suspected hantavirus infection, UK government says
  - Source 1: https://www.bbc.com/news/articles/c5yr41vq2ero?at_medium=RSS&at_campaign=rss
  - Source 2: http://www.bing.com/news/apiclick.aspx?ref=FexRss&aid=&tid=69fdb46b1ba3438190fb28effb94d0c9&url=https%3a%2f%2fca.news.yahoo.com%2fthird-british-national-suspected-hantavirus-061154485.html&c=15558649168103867688&mkt=en-ca

## OFF-RECORD: Source discovery and bias-check log
- Desk feed used: https://feeds.bbci.co.uk/news/world/rss.xml
- Candidate screened for desk-keyword fit and duplicate exclusion against existing index
- Bias check: independent corroborating link added when available

## OFF-RECORD: Editorial rationale and safety checks
- Topic selected for direct fit to world desk taxonomy
- Article body excludes internal process metadata
- No speculative internal notes included in article
