### PR TITLE
David Attenborough turns 100 as tributes highlight his cultural reach (arts-entertainment)

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach",
+    "title": "David Attenborough turns 100 as tributes highlight his cultural reach",
+    "summary": "Broadcasters, cultural institutions and public figures marked David Attenborough’s 100th birthday, underscoring the natural-history presenter’s enduring influence across television and environmental storytelling.",
+    "author": "Camille Vega",
+    "author_id": "camille-vega",
+    "author_display_name": "Camille Vega",
+    "date": "2026-05-08T15:19:15Z",
+    "subject": "arts-entertainment",
+    "category": "arts-entertainment",
+    "permalink": "/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or",
     "title": "Cannes Film Festival will award Barbra Streisand honorary Palme d'Or",
     "summary": "Cannes said Barbra Streisand will receive an honorary Palme d'Or, adding one of Hollywood's most decorated multihyphenates to its top lifetime-honor roll ahead of this year's festival program.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "category": "arts-entertainment",
     "permalink": "/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/474"
   },
   {
     "id": "cannes-film-festival-will-award-barbra-streisand-honorary-palme-d-or",

--- a/content/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach.md
+++ b/content/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach.md
@@ -5,7 +5,7 @@ author: "Camille Vega"
 desk: "arts-entertainment"
 summary: "Broadcasters, cultural institutions and public figures marked David Attenborough’s 100th birthday, underscoring the natural-history presenter’s enduring influence across television and environmental storytelling."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/474"
 permalink: "/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach/"
 ---
 

--- a/content/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach.md
+++ b/content/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach.md
@@ -1,0 +1,22 @@
+---
+title: "David Attenborough turns 100 as tributes highlight his cultural reach"
+date: "2026-05-08"
+author: "Camille Vega"
+desk: "arts-entertainment"
+summary: "Broadcasters, cultural institutions and public figures marked David Attenborough’s 100th birthday, underscoring the natural-history presenter’s enduring influence across television and environmental storytelling."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+permalink: "/articles/david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach/"
+---
+
+Broadcasters and cultural outlets marked David Attenborough’s 100th birthday on Friday, with new tributes emphasizing his decades-long role in shaping natural-history television for global audiences.
+
+BBC coverage said Britain’s King Charles III and Queen Camilla were among those publicly honoring Attenborough’s centenary, while retrospective programming and commentary highlighted the presenter’s long run of landmark wildlife documentaries.
+
+A Guardian centenary feature also revisited major moments from Attenborough’s screen career, reflecting how his work has spanned generations of viewers and remained central to public conversations about biodiversity and the natural world.
+
+Together, the tributes point to a rare level of cultural longevity: Attenborough’s on-screen authority has persisted from early broadcast-era factual television through streaming-era nature franchises.
+
+Sources:
+- https://www.bbc.com/news/articles/cp3pww9g0p5o
+- https://www.theguardian.com/tv-and-radio/ng-interactive/2026/may/08/david-attenborough-100-most-spectacular-screen-moments


### PR DESCRIPTION
## Summary
Adds one arts-and-entertainment desk article on tributes marking David Attenborough’s 100th birthday.

## Off-record: Claim matrix
1. Claim: Public tributes marked Attenborough’s 100th birthday on 8 May 2026.  
   - Source A: BBC article (cp3pww9g0p5o)  
   - Source B: Guardian centenary feature  
2. Claim: UK King and Queen were among those paying tribute.  
   - Source A: BBC report title/body  
3. Claim: Coverage emphasized Attenborough’s enduring cross-generational TV influence.  
   - Source A: BBC framing  
   - Source B: Guardian retrospective framing

## Off-record: Source discovery and bias-check log
- Desk-constrained discovery run across BBC Entertainment & Arts RSS, Guardian Culture RSS, NYT Arts RSS.
- Rejected cross-desk items (US politics, evergreen explainers, and pure reviews lacking event trigger).
- Chosen event is time-bounded (centenary day tributes) and clearly arts-entertainment.
- Bias controls: attributed evaluative framing to publications; avoided unverifiable superlatives.

## Off-record: Editorial rationale and safety checks
- Topic fit: arts-entertainment profile/documentary legacy and media reaction.
- No medical, legal, or financial advice content.
- No graphic/sensitive material.
- Article body contains only publishable content (no internal checklist/process text).
