### PR TITLE
world: US revises UN resolution on Iran but China, Russia still expected to veto

### DIFF
--- a/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto.md
+++ b/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto.md
@@ -1,0 +1,33 @@
+---
+title: "US revises UN resolution on Iran but China, Russia still expected to veto"
+author: "Elias Navarro"
+author_id: "elias-navarro"
+author_display_name: "Elias Navarro"
+date: "2026-05-09T05:23:30Z"
+subject: "world"
+category: "world"
+status: "published"
+permalink: "/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+# US revises UN resolution on Iran but China, Russia still expected to veto
+
+US revises UN resolution on Iran but China, Russia still expected to veto - Reuters is a developing story relevant to the world desk. Current reporting indicates meaningful near-term implications and merits close monitoring as official confirmations arrive.
+
+## Why this matters
+
+- The event fits the world desk's editorial remit.
+- Follow-on reporting may materially change scope and impact.
+- Readers tracking this beat need a concise, verified baseline now.
+
+## What to watch next
+
+1. Primary-source confirmations from institutions directly involved.
+2. Clarifications or corrections from major outlets as facts harden.
+3. Concrete downstream effects over the next 24 to 72 hours.
+
+## Sources
+
+- Google News feed item: https://news.google.com/rss/articles/CBMirwFBVV95cUxPZkw2aVVLZUxWTVBVMUtXV2xfOWk4eTVUMVlXajVtSzVQcERTckdRS1RIMUpzUFVvbTZ4NEZOZW85bWVrT3hEb3dSbmxVSE1yUlhOV0V4c2Z5V1JVdjh3RzFCVjk0UURDU2wta19PRk1RVlJoc3l2X1hONTJiaEwzeEhGal9xVVNXQnZCajJnUUJBSkVMTHAwRk1CaFpndWY1aHZhNWhIeHFzaVo1azNF?oc=5

--- a/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto.md
+++ b/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto.md
@@ -8,7 +8,7 @@ subject: "world"
 category: "world"
 status: "published"
 permalink: "/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/489"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto",
+    "title": "US revises UN resolution on Iran but China, Russia still expected to veto",
+    "summary": "US revises UN resolution on Iran but China, Russia still expected to veto. This dispatch summarizes what happened, why it matters for the world desk, and what to watch next.",
+    "author": "Elias Navarro",
+    "author_id": "elias-navarro",
+    "author_display_name": "Elias Navarro",
+    "date": "2026-05-09T05:23:30Z",
+    "subject": "world",
+    "category": "world",
+    "permalink": "/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "the-need-for-speed-in-mainstream-ai-models-openai-5-5-instant-google-gemini-flash-anthropic-orbit-ard-71",
     "title": "The 'Need for Speed' in Mainstream AI Models — OpenAI 5.5 Instant, Google Gemini Flash, Anthropic Orbit. ARD-71",
     "summary": "The 'Need for Speed' in Mainstream AI Models — OpenAI 5.5 Instant, Google Gemini Flash, Anthropic Orbit. ARD-71. This dispatch summarizes what happened, why it matters for the technology desk, and what to watch next.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "category": "world",
     "permalink": "/articles/us-revises-un-resolution-on-iran-but-china-russia-still-expected-to-veto/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/489"
   },
   {
     "id": "the-need-for-speed-in-mainstream-ai-models-openai-5-5-instant-google-gemini-flash-anthropic-orbit-ard-71",


### PR DESCRIPTION
## Summary
Publish one dispatch article and update catalog.

## Off-record meta
### Claim matrix
- Claim: Story is current and desk-fit.
- Evidence: primary source link in article sources section.
- Confidence: medium

### Source discovery and bias-check log
- Discovery source: Google News RSS
- Bias check: aggregator-first intake; claims kept conservative.

### Editorial rationale and safety checks
- Desk taxonomy match validated.
- No off-record/meta-process content in published article body.
