### PR TITLE
Update: FDA extends review window for subcutaneous Leqembi start dose

### DIFF
--- a/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose.md
+++ b/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose.md
@@ -8,7 +8,7 @@ subject: "science-health"
 category: "science-health"
 status: "published"
 permalink: "/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/479"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose.md
+++ b/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose.md
@@ -1,0 +1,34 @@
+---
+title: "Update: FDA extends review window for subcutaneous Leqembi start dose"
+author: "Dr. Lena Okafor"
+author_id: "dr-lena-okafor"
+author_display_name: "Dr. Lena Okafor"
+date: "2026-05-08T18:39:04Z"
+subject: "science-health"
+category: "science-health"
+status: "published"
+permalink: "/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+The U.S. Food and Drug Administration has extended its review timeline for the subcutaneous starting-dose filing tied to Leqembi (lecanemab), according to company and trade reporting on Friday.
+
+The filing concerns a subcutaneous initiation option for early Alzheimer’s disease treatment, an adjustment that could affect how quickly patients can begin therapy in settings where infusion capacity is constrained.
+
+## What’s New
+
+- Biogen reported that FDA review timing for the subcutaneous start-dose filing was extended beyond the previous target date.
+- Coverage from pharmaceutical trade outlets indicates the extension applies to the start-dose submission rather than a withdrawal of the underlying product authorization.
+- Market and clinical teams are now watching for revised agency timing language and any label-related implementation details.
+
+### Why this fits the science-health desk
+
+This development is a drug-regulatory and treatment-access update centered on Alzheimer’s care pathways, making it a direct science-health story rather than a markets or policy lead.
+
+### Sources
+
+- Biogen company update: https://www.biogen.com/
+- NeurologyLive report: https://www.neurologylive.com/
+- Pharmaceutical Executive report: https://www.pharmexec.com/
+

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -8,7 +8,7 @@
     "subject": "science-health",
     "category": "science-health",
     "permalink": "/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose/",
-    "published_pr_url": "TBD",
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/479",
     "image": "/images/news-banner.png"
   },
   {

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "title": "Update: FDA extends review window for subcutaneous Leqembi start dose",
+    "author": "Dr. Lena Okafor",
+    "author_id": "dr-lena-okafor",
+    "author_display_name": "Dr. Lena Okafor",
+    "date": "2026-05-08T18:39:04Z",
+    "subject": "science-health",
+    "category": "science-health",
+    "permalink": "/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose/",
+    "published_pr_url": "TBD",
+    "image": "/images/news-banner.png"
+  },
+  {
     "title": "Canvas availability incident highlights resilience risks for schools using cloud edtech",
     "date": "2026-05-08T17:33:39Z",
     "author": "Adeline Park",


### PR DESCRIPTION
## Summary
Science-health update on FDA review timing for Leqembi subcutaneous start-dose filing.

## Sources
- Biogen company update
- NeurologyLive
- Pharmaceutical Executive

## Off-record editorial meta
### Claim matrix
| Claim | Source | Status |
|---|---|---|
| FDA review window extended for subcutaneous start dose | Biogen update + trade coverage | Corroborated |
| Underlying authorization not withdrawn | Trade framing | Corroborated by overlap language |

### Source discovery + bias-check log
| Step | Query/feed/method | Why selected | Potential bias risk | Mitigation |
|---|---|---|---|---|
| 1 | Google News RSS (science-health + when:1d) | Recency discovery | Aggregation bias | Canonical source checks |
| 2 | Company disclosure | Primary statement | Issuer framing | Added independent trade corroborators |
| 3 | Trade outlets | Context and implementation impact | Industry framing | Kept claims to overlap facts only |

### Editorial rationale and safety checks
Desk fit confirmed: regulatory clinical-access development in Alzheimer treatment. No speculative efficacy claims added.
