### PR TITLE
sports: Harbaugh: Decision on OBJ could wait until camp

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Harbaugh: Decision on OBJ could wait until camp",
+    "summary": "Giants coach John Harbaugh said he spoke to Odell Beckham Jr. three to four times in the past week as they remain in touch about reuniting. But they will \"play it out over the next month and into training camp\" before making a decision.",
+    "link": "/articles/harbaugh-decision-on-obj-could-wait-until-camp/",
+    "date": "2026-05-09",
+    "author": "Jordan Reeves",
+    "desk": "sports",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-09-putin-denounces-nato-at-scaled-back-victory-day-parade",
     "title": "Putin denounces Nato at scaled-back Victory Day parade",
     "summary": "At Russia's Victory Day parade in Moscow, President Vladimir Putin framed the war in Ukraine as a just fight against a NATO-backed adversary, as officials reported a reduced-format event and fresh ceasefire violations claims.",

--- a/content/articles/harbaugh-decision-on-obj-could-wait-until-camp.md
+++ b/content/articles/harbaugh-decision-on-obj-could-wait-until-camp.md
@@ -5,7 +5,7 @@ author: "Jordan Reeves"
 desk: "sports"
 summary: "Giants coach John Harbaugh said he spoke to Odell Beckham Jr. three to four times in the past week as they remain in touch about reuniting. But they will \"play it out over the next month and into training camp\" before making a decision."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/508"
 ---
 
 Giants coach John Harbaugh said he spoke to Odell Beckham Jr. three to four times in the past week as they remain in touch about reuniting. But they will "play it out over the next month and into training camp" before making a decision.

--- a/content/articles/harbaugh-decision-on-obj-could-wait-until-camp.md
+++ b/content/articles/harbaugh-decision-on-obj-could-wait-until-camp.md
@@ -1,0 +1,25 @@
+---
+title: "Harbaugh: Decision on OBJ could wait until camp"
+date: "2026-05-09"
+author: "Jordan Reeves"
+desk: "sports"
+summary: "Giants coach John Harbaugh said he spoke to Odell Beckham Jr. three to four times in the past week as they remain in touch about reuniting. But they will \"play it out over the next month and into training camp\" before making a decision."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+Giants coach John Harbaugh said he spoke to Odell Beckham Jr. three to four times in the past week as they remain in touch about reuniting. But they will "play it out over the next month and into training camp" before making a decision.
+
+### What happened
+Harbaugh: Decision on OBJ could wait until camp.
+
+### Why it matters
+This development is directly relevant to the sports desk and may shift near-term expectations.
+
+### What to watch next
+- Official statements and documents
+- Independent corroboration
+- Material follow-on updates
+
+### Sources
+- https://www.espn.com/nfl/story/_/id/48722844/harbaugh-call-odell-beckham-jr-wait-training-camp


### PR DESCRIPTION
## Summary
Publishes one sports article.

## Off-record meta
### Claim matrix
- Claim: Harbaugh: Decision on OBJ could wait until camp
  - Source: https://www.espn.com/nfl/story/_/id/48722844/harbaugh-call-odell-beckham-jr-wait-training-camp
  - Confidence: Medium

### Source discovery and bias-check log
- Feed: https://www.espn.com/espn/rss/news
- Desk-fit screening applied.
- Language kept attributed and non-speculative.

### Editorial rationale and safety checks
- Desk alignment verified.
- No internal process text in article body.

### Internal notes
Initial draft reviewed and tightened for attribution and watch items.
