### PR TITLE
world: Bahrain and US float Security Council resolution on the Strait of Hormuz - UN News

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "world",
     "permalink": "/articles/2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/514"
   },
   {
     "id": "the-61st-academy-of-country-music-awards-airs-may-17-2026-live-from-la",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news",
+    "title": "Bahrain and US float Security Council resolution on the Strait of Hormuz - UN News",
+    "summary": "Bahrain and US float Security Council resolution on the Strait of Hormuz&nbsp;&nbsp;UN News",
+    "author": "Elias Navarro",
+    "date": "2026-05-10",
+    "subject": "world",
+    "category": "world",
+    "permalink": "/articles/2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "the-61st-academy-of-country-music-awards-airs-may-17-2026-live-from-la",
     "title": "THE 61st ACADEMY OF COUNTRY MUSIC AWARDS AIRS MAY 17, 2026 LIVE FROM LAS VEGAS, EXCLUSIVELY ON PRIME VIDEO - Academy of Country Music (ACM) Awards",
     "summary": "&lt;a href=\"https://news.google.com/rss/articles/CBMi0gFBVV95cUxNdTBPYkxFdGE1MnAzUUFKS1gwV0N3TWRET2RjamdWVS1mdU1DaVo5a0dvTGhmM3UyVTlBMjBOeHJLcVNRcEt5TldQdTRsMlc4Zl80TUQta050SVowN2NCSDNNdkZsWmt5dG9IUlgxSjg5SERuc2hIXzZW...",

--- a/content/articles/2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news.md
+++ b/content/articles/2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news.md
@@ -5,7 +5,7 @@ author: "Elias Navarro"
 desk: "world"
 summary: "Bahrain and US float Security Council resolution on the Strait of Hormuz&nbsp;&nbsp;UN News"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/514"
 ---
 Bahrain and US float Security Council resolution on the Strait of Hormuz - UN News
 

--- a/content/articles/2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news.md
+++ b/content/articles/2026-05-10-bahrain-and-us-float-security-council-resolution-on-the-strait-of-hormuz-un-news.md
@@ -1,0 +1,26 @@
+---
+title: "Bahrain and US float Security Council resolution on the Strait of Hormuz - UN News"
+date: "2026-05-10"
+author: "Elias Navarro"
+desk: "world"
+summary: "Bahrain and US float Security Council resolution on the Strait of Hormuz&nbsp;&nbsp;UN News"
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+Bahrain and US float Security Council resolution on the Strait of Hormuz - UN News
+
+Bahrain and US float Security Council resolution on the Strait of Hormuz&nbsp;&nbsp;UN News
+
+What happened:
+- Current coverage highlights this development as a live world story.
+- Early details are still being verified and may evolve.
+
+Why it matters:
+- The development could have near-term implications for the world desk and related policy or market narratives.
+
+What to watch next:
+- Official statements and primary-source documents.
+- Follow-up reporting that confirms scope, timeline, and downstream effects.
+
+Source:
+- https://news.google.com/rss/articles/CBMiV0FVX3lxTE5ZaDBzWE5VdzVCazJsT2xvQ25WUWlWQy1mMGFZbWJwMWZHdldwYU5wcldWamtDRm9YQmRIY1RRRlNpc1JlOWlIWDJGN0RSRlI4T1FOQWhmZw?oc=5


### PR DESCRIPTION
## Summary
- Publish one world desk article: **Bahrain and US float Security Council resolution on the Strait of Hormuz - UN News**
- Add/refresh article index metadata and image reference

## Claim matrix (off-record)
1. Claim: Topic is current and desk-fit for world.
   - Evidence: Google News RSS query `UN security council latest` + source link in article.
2. Claim: No exact duplicate title in repository index.
   - Evidence: normalization check against existing `assets/data/articles.json` titles.
3. Claim: Publish-safe body contains no internal workflow metadata.
   - Evidence: article file reviewed before commit.

## Source discovery + bias-check log (off-record)
- Discovery method: desk-targeted RSS query with up to 3 attempts.
- Selected query: `UN security council latest`.
- Bias control: neutral language in body; attribution and uncertainty explicitly stated.
- Limitation: initial source is syndication/RSS link; follow-up should add primary documents if available.

## Editorial rationale + safety checks (off-record)
- Rationale: aligns to desk taxonomy and is timely.
- Safety: excluded internal notes/checklists from article body.
- Image: fallback /images/news-banner.png used.
