### PR TITLE
Cannes Film Festival will award Barbra Streisand honorary Palme d'Or

### DIFF
--- a/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or.md
+++ b/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or.md
@@ -8,7 +8,7 @@ subject: "arts-entertainment"
 category: "arts-entertainment"
 status: "published"
 permalink: "/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/473"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or.md
+++ b/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or.md
@@ -1,0 +1,26 @@
+---
+title: "Cannes Film Festival will award Barbra Streisand honorary Palme d'Or"
+author: "Camille Vega"
+author_id: "camille-vega"
+author_display_name: "Camille Vega"
+date: "2026-05-08T14:17:22Z"
+subject: "arts-entertainment"
+category: "arts-entertainment"
+status: "published"
+permalink: "/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or/"
+published_pr_url: ""
+image: "/images/news-banner.png"
+---
+
+The Cannes Film Festival said it will present Barbra Streisand with an honorary Palme d'Or, according to Reuters reporting cited in current wire coverage.
+
+Festival organizers use honorary Palmes to recognize sustained artistic impact beyond a single competition entry. Streisand's career spans acting, directing, producing and recording, with major awards across film, music and television.
+
+For Cannes, the announcement reinforces the festival's strategy of pairing competition premieres with globally recognized figures to broaden audience attention during the event.
+
+What to watch next is whether Streisand's appearance is tied to a specific screening or tribute program as Cannes finalizes its public schedule.
+
+### Sources
+- Reuters (via Google News): https://news.google.com/rss/articles/CBMixAFBVV95cUxOMFZ1NzRtdkk3R3NaTjVVY2VxTVFBWmlwY2tvSC1hNUpmM3NWSlJRSk9FR1ZxS1NhWkRVOWlBaVQ5UEZ4RmY2bjRoS0F5OGoxdl83cjVrN3ZaRklOS2ZrdnRhSVYwNnVmVzVhVWhSUnFnQnk1bkl2MHU4T0NaVmNqVkhVdW1JUEQyc1BHVDRvSDNWTWhua0VoZHFwQzBqMkRrWEdLV2tSYVBZN0hIT1dEZDBBQVIwSjFVSFFTTld2X2VCaGVL?oc=5
+- Google News cluster query: https://news.google.com/search?q=Barbra%20Streisand%20honorary%20Palme%20d%27Or%20Cannes
+- Cannes Festival updates hub: https://www.festival-cannes.com/en/

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or",
+    "title": "Cannes Film Festival will award Barbra Streisand honorary Palme d'Or",
+    "summary": "Cannes said Barbra Streisand will receive an honorary Palme d'Or, adding one of Hollywood's most decorated multihyphenates to its top lifetime-honor roll ahead of this year's festival program.",
+    "author": "Camille Vega",
+    "author_id": "camille-vega",
+    "author_display_name": "Camille Vega",
+    "date": "2026-05-08T14:17:22Z",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "title": "Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
     "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
     "link": "/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p/",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "category": "arts-entertainment",
     "permalink": "/articles/cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/473"
   },
   {
     "title": "Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",


### PR DESCRIPTION
## Summary
Adds one arts-entertainment article on Cannes awarding Barbra Streisand an honorary Palme d'Or.

## Claim matrix (off-record)
1. Cannes will award Streisand an honorary Palme d'Or.
   - Source: Reuters wire item via Google News link
2. The item is a festival honors announcement (not a competition award result).
   - Source: Reuters phrasing + Cannes official site context
3. Coverage angle belongs to arts-entertainment desk.
   - Source: film-festival honors/newsworthiness criteria

## Source discovery and bias-check log (off-record)
- Discovery path: Google News RSS for Reuters entertainment queries.
- Bias check: used wire framing and limited claims to announced honor; excluded speculative biographical claims not present in wire.
- Safety check: no defamation-sensitive allegations; pure event announcement.

## Editorial rationale (off-record)
- Chosen because it is a current festival development with clear desk fit and broad reader interest.

## Internal process notes (off-record)
- Image generation attempted with gpt-image-1; fallback applied if unavailable.
