### PR TITLE
Science-health: WHO says hepatitis progress is real, but 2030 targets are at risk

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "category": "science-health",
     "permalink": "/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/482"
   },
   {
     "id": "2026-05-08-governor-stein-announces-nc-film-and-entertainment-grant-program-award",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk",
+    "title": "WHO says hepatitis progress is real, but 2030 elimination targets are at risk",
+    "summary": "WHO reports declines in new hepatitis B infections and hepatitis C deaths, but says prevention, diagnosis and treatment must accelerate to hit 2030 elimination goals.",
+    "author": "Dr. Lena Okafor",
+    "author_id": "dr-lena-okafor",
+    "author_display_name": "Dr. Lena Okafor",
+    "date": "2026-05-08T20:46:29Z",
+    "subject": "science-health",
+    "category": "science-health",
+    "permalink": "/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-08-governor-stein-announces-nc-film-and-entertainment-grant-program-award",
     "title": "Governor Stein Announces NC Film and Entertainment Grant Program Awardees",
     "summary": "Governor Stein Announces NC Film and Entertainment Grant Program Awardees. This dispatch summarizes what happened, why it matters for the arts-entertainment desk, and what to watch next.",
@@ -27,7 +41,7 @@
     "date": "2026-05-08T17:33:39Z",
     "author": "Adeline Park",
     "desk": "technology",
-    "summary": "Instructure\u2019s status page shows an active Canvas availability incident affecting some environments, underscoring how outages in core learning platforms can disrupt coursework, exams and campus operations.",
+    "summary": "Instructure’s status page shows an active Canvas availability incident affecting some environments, underscoring how outages in core learning platforms can disrupt coursework, exams and campus operations.",
     "link": "/articles/canvas-availability-incident-highlights-edtech-resilience-risks/",
     "image": "/images/news-banner.png"
   },
@@ -43,7 +57,7 @@
   {
     "id": "david-attenborough-turns-100-as-tributes-highlight-his-cultural-reach",
     "title": "David Attenborough turns 100 as tributes highlight his cultural reach",
-    "summary": "Broadcasters, cultural institutions and public figures marked David Attenborough\u2019s 100th birthday, underscoring the natural-history presenter\u2019s enduring influence across television and environmental storytelling.",
+    "summary": "Broadcasters, cultural institutions and public figures marked David Attenborough’s 100th birthday, underscoring the natural-history presenter’s enduring influence across television and environmental storytelling.",
     "author": "Camille Vega",
     "author_id": "camille-vega",
     "author_display_name": "Camille Vega",
@@ -69,8 +83,8 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/473"
   },
   {
-    "title": "Update: 2026 Lower East Side Film Festival award winners include \u2018Public Access\u2019 and \u2018The Plan\u2019",
-    "summary": "2026 Lower East Side Film Festival award winners include \u2018Public Access\u2019 and \u2018The Plan\u2019&nbsp;&nbsp;Gold Derby",
+    "title": "Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
+    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
     "link": "/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p/",
     "date": "2026-05-08T13:14:01Z",
     "author": "Camille Vega",
@@ -104,7 +118,7 @@
   {
     "id": "update-why-regenerative-farming-is-the-latest-wellness-travel-trend",
     "title": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend",
-    "summary": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend \u2014 key verified developments and why they matter for lifestyle readers.",
+    "summary": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend — key verified developments and why they matter for lifestyle readers.",
     "author": "Nico Laurent",
     "date": "2026-05-08",
     "category": "lifestyle",
@@ -128,7 +142,7 @@
     "date": "2026-05-08",
     "author": "Simone Hart",
     "desk": "opinion-editorials",
-    "summary": "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active\u2014underscoring how fragile crisis stability becomes when military signaling outruns diplomacy.",
+    "summary": "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active—underscoring how fragile crisis stability becomes when military signaling outruns diplomacy.",
     "link": "/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/460"
@@ -148,7 +162,7 @@
     "author": "Adeline Park",
     "category": "technology",
     "date": "2026-05-08T03:33:49Z",
-    "excerpt": "The platform said it would remove end-to-end encrypted messages, a major U\u2011turn by parent company Meta.",
+    "excerpt": "The platform said it would remove end-to-end encrypted messages, a major U‑turn by parent company Meta.",
     "image": "/images/news-banner.png",
     "path": "/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms/"
   },
@@ -166,7 +180,7 @@
     "date": "2026-05-08",
     "desk": "business-economy",
     "author": "Priya Desai",
-    "summary": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar \u2014 latest verified development for the business-economy desk.",
+    "summary": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar — latest verified development for the business-economy desk.",
     "link": "/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/456"
@@ -176,7 +190,7 @@
     "date": "2026-05-08",
     "desk": "sports",
     "author": "Jordan Reeves",
-    "summary": "2025/26 Champions League: All the fixtures and results - UEFA.com \u2014 latest verified development for the sports desk.",
+    "summary": "2025/26 Champions League: All the fixtures and results - UEFA.com — latest verified development for the sports desk.",
     "link": "/articles/2026-05-08-2025-26-champions-league-all-the-fixtures-and-results-uefa-com/",
     "image": "/images/news-banner.png"
   },
