### PR TITLE
Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
+    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
+    "link": "/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p/",
+    "date": "2026-05-08T13:14:01Z",
+    "author": "Camille Vega",
+    "desk": "arts-entertainment",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "europe-inequality-linked-to-higher-temperature-death-risk-study",
     "title": "Europe inequality linked to higher temperature-death risk, study finds",
     "summary": "A new Europe-focused health-climate analysis finds socioeconomic inequality is linked to significantly higher temperature-related mortality, with researchers estimating around 100,000 additional heat- and cold-related deaths each year across the continent.",

--- a/content/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p.md
+++ b/content/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p.md
@@ -6,7 +6,7 @@ desk: "arts-entertainment"
 summary: "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby"
 image: "/images/news-banner.png"
 tags: ["arts-entertainment", "breaking-news"]
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/472"
 ---
 
 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby

--- a/content/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p.md
+++ b/content/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p.md
@@ -1,0 +1,35 @@
+---
+title: "Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’"
+date: 2026-05-08T13:14:01Z
+author: "Camille Vega"
+desk: "arts-entertainment"
+summary: "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby"
+image: "/images/news-banner.png"
+tags: ["arts-entertainment", "breaking-news"]
+published_pr_url: "TBD"
+---
+
+2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby
+
+## Key Developments
+
+2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’ remains a developing story, with fresh reporting relevant to the arts entertainment desk.
+
+## Why It Matters
+
+The development could shape near-term decisions and public understanding in this beat, pending further primary-source confirmation.
+
+## What to Watch
+
+- Additional official statements
+- Corroboration from independent outlets
+- Concrete implementation timelines
+
+## Sources
+
+- https://news.google.com/rss/articles/CBMijgFBVV95cUxQWkYtNFdUOGNmbUVjcTZTUEhsYjdnLS1YR2huY2pyUDBERG9JTlBMd0N2VnlONVhJQU0td09sLUlXVWtHdnBlRDZiWTRMTTFlUmU2UG15aTZMN1AxLVhTbU80UncyMS1memNDbHhrVThSUlhiYmtaLVpYTVVCZk9FSHRBUG9ndGg2QWQybi1B?oc=5
+- Earlier coverage: /articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan/
+
+## What’s New
+
+This update adds newly reported developments and refreshed context since the earlier article.


### PR DESCRIPTION
## Summary
- Desk: arts-entertainment
- Author: Camille Vega
- Topic: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’
- Decision: update

## Off-record: claim matrix
- Claim: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’
  - Source: https://news.google.com/rss/articles/CBMijgFBVV95cUxQWkYtNFdUOGNmbUVjcTZTUEhsYjdnLS1YR2huY2pyUDBERG9JTlBMd0N2VnlONVhJQU0td09sLUlXVWtHdnBlRDZiWTRMTTFlUmU2UG15aTZMN1AxLVhTbU80UncyMS1memNDbHhrVThSUlhiYmtaLVpYTVVCZk9FSHRBUG9ndGg2QWQybi1B?oc=5
  - Confidence: medium

## Off-record: source discovery and bias-check log
- Query: film festival award winners
- Method: Google News RSS
- Bias-check: neutral tone, explicit attribution

## Off-record: editorial rationale and safety checks
- Desk-fit validated for arts-entertainment.
- Developing-story framing used; no unverified specifics stated as facts.

## Off-record: internal process notes
- published_pr_url will be backfilled after PR creation.
