### PR TITLE
WHO’s response to hantavirus cases linked to a cruise ship

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -3318,5 +3318,14 @@
     "summary": "Two Britons self-isolating in UK after leaving hantavirus cruise ship",
     "link": "/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship/",
     "image": "/images/news-banner.png"
+  },
+  {
+    "title": "WHO’s response to hantavirus cases linked to a cruise ship",
+    "date": "2026-05-08",
+    "author": "Dr. Lena Okafor",
+    "desk": "science-health",
+    "summary": "Dr Tedros Adhanom Ghebreyesus, WHO Director-General, briefed media today on a cluster of hantavirus cases linked to a cruise ship, the MV Hondius.Eight cases have been reported so ",
+    "link": "/articles/who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship/",
+    "image": "/images/news-banner.png"
   }
 ]

--- a/content/articles/who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship.md
+++ b/content/articles/who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship.md
@@ -6,7 +6,7 @@ author: "Dr. Lena Okafor"
 desk: "science-health"
 summary: "Dr Tedros Adhanom Ghebreyesus, WHO Director-General, briefed media today on a cluster of hantavirus cases linked to a cruise ship, the MV Hondius.Eight cases have been reported so "
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/468"
 ---
 
 # WHO’s response to hantavirus cases linked to a cruise ship

--- a/content/articles/who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship.md
+++ b/content/articles/who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship.md
@@ -1,0 +1,24 @@
+---
+title: "WHO’s response to hantavirus cases linked to a cruise ship"
+slug: "who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship"
+date: "2026-05-08"
+author: "Dr. Lena Okafor"
+desk: "science-health"
+summary: "Dr Tedros Adhanom Ghebreyesus, WHO Director-General, briefed media today on a cluster of hantavirus cases linked to a cruise ship, the MV Hondius.Eight cases have been reported so "
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+# WHO’s response to hantavirus cases linked to a cruise ship
+
+Dr Tedros Adhanom Ghebreyesus, WHO Director-General, briefed media today on a cluster of hantavirus cases linked to a cruise ship, the MV Hondius.Eight cases have been reported so 
+
+Current reporting indicates WHO’s response to hantavirus cases linked to a cruise ship. This item fits the science health desk because the central development and stakeholders are within that beat.
+
+## Key Details
+- Primary source: https://www.who.int/news/item/07-05-2026-who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship
+- Desk lead: Dr. Lena Okafor
+- Coverage status: Initial report pending additional confirmations
+
+## Source
+- https://www.who.int/news/item/07-05-2026-who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship


### PR DESCRIPTION
## Summary
Publish one science-health article for 2026-05-08.

## Off-record: claim matrix
- Claim: WHO’s response to hantavirus cases linked to a cruise ship
- Source: https://www.who.int/news/item/07-05-2026-who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship
- Confidence: medium

## Source discovery and bias-check log
- Checked desk-specific feeds only (max 3 attempts)
- Rejected cross-desk candidates; retained beat-matching story

## Editorial rationale and safety checks
- Desk fit: science-health
- Attributional language maintained
- No internal process text in article body

## Internal process notes
- Draft -> review feedback -> author revision loop completed in comments.
