### PR TITLE
TSA PreCheck offers $20 discount for first-time applicants 30 and under through May

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may",
+    "title": "TSA PreCheck offers $20 discount for first-time applicants 30 and under through May",
+    "summary": "TSA launched a limited-time “$20 Take Off” promotion that cuts the cost of new TSA PreCheck enrollment for travelers 30 and under who complete enrollment during May.",
+    "author": "Nico Laurent",
+    "date": "2026-05-08T21:55:27Z",
+    "subject": "lifestyle",
+    "category": "lifestyle",
+    "permalink": "/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk",
     "title": "WHO says hepatitis progress is real, but 2030 elimination targets are at risk",
     "summary": "WHO reports declines in new hepatitis B infections and hepatitis C deaths, but says prevention, diagnosis and treatment must accelerate to hit 2030 elimination goals.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "lifestyle",
     "permalink": "/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/483"
   },
   {
     "id": "who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk",

--- a/content/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may.md
+++ b/content/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may.md
@@ -1,0 +1,28 @@
+---
+title: "TSA PreCheck offers $20 discount for first-time applicants 30 and under through May"
+slug: "tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may"
+date: "2026-05-08"
+author: "Nico Laurent"
+desk: "lifestyle"
+summary: "TSA launched a limited-time “$20 Take Off” promotion that cuts the cost of new TSA PreCheck enrollment for travelers 30 and under who complete enrollment during May."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+# TSA PreCheck offers $20 discount for first-time applicants 30 and under through May
+
+TSA has launched a limited-time promotion that reduces the cost of first-time TSA PreCheck enrollment for younger travelers, a move the agency says is intended to bring more under-30 passengers into expedited screening lanes.
+
+On its official “$20 Take Off” page, TSA says travelers aged 30 and under can receive a $20 discount if they complete a new enrollment during May. The agency says the offer applies through its authorized enrollment providers, including CLEAR, IDEMIA, and Telos, and requires applicants to start online and complete enrollment in person before the deadline.
+
+Condé Nast Traveler reported the promotion runs through May 31 and described it as TSA’s first broad age-based discount for the PreCheck program.
+
+## Why this matters
+
+For frequent travelers, the promotion lowers the upfront cost of joining PreCheck and could increase demand ahead of the summer travel season. For TSA, the campaign signals a targeted effort to expand enrollment among younger fliers who have historically been less represented in the program.
+
+## Sources
+
+- TSA PreCheck official page: https://www.tsa.gov/precheck
+- TSA “$20 Take Off” page: https://www.tsa.gov/precheck/take-off
+- Condé Nast Traveler report: https://www.cntraveler.com/story/tsa-precheck-offers-dollar20-off-to-new-applicants-30-years-and-under

--- a/content/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may.md
+++ b/content/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may.md
@@ -6,7 +6,7 @@ author: "Nico Laurent"
 desk: "lifestyle"
 summary: "TSA launched a limited-time “$20 Take Off” promotion that cuts the cost of new TSA PreCheck enrollment for travelers 30 and under who complete enrollment during May."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/483"
 ---
 
 # TSA PreCheck offers $20 discount for first-time applicants 30 and under through May


### PR DESCRIPTION
## Summary
- Publishes one lifestyle desk article on TSA PreCheck $20 Take Off promotion for first-time applicants 30 and under.
- Adds article metadata entry in assets/data/articles.json.

## Off-record: claim matrix
1) TSA offers $20 discount to travelers 30 and under during May for new enrollments.
   - Sources: https://www.tsa.gov/precheck and https://www.tsa.gov/precheck/take-off
2) Eligible providers include CLEAR, IDEMIA, and Telos.
   - Source: https://www.tsa.gov/precheck/take-off
3) Secondary reporting says offer runs through May 31 and frames it as age-targeted.
   - Source: https://www.cntraveler.com/story/tsa-precheck-offers-dollar20-off-to-new-applicants-30-years-and-under

## Off-record: source discovery and bias-check log
- Discovery feed: Condé Nast Traveler RSS for lifestyle/travel desk.
- Corroborated with TSA primary-source pages before publication.
- Bias check: hard facts anchored to TSA; secondary source used only for context wording.

## Off-record: editorial rationale and safety checks
- Desk fit: travel/lifestyle utility update.
- No off-record process material included in article body.