@@ -329,13 +343,13 @@
     "date": "2026-05-07",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "A Bon App\u00e9tit report spotlights how Riviera Nayarit\u2019s Rosewood Mandarina is centering local sourcing and agave-led beverage culture in luxury travel experiences.",
+    "summary": "A Bon Appétit report spotlights how Riviera Nayarit’s Rosewood Mandarina is centering local sourcing and agave-led beverage culture in luxury travel experiences.",
     "link": "/articles/sun-sand-and-spirits-in-mexicos-riviera-nayarit/",
     "image": "/images/news-banner.png"
   },
   {
-    "title": "Why Google, Microsoft and xAI\u2019s U.S. AI deal matters",
-    "summary": "Why Google, Microsoft and xAI\u2019s U.S. AI deal matters. This is a developing technology story with details still emerging.",
+    "title": "Why Google, Microsoft and xAI’s U.S. AI deal matters",
+    "summary": "Why Google, Microsoft and xAI’s U.S. AI deal matters. This is a developing technology story with details still emerging.",
     "link": "/articles/why-google-microsoft-and-xai-s-u-s-ai-deal-matters/",
     "image": "/images/news-banner.png",
     "date": "2026-05-07",
@@ -343,7 +357,7 @@
   },
   {
     "id": "2026-05-07-melissa-barrera-questions-scream-7-box-office-claims",
-    "title": "Melissa Barrera Questions \u2018Scream 7\u2019 Box-Office Claims After Exit From Franchise",
+    "title": "Melissa Barrera Questions ‘Scream 7’ Box-Office Claims After Exit From Franchise",
     "summary": "The actor says she doubts widely cited claims about Scream 7 performance, highlighting ongoing debate over franchise-era box-office narratives.",
     "author": "Camille Vega",
     "date": "2026-05-07",
@@ -377,7 +391,7 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "TikTok Has Discovered Tae Bo, the Beloved \u201990s Workout",
+    "title": "TikTok Has Discovered Tae Bo, the Beloved ’90s Workout",
     "slug": "tiktok-has-discovered-tae-bo-the-beloved-90s-workout",
     "date": "2026-05-07",
     "author": "Nico Laurent",
@@ -388,7 +402,7 @@
   },
   {
     "id": "2026-05-07-nba-stars-playing-in-europe-instead-of-u-s-that-s-what-soccer-giants-want",
-    "title": "NBA stars playing in Europe instead of U.S.? That\u2019s what soccer giants want",
+    "title": "NBA stars playing in Europe instead of U.S.? That’s what soccer giants want",
     "permalink": "/2026-05-07/nba-stars-playing-in-europe-instead-of-u-s-that-s-what-soccer-giants-want",
     "date": "2026-05-07",
     "author_id": "sports_lead",
@@ -418,8 +432,8 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "Does This Feel Like a \u2018Catholic Moment\u2019?",
-    "summary": "Readers respond to an Opinion guest essay by Christine Emba about a possible Catholic revival. Also: A woman\u2019s face.",
+    "title": "Does This Feel Like a ‘Catholic Moment’?",
+    "summary": "Readers respond to an Opinion guest essay by Christine Emba about a possible Catholic revival. Also: A woman’s face.",
     "link": "/articles/2026-05-06-does-this-feel-like-a-catholic-moment/",
     "date": "2026-05-06",
     "author": "Simone Hart",
@@ -444,7 +458,7 @@
     "date": "2026-05-06",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "Guests at the Met Gala had different interpretations of the night\u2019s dress code.",
+    "summary": "Guests at the Met Gala had different interpretations of the night’s dress code.",
     "link": "/articles/was-it-art-was-it-fashion-was-it-good/",
     "image": "/images/news-banner.png"
   },
