### PR TITLE
Environment Desk: Forest loss eased in 2025 but fire risk threatens gains

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,15 @@
 [
   {
+    "title": "Global forest loss fell in 2025, but fire risk keeps deforestation goals off track",
+    "slug": "2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track",
+    "date": "2026-05-09",
+    "author": "Rowan Hale",
+    "desk": "environment",
+    "summary": "Global monitoring shows tropical primary forest loss dropped in 2025, but researchers warn fire risk and policy gaps still leave 2030 deforestation goals out of reach.",
+    "link": "/articles/2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "title": "PM turns to old Labour hands after election losses but some MPs left baffled",
     "slug": "pm-turns-to-old-labour-hands-after-election-losses-but-some-mps-left-baffled",
     "date": "2026-05-09",

--- a/content/articles/2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track.md
+++ b/content/articles/2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track.md
@@ -5,7 +5,7 @@ desk: "environment"
 author: "Rowan Hale"
 date: "2026-05-09"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/510"
 ---
 
 New global forest monitoring data show a substantial decline in tropical primary forest loss in 2025, but researchers and climate analysts say the world remains off track to end deforestation by 2030 and vulnerable to renewed fire-driven losses.

--- a/content/articles/2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track.md
+++ b/content/articles/2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track.md
@@ -1,0 +1,31 @@
+---
+title: "Global forest loss fell in 2025, but fire risk keeps deforestation goals off track"
+slug: "2026-05-09-global-forest-loss-fell-in-2025-but-fire-risk-keeps-deforestation-goals-off-track"
+desk: "environment"
+author: "Rowan Hale"
+date: "2026-05-09"
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+New global forest monitoring data show a substantial decline in tropical primary forest loss in 2025, but researchers and climate analysts say the world remains off track to end deforestation by 2030 and vulnerable to renewed fire-driven losses.
+
+According to Global Forest Watch’s latest assessment, tropical primary forest loss fell 36% year over year in 2025. The analysis attributes much of that drop to fewer severe fire conditions than in 2024, rather than to a structural break from long-term forest clearing pressures.
+
+BBC coverage of the same dataset highlighted that El Nino-linked fire conditions helped drive major losses in the prior year, and warned that future climate variability could quickly reverse recent gains. Independent reporting by Mongabay similarly noted that, despite the improvement, annual loss remains far above what is consistent with the 2030 global deforestation pledge.
+
+## Why this matters
+
+For the environment desk, this is a core climate biodiversity accountability story: progress headlines can mask fragile underlying trends when outcomes are highly sensitive to fire weather. A single extreme climate cycle can erase multiple years of policy gains if prevention, enforcement, and restoration capacity do not scale in parallel.
+
+## What to watch next
+
+- Whether major forest countries announce stronger 2026 fire-prevention and rapid-response funding before the next high-risk dry season.
+- Whether national enforcement data show sustained declines in non-fire clearing, which would indicate deeper structural progress.
+- Whether upcoming COP and climate-finance negotiations tie measurable forest outcomes to disbursement conditions.
+
+## Sources
+
+- Global Forest Watch primary dataset release: https://www.globalforestwatch.org/blog/data-and-research/global-forest-loss-2025/
+- BBC Science and Environment report: https://www.bbc.com/news/articles/c78q5pygn66o
+- Mongabay analysis: https://news.mongabay.com/2026/04/tropical-forest-loss-falls-in-2025-but-world-still-off-track-on-deforestation-goals/


### PR DESCRIPTION
## Summary
Adds an environment desk article on 2025 tropical primary forest-loss decline and continuing fire-risk vulnerability.

## Claim matrix
1. Tropical primary forest loss fell 36 percent in 2025 vs 2024.  
   - Source: Global Forest Watch release.
2. Progress may be fragile because lower loss was partly linked to reduced fire pressure vs prior El Nino period.  
   - Sources: GFW release and BBC reporting.
3. World remains off-track for 2030 deforestation goals despite improvement.  
   - Sources: Mongabay analysis of latest data and underlying trend lines.

## Source discovery and bias-check log
- Started from BBC science and environment feed candidate list for desk fit.
- Cross-checked with primary publisher Global Forest Watch release.
- Added independent contextual report from Mongabay.
- Bias check: avoided advocacy framing by attributing evaluative language to sources and keeping policy implications conditional.

## Editorial rationale and safety checks
- Desk fit: environment topic focused on deforestation, wildfire risk, and climate-linked ecosystem outcomes.
- Safety: no medical, legal, or personal advice content.
- Accuracy: numerical claim and trend framing sourced explicitly.
