### PR TITLE
Environment: Europe inequality and temperature-related deaths study

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "europe-inequality-linked-to-higher-temperature-death-risk-study",
+    "title": "Europe inequality linked to higher temperature-death risk, study finds",
+    "summary": "A new Europe-focused health-climate analysis finds socioeconomic inequality is linked to significantly higher temperature-related mortality, with researchers estimating around 100,000 additional heat- and cold-related deaths each year across the continent.",
+    "author": "Rowan Hale",
+    "date": "2026-05-08T12:08:24Z",
+    "subject": "environment",
+    "category": "environment",
+    "permalink": "/articles/europe-inequality-linked-to-higher-temperature-death-risk-study/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords",
     "title": "Alaska megatsunami study raises climate-era risk warnings for glacier fjords",
     "summary": "New reporting on a massive Alaska fjord wave says glacier retreat and slope instability are increasing the probability of rare but high-impact megatsunami hazards in coastal channels.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "environment",
     "permalink": "/articles/europe-inequality-linked-to-higher-temperature-death-risk-study/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/469"
   },
   {
     "id": "alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords",

--- a/content/articles/europe-inequality-linked-to-higher-temperature-death-risk-study.md
+++ b/content/articles/europe-inequality-linked-to-higher-temperature-death-risk-study.md
@@ -5,7 +5,7 @@ author: "Rowan Hale"
 desk: "environment"
 summary: "A new Europe-focused health-climate analysis finds socioeconomic inequality is linked to significantly higher temperature-related mortality, with researchers estimating around 100,000 additional heat- and cold-related deaths each year across the continent."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/469"
 ---
 
 A Europe-wide climate-health analysis is drawing new attention to how social inequality shapes who dies during extreme temperatures.

--- a/content/articles/europe-inequality-linked-to-higher-temperature-death-risk-study.md
+++ b/content/articles/europe-inequality-linked-to-higher-temperature-death-risk-study.md
@@ -1,0 +1,26 @@
+---
+title: "Europe inequality linked to higher temperature-death risk, study finds"
+date: "2026-05-08T12:08:24Z"
+author: "Rowan Hale"
+desk: "environment"
+summary: "A new Europe-focused health-climate analysis finds socioeconomic inequality is linked to significantly higher temperature-related mortality, with researchers estimating around 100,000 additional heat- and cold-related deaths each year across the continent."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+A Europe-wide climate-health analysis is drawing new attention to how social inequality shapes who dies during extreme temperatures.
+
+Reporting from The Guardian and Phys.org says researchers found strong links between socioeconomic disparities and temperature-related mortality, estimating roughly 100,000 additional deaths each year from heat and cold across Europe.
+
+The study, led by the Barcelona Institute for Global Health (ISGlobal), indicates that poorer regions face disproportionately higher cold-related mortality, while richer and more urbanized areas show elevated heat risk during heatwaves.
+
+Why it matters: For the environment desk, this is a climate adaptation and justice story. It connects warming-era weather extremes to uneven resilience, suggesting that public-health planning, housing quality, and energy access are as important as temperature forecasts.
+
+What to watch next:
+- Whether national and EU-level adaptation plans add more place-based heat and cold protection measures.
+- How local governments target vulnerable neighborhoods for cooling, insulation, and emergency response.
+- Follow-up peer-reviewed work quantifying which interventions reduce mortality fastest.
+
+Sources:
+- https://www.theguardian.com/environment/2026/may/08/inequality-extra-deaths-heat-cold-europe-climate
+- https://phys.org/news/2026-05-europeans-deadlier-cold-inequality-reveals.html


### PR DESCRIPTION
## Summary
Publishes one environment-desk article on newly reported Europe temperature-mortality inequality findings.

## OFF-RECORD: Claim matrix
1. Claim: Study links socioeconomic inequality with higher temperature-related mortality in Europe.  
   - Source: Phys.org report on ISGlobal-led study.  
   - Confidence: Medium (secondary write-up).
2. Claim: Estimated ~100,000 extra deaths annually from heat and cold in Europe due to inequality factors.  
   - Source: Guardian coverage citing findings.  
   - Confidence: Medium.
3. Claim: Poorer regions show higher cold mortality while wealthier/urbanized regions face higher heat-wave risk.  
   - Source: Phys.org summary.  
   - Confidence: Medium.

## OFF-RECORD: Source discovery and bias-check log
- Discovery path: Guardian environment RSS + Google News cross-check.
- Corroboration used: Guardian + Phys.org.
- Bias checks: avoided advocacy framing; attributed findings to researchers/reporting; used neutral tone.
- Limitations: Could not retrieve full primary paper within run window; claims scoped to reported findings.

## OFF-RECORD: Editorial rationale and safety checks
- Desk-fit: Environment (climate-health adaptation and inequality impacts).
- Safety: No medical advice, no sensitive personal data, no graphic content.
- Duplicate gate: no matching article found in repo for this event.

## OFF-RECORD: Internal process notes
- Image generation attempt with gpt-image-1 returned HTTP 400; fallback image used (/images/news-banner.png).
- Will backfill `published_pr_url` after PR creation.