@@ -478,9 +492,9 @@
   },
   {
     "id": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
-    "title": "Darren Aronofsky to receive Locarno Film Festival\u2019s Pardo d\u2019Onore award",
+    "title": "Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award",
     "slug": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
-    "summary": "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d\u2019Onore award, signaling a high-profile addition to this year\u2019s festival lineup.",
+    "summary": "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d’Onore award, signaling a high-profile addition to this year’s festival lineup.",
     "author": "Camille Vega",
     "date": "2026-05-06T11:56:26Z",
     "subject": "arts-entertainment",
@@ -490,7 +504,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/411"
   },
   {
-    "title": "Labour\u2019s nationwide collapse risks making Nigel Farage the face of the UK\u2019s fragile union",
+    "title": "Labour’s nationwide collapse risks making Nigel Farage the face of the UK’s fragile union",
     "date": "2026-05-06",
     "author": "Simone Hart",
     "desk": "opinion-editorials",
@@ -591,8 +605,8 @@
   },
   {
     "id": "apple-reaches-250mn-settlement-over-delayed-ai-siri-financial-times",
-    "title": "Apple reaches $250mn settlement over delayed \u2018AI Siri\u2019 - Financial Times",
-    "summary": "Apple reaches $250mn settlement over delayed \u2018AI Siri\u2019&nbsp;&nbsp;Financial TimesApple Reaches $250 Million Settlement Over Claims It Misled People on A.I.&nbsp;&nbsp;The New York TimesApple settles lawsuit over late Sir",
+    "title": "Apple reaches $250mn settlement over delayed ‘AI Siri’ - Financial Times",
+    "summary": "Apple reaches $250mn settlement over delayed ‘AI Siri’&nbsp;&nbsp;Financial TimesApple Reaches $250 Million Settlement Over Claims It Misled People on A.I.&nbsp;&nbsp;The New York TimesApple settles lawsuit over late Sir",
     "author": "Adeline Park",
     "date": "2026-05-05T23:15:15Z",
     "subject": "technology",
@@ -605,7 +619,7 @@
     "title": "What to Expect in Markets This Week: Big Bank Earnings, December Inflation Data, Retail Sales, TSMC Earnings",
     "author": "Priya Desai",
     "desk": "business-economy",
-    "summary": "What to Expect in Markets This Week: Big Bank Earnings, December Inflation Data, Retail Sales, TSMC Earnings. Here\u2019s what happened, why it matters, and what to watch next.",
+    "summary": "What to Expect in Markets This Week: Big Bank Earnings, December Inflation Data, Retail Sales, TSMC Earnings. Here’s what happened, why it matters, and what to watch next.",
     "link": "/articles/2026-05-05-what-to-expect-in-markets-this-week-big-bank-earnings-december-inflati/",
     "image": "/images/news-banner.png",
     "date": "2026-05-05T22:11:00Z"
@@ -640,9 +654,9 @@
   },
   {
     "id": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
-    "title": "2026 Lower East Side Film Festival award winners include \u2018Public Access\u2019 and \u2018The Plan\u2019",
+    "title": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
     "slug": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
-    "summary": "2026 Lower East Side Film Festival award winners include \u2018Public Access\u2019 and \u2018The Plan\u2019&nbsp;&nbsp;Gold Derby",
+    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
     "author": "Camille Vega",
     "date": "2026-05-05",
     "subject": "arts-entertainment",
@@ -704,7 +718,7 @@
   {
     "id": "white-house-news-latest-updates-and-video-on-us-politics-and-government",
     "title": "White House News: Latest Updates and Video on U.S. Politics and Government",
-    "summary": "White House News: Latest Updates and Video on U.S. Politics and Government \u2014 key verified developments and why they matter for the news politics desk.",
+    "summary": "White House News: Latest Updates and Video on U.S. Politics and Government — key verified developments and why they matter for the news politics desk.",
     "author": "Maya Sterling",
     "date": "2026-05-05T11:31:47Z",
     "category": "news-politics",
@@ -715,8 +729,8 @@
   },
   {
     "id": "market-expert-says-potential-fed-rate-cuts-could-spark-one-of-the-biggest-explosions-in-us",
-    "title": "Market expert says potential Fed rate cuts could spark \u2018one of the biggest explosions\u2019 in US economy",
-    "summary": "Priya Desai reports on Market expert says potential Fed rate cuts could spark \u2018one of the biggest explosions\u2019 in US economy and why it matters for the business economy desk.",
+    "title": "Market expert says potential Fed rate cuts could spark ‘one of the biggest explosions’ in US economy",
+    "summary": "Priya Desai reports on Market expert says potential Fed rate cuts could spark ‘one of the biggest explosions’ in US economy and why it matters for the business economy desk.",
     "author": "Priya Desai",
     "date": "2026-05-05T09:27:05Z",
     "category": "business-economy",
@@ -738,7 +752,7 @@
   {
     "id": "towards-a-people-centered-regulatory-democracy",
     "title": "Towards a People-centered Regulatory Democracy",
-    "summary": "Towards a People-centered Regulatory Democracy \u2014 latest confirmed developments and what to watch next.",
+    "summary": "Towards a People-centered Regulatory Democracy — latest confirmed developments and what to watch next.",
     "author": "Simone Hart",
     "date": "2026-05-05",
     "subject": "opinion-editorials",
@@ -762,8 +776,8 @@
   },
   {
     "id": "2026-05-05-disabled-people-are-being-abandoned-by-the-g-o-p",
-    "title": "Opinion: Disabled Americans and the GOP\u2019s Policy Crossroads",
-    "summary": "A new New York Times opinion essay argues Republicans have moved away from an older bipartisan disability-rights posture, using George H.W. Bush\u2019s legacy as a benchmark for what policy support once looked like.",
+    "title": "Opinion: Disabled Americans and the GOP’s Policy Crossroads",
+    "summary": "A new New York Times opinion essay argues Republicans have moved away from an older bipartisan disability-rights posture, using George H.W. Bush’s legacy as a benchmark for what policy support once looked like.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -854,7 +868,7 @@
   },
   {
     "id": "2026-05-04-openai-google-and-microsoft-back-bill-to-fund-ai-literacy-in-schools",
-    "title": "OpenAI, Google, and Microsoft Back Bill to Fund \u2018AI Literacy\u2019 in Schools",
+    "title": "OpenAI, Google, and Microsoft Back Bill to Fund ‘AI Literacy’ in Schools",
     "permalink": "/articles/2026-05-04-openai-google-and-microsoft-back-bill-to-fund-ai-literacy-in-schools",
     "date": "2026-05-04",
     "author_id": "technology_lead",
@@ -877,7 +891,7 @@
     "title": "UK joining Ukraine loan scheme would be good for EU ties, Starmer says",
     "author": "Maya Sterling",
     "date": "2026-05-04",
-    "summary": "The UK is \"discussing participating\" in a \u00a378bn (\u20ac90bn) European Union loan scheme to support Ukraine, the prime minister says.",
+    "summary": "The UK is \"discussing participating\" in a £78bn (€90bn) European Union loan scheme to support Ukraine, the prime minister says.",
     "link": "/articles/2026-05-04-uk-joining-ukraine-loan-scheme-would-be-good-for-eu-ties-starmer-says/",
     "image": "/images/news-banner.png",
     "desk": "news-politics"
@@ -885,7 +899,7 @@
   {
     "id": "2026-05-04-what-champions-league-failure-means-for-broken-club-chelsea",
     "title": "What Champions League failure means for 'broken club' Chelsea",
-    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far\u2011reaching consequences.",
+    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far‑reaching consequences.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -938,7 +952,7 @@
   {
     "slug": "2026-05-04-irish-actor-and-banshees-of-inisherin-star-gary-lydon-dies-aged-61",
     "title": "Irish actor and Banshees of Inisherin star Gary Lydon dies aged 61",
-    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland\u2019s film and television community.",
+    "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland’s film and television community.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -947,8 +961,8 @@
   },
   {
     "slug": "2026-05-04-how-7-looks-for-the-devil-wears-prada-2-came-together",
-    "title": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together",
-    "description": "How 7 Looks for \u2018The Devil Wears Prada 2\u2019 Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
+    "title": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together",
+    "description": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
     "author": "Camille Vega",
     "desk": "arts-entertainment",
     "date": "2026-05-04",
@@ -1012,7 +1026,7 @@
   {
     "id": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
     "slug": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
-    "title": "The \u2018Devil Wears Prada 2\u2019 Costume Rollout Fuels a New Fashion-Marketing Playbook",
+    "title": "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook",
     "summary": "Early wardrobe reveals for The Devil Wears Prada 2 are being treated as headline entertainment and fashion moments, signaling a broader shift in how sequel campaigns are packaged across media.",
     "date": "2026-05-04T01:00:00Z",
     "subject": "arts-entertainment",
@@ -1122,7 +1136,7 @@
     "id": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "slug": "2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance",
     "title": "Update: COP31 hosting deal tests whether climate diplomacy can outrun energy-security politics",
-    "summary": "Turkey\u2019s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
+    "summary": "Turkey’s confirmation as COP31 host, with Australia in a larger negotiating role, shifts the climate debate from bid politics to whether implementation design can survive security-era pressures.",
     "date": "2026-05-03T15:39:52Z",
     "subject": "opinion-editorials",
     "category": "opinion-editorials",
@@ -1149,7 +1163,7 @@
     "date": "2026-05-03",
     "author": "Nico Laurent",
     "desk": "lifestyle",
-    "summary": "For five years, our column has attempted to settle rows about the important little things \u2026 but what happens after the verdicts are in?Since 2021, I\u2019ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
+    "summary": "For five years, our column has attempted to settle rows about the important little things … but what happens after the verdicts are in?Since 2021, I’ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
     "link": "/articles/from-shared-toothbrushes-to-mid-sex-water-bladders-you-be-the-judge-tries-to-settle-domest/",
     "image": "/images/news-banner.png"
   },
@@ -1444,8 +1458,8 @@
   {
     "id": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
     "slug": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
-    "title": "Greens pledge \u00a315 minimum wage for all workers",
-    "summary": "The Green Party says it would raise the minimum wage to \u00a315 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
+    "title": "Greens pledge £15 minimum wage for all workers",
+    "summary": "The Green Party says it would raise the minimum wage to £15 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
     "date": "2026-05-02T07:50:30Z",
     "subject": "news-politics",
     "category": "news-politics",
@@ -1557,8 +1571,8 @@
   },
   {
     "id": "2026-05-01-world-s-largest-study-of-women-s-health-marks-30-years-of-pioneering-research-ndph-ox-ac-u",
-    "title": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk",
-    "summary": "World\u2019s largest study of women\u2019s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
+    "title": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk",
+    "summary": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
     "date": "2026-05-01T21:04:46Z",
     "subject": "science-health",
     "category": "science-health",
@@ -1585,8 +1599,8 @@
   },
   {
     "id": "2026-05-01-dprk-korea-continued-militarisation-a-serious-concern-political-affairs-chief-warns-security-counci",
-    "title": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News",
-    "summary": "DPRK Korea: Continued militarisation a \u2018serious concern\u2019, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
+    "title": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News",
+    "summary": "DPRK Korea: Continued militarisation a ‘serious concern’, political affairs chief warns Security Council - UN News is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the world desk.",
     "date": "2026-05-01T17:54:11Z",
     "subject": "world",
     "category": "world",
@@ -1600,7 +1614,7 @@
   {
     "id": "2026-05-01-update-pentagon-expands-classified-ai-contracts",
     "title": "Update: Pentagon expands classified AI contracts to multiple cloud and model vendors",
-    "summary": "New reporting indicates the Pentagon\u2019s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
+    "summary": "New reporting indicates the Pentagon’s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
     "date": "2026-05-01T16:46:26Z",
     "subject": "technology",
     "category": "technology",
@@ -1684,7 +1698,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/260"
   },
   {
-    "title": "Microsoft\u2019s AI Growth Signals Big Upside Ahead",
+    "title": "Microsoft’s AI Growth Signals Big Upside Ahead",
     "date": "2026-05-01",
     "author": "Adeline Park",
     "desk": "technology",
@@ -1745,13 +1759,13 @@
   },
   {
     "id": "governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating",
-    "title": "Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
+    "title": "Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil, Colombia, and Chile",
     "permalink": "/articles/governor-newsom-expands-california-s-global-climate-leadership-at-cop30-creating/",
     "date": "2026-04-30",
     "author": "Rowan Hale",
     "category": "environment",
     "image": "/images/news-banner.png",
-    "excerpt": "Latest verified developments on Governor Newsom expands California\u2019s global climate leadership at COP30, creating new partnerships with Brazil"
+    "excerpt": "Latest verified developments on Governor Newsom expands California’s global climate leadership at COP30, creating new partnerships with Brazil"
   },
   {
     "id": "2026-04-30-protecting-lions-and-people-the-biologist-dedicated-to-tackling-human-wildlife-conflict",
@@ -1860,8 +1874,8 @@
   },
   {
     "id": "2026-04-30-what-s-at-stake-for-elections-at-the-supreme-court",
-    "title": "What\u2019s at Stake for Elections at the Supreme Court",
-    "summary": "What\u2019s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
+    "title": "What’s at Stake for Elections at the Supreme Court",
+    "summary": "What’s at Stake for Elections at the Supreme Court has emerged as a key development on the news-politics desk, based on current reporting from Voting Rights Lab.",
     "author": "Maya Sterling",
     "author_id": "maya-sterling",
     "author_display_name": "Maya Sterling",
@@ -1896,7 +1910,7 @@
   {
     "id": "2026-04-29-senate-rejects-curb-on-trump-military-action-in-cuba-axios",
     "title": "Senate rejects curb on Trump military action in Cuba - Axios",
-    "summary": "Senate rejects curb on Trump military action in Cuba - Axios \u2014 key confirmed developments and what they mean for news-politics.",
+    "summary": "Senate rejects curb on Trump military action in Cuba - Axios — key confirmed developments and what they mean for news-politics.",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
     "author_display_name": "Maya Sterling",
@@ -1963,7 +1977,7 @@
   },
   {
     "id": "trump-s-war-global-justice-court-staff-u-n-face",
-    "title": "In Trump\u2019s war on global justice, court staff and U.N. face terrorist\u2011grade sanctions - Reuters",
+    "title": "In Trump’s war on global justice, court staff and U.N. face terrorist‑grade sanctions - Reuters",
     "author": "Elias Navarro",
     "date": "2026-04-29",
     "category": "world",
@@ -1973,7 +1987,7 @@
   {
     "id": "2026-04-29-top-transfer-qb-brendan-sorsby-taking-leave-of-absence-from-texas-tech-for-gambling-the-athletic",
     "title": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic",
-    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic \u2014 key confirmed developments and what they mean for sports.",
+    "summary": "Top transfer QB Brendan Sorsby taking leave of absence from Texas Tech for gambling - The Athletic — key confirmed developments and what they mean for sports.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -2010,8 +2024,8 @@
   },
   {
     "id": "2026-04-29-over-half-of-south-sudan-s-population-faces-acute-hunger-crisis-un-news",
-    "title": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
-    "summary": "Over half of South Sudan\u2019s population faces acute hunger crisis - UN News",
+    "title": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
+    "summary": "Over half of South Sudan’s population faces acute hunger crisis - UN News",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -2063,7 +2077,7 @@
   {
     "id": "2026-04-28-southern-china-torrential-rain-flooding-fears",
     "title": "Southern China Braces for Flood Risk as Torrential Rainfall Intensifies",
-    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150\u2013200mm.",
+    "summary": "Torrential rain across southern China has raised flood concerns, with localized precipitation potentially reaching 150–200mm.",
     "author": "Rowan Hale",
     "author_id": "environment_lead",
     "author_display_name": "Rowan Hale",
@@ -2097,7 +2111,7 @@
   },
   {
     "id": "2026-04-28-opinion-russia-internet-blackouts-legitimacy-cost",
-    "title": "Opinion: Russia\u2019s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
+    "title": "Opinion: Russia’s Internet Blackouts Risk Trading Wartime Control for Long-Term Legitimacy Loss",
     "summary": "An opinion-editorial arguing that broad wartime internet shutdowns can erode state legitimacy faster than they secure it.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -2173,7 +2187,7 @@
   },
   {
     "id": "2026-04-28-opinion-america-immigration-edge-welcoming-talent-safeguarding-legitimacy",
-    "title": "Opinion: America\u2019s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
+    "title": "Opinion: America’s Immigration Edge Depends on Welcoming Talent and Safeguarding Legitimacy",
     "summary": "An opinion-editorial arguing that durable U.S. immigration policy must pair lawful-entry capacity with accountable enforcement.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
@@ -2244,8 +2258,8 @@
   },
   {
     "id": "2026-04-28-summer-movie-guide-2026-theatrical-and-streaming-slate",
-    "title": "Summer Movie Guide 2026: What\u2019s Coming to Theaters and Streaming From May Through August",
-    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios\u2019 peak-season strategy.",
+    "title": "Summer Movie Guide 2026: What’s Coming to Theaters and Streaming From May Through August",
+    "summary": "AP reports a packed 2026 summer film slate across theaters and streaming, with franchise bets and family titles driving studios’ peak-season strategy.",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
     "author_display_name": "Camille Vega",
@@ -2257,8 +2271,8 @@
   },
   {
     "id": "2026-04-28-south-korea-court-expands-convictions-around-yoon-circle",
-    "title": "South Korean Court Expands Convictions Around Ousted President Yoon\u2019s Inner Circle",
-    "summary": "South Korean courts expanded convictions across former President Yoon\u2019s inner circle, with new sentencing moves affecting both family and leadership figures.",
+    "title": "South Korean Court Expands Convictions Around Ousted President Yoon’s Inner Circle",
+    "summary": "South Korean courts expanded convictions across former President Yoon’s inner circle, with new sentencing moves affecting both family and leadership figures.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
     "author_display_name": "Elias Navarro",
@@ -2330,7 +2344,7 @@
   },
   {
     "id": "wellness-retreats-on-mexico-s-yucat-n-peninsula-connect-with-cultural-traditions",
-    "title": "Wellness retreats on Mexico\u2019s Yucat\u00e1n Peninsula connect with cultural traditions",
+    "title": "Wellness retreats on Mexico’s Yucatán Peninsula connect with cultural traditions",
     "author": "Nico Laurent",
     "date": "2026-04-28T12:55:43Z",
     "category": "lifestyle",
@@ -2339,7 +2353,7 @@
   },
   {
     "id": "my-tenant-owes-15000-in-rent-but-i-cant-get-them-out-of-the-property-20260428",
-    "title": "My tenant owes \u00a315,000 in rent, but I can't get them out of the property",
+    "title": "My tenant owes £15,000 in rent, but I can't get them out of the property",
     "description": "Landlords tell BBC News why they fear new laws could make it harder to remove problematic tenants.",
     "author": "Priya Desai",
     "date": "2026-04-28T05:37:45Z",
@@ -2402,7 +2416,7 @@
   {
     "id": "2026-04-24-opinion-powell-probe-fed-independence-guardrails",
     "title": "Opinion: Ending the Powell Probe Should Trigger Harder Guardrails for Fed Independence",
-    "summary": "The DOJ\u2019s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
+    "summary": "The DOJ’s reported decision to end its Powell probe may close a headline cycle, but it underscores a deeper institutional question: how to preserve scrutiny without normalizing political pressure on monetary authorities.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -2454,7 +2468,7 @@
   {
     "id": "2026-04-24-alcaraz-misses-french-open-title-defense-wrist-injury",
     "title": "Carlos Alcaraz to Miss French Open, Ending Bid for Third Straight Title",
-    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men\u2019s draw and reshaping the tournament outlook.",
+    "summary": "Carlos Alcaraz said he will miss the French Open because of a wrist injury, removing the two-time defending champion from the men’s draw and reshaping the tournament outlook.",
     "author": "Jordan Reeves",
     "author_id": "sports_lead",
     "author_display_name": "Jordan Reeves",
@@ -2466,7 +2480,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90b-euro-ukraine-loan-after-hungary-veto-lifted",
-    "title": "EU Approves \u20ac90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
+    "title": "EU Approves €90B ($106B) Ukraine Loan Package After Hungary Veto Standoff Ends",
     "summary": "The EU approved a 90-billion-euro ($106B) two-year Ukraine package after a Hungary-linked standoff eased, re-opening a key wartime financing channel for Kyiv.",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -2578,7 +2592,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/",
-    "summary": "Update coverage adds Reuters-reported detail that DeepSeek\u2019s latest model preview is adapted for Huawei chips, sharpening the story\u2019s infrastructure and ecosystem implications.",
+    "summary": "Update coverage adds Reuters-reported detail that DeepSeek’s latest model preview is adapted for Huawei chips, sharpening the story’s infrastructure and ecosystem implications.",
     "image": "/images/articles/update-deepseek-huawei-chip-optimized-ai-model-preview.png"
   },
   {
@@ -2591,7 +2605,7 @@
     "subject": "arts-entertainment",
     "category": "arts-entertainment",
     "permalink": "/articles/2026-04-24-update-devil-wears-prada-2-asia-backlash-milan-rollout/",
-    "summary": "New coverage links the sequel\u2019s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
+    "summary": "New coverage links the sequel’s Milan-centered launch narrative with Asia-facing backlash over character portrayal, highlighting global-release sensitivity for entertainment franchises.",
     "image": "/images/articles/update-devil-wears-prada-2-asia-backlash-milan-rollout.png"
   },
   {
@@ -2630,7 +2644,7 @@
     "subject": "environment",
     "category": "environment",
     "permalink": "/articles/2026-04-24-france-drops-climate-from-g7-environment-talks/",
-    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqu\u00e9s.",
+    "summary": "France removed explicit climate language from a G7 environment-track agenda to avoid a direct clash with the U.S., raising uncertainty over how strongly climate commitments will appear in final communiqués.",
     "image": "/images/articles/france-drops-climate-from-g7-environment-talks.png"
   },
   {
@@ -2656,7 +2670,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-meta-aws-graviton-deployment-agentic-ai-workloads/",
-    "summary": "Meta\u2019s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
+    "summary": "Meta’s reported AWS Graviton agreement for agentic AI workloads highlights a potential shift toward CPU-heavy AI infrastructure strategies alongside existing GPU-centric expansion.",
     "image": "/images/articles/meta-aws-graviton-deployment-agentic-ai-workloads.png"
   },
   {
@@ -2674,7 +2688,7 @@
   },
   {
     "id": "2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model",
-    "title": "China\u2019s DeepSeek says releases long-awaited new AI model",
+    "title": "China’s DeepSeek says releases long-awaited new AI model",
     "date": "2026-04-24",
     "author": "Adeline Park",
     "author_id": "technology_lead",
@@ -2682,7 +2696,7 @@
     "subject": "technology",
     "category": "technology",
     "permalink": "/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/",
-    "summary": "China\u2019s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China\u2019s fast-moving model race.",
+    "summary": "China’s DeepSeek has released a preview of its long-awaited V4 AI model, with multiple outlets describing the launch as a potentially lower-cost step-up in China’s fast-moving model race.",
     "image": "/images/news-banner.png"
   },
   {
@@ -2700,7 +2714,7 @@
   },
   {
     "id": "2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels",
-    "title": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
+    "title": "Condé Nast Traveler’s 2026 Hot List Spotlights Wellness Hotels as Global Travel Spending Climbs",
     "date": "2026-04-24",
     "author": "Nico Laurent",
     "author_id": "lifestyle_lead",
@@ -2708,7 +2722,7 @@
     "subject": "lifestyle",
     "category": "lifestyle",
     "permalink": "/articles/2026-04-24-conde-nast-traveler-2026-hot-list-wellness-hotels/",
-    "summary": "Cond\u00e9 Nast Traveler\u2019s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
+    "summary": "Condé Nast Traveler’s 2026 Hot List package puts wellness hotels in a lead editorial lane, as broader travel and wellness spending data point to continued demand for experience-led trips.",
     "image": "/images/articles/conde-nast-traveler-2026-hot-list-wellness-hotels.png"
   },
   {
@@ -2799,7 +2813,7 @@
     "subject": "sports",
     "category": "sports",
     "permalink": "/articles/2026-04-24-world-cup-final-resale-listings-top-2m-ticket-scrutiny/",
-    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA\u2019s platform, as broader pricing and access scrutiny intensifies.",
+    "summary": "Resale listings for the 2026 FIFA World Cup final reached about $2.3 million per ticket on FIFA’s platform, as broader pricing and access scrutiny intensifies.",
     "image": "/images/news-banner.png"
   },
   {
@@ -2878,7 +2892,7 @@
     "permalink": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "path": "/articles/2026-04-24-the-international-right-has-cpac-has-the-left-finally-found-its-answer/",
     "image": "/images/articles/the-international-right-has-cpac-has-the-left-finally-found-its-answer.png",
-    "excerpt": "Spain\u2019s PM, Pedro S\u00e1nchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
+    "excerpt": "Spain’s PM, Pedro Sánchez, hosted the inaugural meeting of the Global Progressive Mobilisation. Keir Starmer and other social democrats were notable by their absenceCan progressives push back the rising tide of author..."
   },
   {
     "id": "2026-04-24-nfl-draft-day-1-first-round-recap-2026",
@@ -2921,7 +2935,7 @@
   },
   {
     "id": "2026-04-24-summer-house-season-10-reunion-no-separate-interviews",
-    "title": "Bravo\u2019s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
+    "title": "Bravo’s Summer House Reunion Keeps Single-Stage Format, Skips Separate Andy Cohen Interviews",
     "date": "2026-04-24",
     "author": "Camille Vega",
     "author_id": "arts_entertainment_lead",
@@ -2960,7 +2974,7 @@
   },
   {
     "id": "2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions",
-    "title": "EU Formally Approves \u20ac90 Billion Ukraine Loan and New Russia Sanctions",
+    "title": "EU Formally Approves €90 Billion Ukraine Loan and New Russia Sanctions",
     "date": "2026-04-24",
     "author": "Elias Navarro",
     "author_id": "world_lead",
@@ -2968,7 +2982,7 @@
     "subject": "world",
     "category": "world",
     "permalink": "/articles/2026-04-24-eu-approves-90bn-ukraine-loan-russia-sanctions/",
-    "summary": "EU institutions finalized a \u20ac90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
+    "summary": "EU institutions finalized a €90 billion support-loan framework for Ukraine and advanced a fresh sanctions package against Russia, according to cross-outlet reporting.",
     "image": "/images/articles/eu-approves-90bn-ukraine-loan-russia-sanctions.png"
   },
   {
@@ -3012,7 +3026,7 @@
   },
   {
     "id": "2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama",
-    "title": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?",
+    "title": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?",
     "date": "2026-04-23",
     "author": "Maya Sterling",
     "author_id": "news_politics_lead",
@@ -3020,7 +3034,7 @@
     "subject": "news-politics",
     "category": "news-politics",
     "permalink": "/articles/2026-04-23-us-senate-passes-ice-funding-resolution-after-vote-a-rama/",
-    "summary": "US Senate passes ICE funding resolution after \u2018vote-a-rama\u2019: What\u2019s next?&nbsp;&nbsp;Al Jazeera",
+    "summary": "US Senate passes ICE funding resolution after ‘vote-a-rama’: What’s next?&nbsp;&nbsp;Al Jazeera",
     "image": "/images/news-banner.png"
   },
   {
@@ -3257,7 +3271,7 @@
   },
   {
     "title": "Two Trains Collide North of Copenhagen, Leaving Five Critically Injured",
-    "summary": "A head-on train collision near Hiller\u00f8d north of Copenhagen left five people critically injured, with authorities investigating the cause.",
+    "summary": "A head-on train collision near Hillerød north of Copenhagen left five people critically injured, with authorities investigating the cause.",
     "date": "2026-04-23",
     "subject": "world",
     "author_id": "world_lead",
@@ -3410,7 +3424,7 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "WHO\u2019s response to hantavirus cases linked to a cruise ship",
+    "title": "WHO’s response to hantavirus cases linked to a cruise ship",
     "date": "2026-05-08",
     "author": "Dr. Lena Okafor",
     "desk": "science-health",

--- a/content/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk.md
+++ b/content/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk.md
@@ -6,7 +6,7 @@ author: "Dr. Lena Okafor"
 desk: "science-health"
 summary: "WHO reports declines in new hepatitis B infections and hepatitis C deaths, but says prevention, diagnosis and treatment must accelerate to hit 2030 elimination goals."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/482"
 ---
 
 # WHO says hepatitis progress is real, but 2030 elimination targets are at risk

--- a/content/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk.md
+++ b/content/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk.md
@@ -1,0 +1,29 @@
+---
+title: "WHO says hepatitis progress is real, but 2030 elimination targets are at risk"
+slug: "who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk"
+date: "2026-05-08"
+author: "Dr. Lena Okafor"
+desk: "science-health"
+summary: "WHO reports declines in new hepatitis B infections and hepatitis C deaths, but says prevention, diagnosis and treatment must accelerate to hit 2030 elimination goals."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+# WHO says hepatitis progress is real, but 2030 elimination targets are at risk
+
+The World Health Organization said global hepatitis control efforts are delivering measurable gains, while warning the pace is still too slow to meet 2030 elimination targets.
+
+According to WHO's 2026 global update, annual new hepatitis B infections have fallen 32%, and hepatitis C-related deaths are down 12% from baseline trends. But hepatitis B and C still caused about 1.3 million deaths in 2024, and transmission remains active with thousands of new infections each day.
+
+WHO said major gaps remain in diagnosis and treatment coverage. The agency estimated that fewer than 5% of people living with chronic hepatitis B were receiving treatment in 2024, and that hepatitis C treatment uptake remains well below what is needed for elimination.
+
+The report highlights regional disparities, including lower hepatitis B birth-dose vaccination coverage in parts of Africa, and calls for stronger financing, expanded testing, and integration of hepatitis services into primary care.
+
+## Why this matters
+
+The update suggests the world has effective tools, but not yet enough implementation scale. For health systems and donors, the central policy question is no longer whether elimination is possible, but whether countries can close treatment and prevention gaps fast enough to meet the 2030 deadline.
+
+## Sources
+
+- WHO news release (28 May 2026): https://www.who.int/news/item/28-04-2026-efforts-to-eliminate-hepatitis-delivers-gains-but-more-action-needed-to-meet-2030-targets
+- WHO Global Hepatitis Report 2026 (linked by WHO release)


### PR DESCRIPTION
## Summary
Publishes one science-health dispatch on WHO's latest hepatitis elimination progress update and remaining 2030 gap.

## Off-record editorial package
### Claim matrix
1. WHO says hepatitis B new infections declined 32%.
2. WHO says hepatitis C-related deaths declined 12%.
3. WHO says about 1.3 million hepatitis B/C deaths persisted in 2024 and progress is insufficient for 2030 targets.
4. WHO says major treatment coverage gaps remain, including under-5% HBV treatment coverage.

### Source discovery and bias-check log
- Desk fit: science-health (disease burden, prevention, treatment coverage, public-health policy).
- Primary evidence: WHO institutional publication; bias risk is institutional framing.
- Mitigation: attributed framing and no extrapolation beyond cited metrics.

### Editorial rationale and safety checks
- High public-interest health-policy update.
- No medical advice, no personal data, no unverifiable claims.
- Non-sensational policy tone.
