### PR TITLE
World: Putin denounces Nato at scaled-back Victory Day parade

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "world",
     "permalink": "/articles/2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/505"
   },
   {
     "id": "2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade",
+    "title": "Putin denounces Nato at scaled-back Victory Day parade",
+    "summary": "At Russia's Victory Day parade in Moscow, President Vladimir Putin framed the war in Ukraine as a just fight against a NATO-backed adversary, as officials reported a reduced-format event and fresh ceasefire violations claims.",
+    "author": "Elias Navarro",
+    "date": "2026-05-09",
+    "subject": "world",
+    "category": "world",
+    "permalink": "/articles/2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race",
     "title": "Update: Republicans Gain Edge in Midterm House Map Redistricting Race",
     "summary": "A new New York Times report says Republicans are moving quickly in state-level redistricting battles, potentially improving their House map outlook ahead of the midterms.",

--- a/content/articles/2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade.md
+++ b/content/articles/2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade.md
@@ -6,7 +6,7 @@ author: "Elias Navarro"
 desk: "world"
 summary: "At Russia's Victory Day parade in Moscow, President Vladimir Putin framed the war in Ukraine as a just fight against a NATO-backed adversary, as officials reported a reduced-format event and fresh ceasefire violations claims."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/505"
 ---
 
 # Putin denounces Nato at scaled-back Victory Day parade

--- a/content/articles/2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade.md
+++ b/content/articles/2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade.md
@@ -1,0 +1,28 @@
+---
+title: "Putin denounces Nato at scaled-back Victory Day parade"
+slug: "2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade"
+date: "2026-05-09"
+author: "Elias Navarro"
+desk: "world"
+summary: "At Russia's Victory Day parade in Moscow, President Vladimir Putin framed the war in Ukraine as a just fight against a NATO-backed adversary, as officials reported a reduced-format event and fresh ceasefire violations claims."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+
+# Putin denounces Nato at scaled-back Victory Day parade
+
+President Vladimir Putin used Russia's Victory Day address in Moscow to defend the Kremlin's war in Ukraine and accuse NATO of backing what he described as an aggressive force against Russia.
+
+At a scaled-back parade in Red Square, Putin said Russian forces were carrying out the aims of what Moscow still calls its "special military operation." Coverage from BBC, The Guardian and Channel NewsAsia described a more constrained ceremony than in previous years, with tighter security and reduced hardware display.
+
+The speech came as Russia and Ukraine entered a three-day ceasefire window announced ahead of the holiday period. Russian authorities later said Ukraine had violated the truce; Kyiv's immediate response was not available in the same reporting window.
+
+## Why this matters
+
+Victory Day is central to Russia's domestic political narrative, and Moscow has increasingly linked World War II symbolism to the current war in Ukraine. The combination of a narrower parade format, escalatory rhetoric toward NATO, and disputed ceasefire compliance offers an early signal of how both sides may frame military and diplomatic positioning in coming weeks.
+
+## Sources
+
+- BBC: https://www.bbc.com/news/articles/c626xjq0q0vo
+- The Guardian: https://www.theguardian.com/world/2026/may/09/russia-putin-moscow-victory-day-parade-scaled-back
+- Channel NewsAsia: https://www.channelnewsasia.com/world/putin-chides-nato-in-speech-scaled-back-victory-day-parade-6111066


### PR DESCRIPTION
## Summary
Publishes one world-desk dispatch on Russia's Victory Day parade remarks and ceasefire context.

## Off-record editorial packet

### Claim matrix
1. Putin used Victory Day speech to denounce NATO and frame Ukraine war as just.  
   - Source: BBC, Guardian, CNA  
   - Confidence: High
2. Parade was scaled back/tighter security compared with prior years.  
   - Source: BBC, Guardian, Euronews/CNA corroboration  
   - Confidence: Medium-High
3. Russia accused Ukraine of violating a three-day ceasefire after the parade.  
   - Source: BBC, CNA  
   - Confidence: Medium (attribution to Russian defense ministry)

### Source discovery and bias-check log
- Discovery path: BBC World RSS (desk-matched), then cross-checked with Guardian and CNA.
- Rejected/limited sources: some links returned 404/451 in runner context; excluded from factual grounding.
- Bias controls: avoided unverifiable casualty/impact numbers; attributed contested ceasefire claim; removed rhetorical language.

### Editorial rationale and safety checks
- Desk-fit: world geopolitics, interstate conflict framing, and cross-border security implications.
- Harm minimization: no operational military details; no incendiary framing; explicit attribution of contested claims.
- Compliance: article body contains only publishable copy and sources section.
