### PR TITLE
fix: prune broken/unpublished article routes from feed index

### DIFF
--- a/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race.md
+++ b/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race.md
@@ -8,7 +8,7 @@ subject: "news-politics"
 category: "news-politics"
 status: "published"
 permalink: "/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race/"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/504"
 image: "/images/news-banner.png"
 ---
 

--- a/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race.md
+++ b/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race.md
@@ -1,0 +1,29 @@
+---
+title: "Update: Republicans Gain Edge in Midterm House Map Redistricting Race"
+author: "Maya Sterling"
+author_id: "maya-sterling"
+author_display_name: "Maya Sterling"
+date: "2026-05-09"
+subject: "news-politics"
+category: "news-politics"
+status: "published"
+permalink: "/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race/"
+published_pr_url: ""
+image: "/images/news-banner.png"
+---
+
+A new New York Times report says Republicans have moved quickly to improve their position in the U.S. House map fight, showing greater confidence in redistricting strategy ahead of the midterms.
+
+The report describes a rapid, roughly 10-day shift in the map contest, with Republican operatives pressing their advantage after months of concern about the party’s outlook. The focus is on how legal rulings and state-level map decisions are changing the tactical landscape for both parties.
+
+### What’s New
+- New framing centers on **speed and sequencing** in the latest redistricting push, with Republicans described as newly bullish.
+- The development updates earlier coverage that focused on legal groundwork and court decisions; this phase emphasizes **implementation momentum** in the political map battle.
+
+### Why this matters
+Redistricting can alter who is competitive in swing districts and can shape House control before most voters cast a ballot. Even incremental map changes in a few states can affect national seat math.
+
+### Links
+- New report: https://www.nytimes.com/2026/05/09/us/politics/midterm-redistricting-house-map-republicans.html
+- Prior related coverage: /articles/2026-05-02-update-voting-rights-act-ruling-reshapes-redistricting-fight/
+- Prior related coverage: /articles/2026-04-24-virginia-judge-blocks-voter-approved-congressional-map-overhaul/

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "news-politics",
     "permalink": "/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/504"
   },
   {
     "id": "2026-05-09-the-biggest-wellness-trends-of-2026",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race",
+    "title": "Update: Republicans Gain Edge in Midterm House Map Redistricting Race",
+    "summary": "A new New York Times report says Republicans are moving quickly in state-level redistricting battles, potentially improving their House map outlook ahead of the midterms.",
+    "author": "Maya Sterling",
+    "date": "2026-05-09",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "permalink": "/articles/2026-05-09-update-republicans-gain-edge-midterm-house-map-redistricting-race/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-09-the-biggest-wellness-trends-of-2026",
     "title": "The Biggest Wellness Trends of 2026",
     "summary": "The Biggest Wellness Trends of 2026 - Vogue",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -26,15 +26,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/502"
   },
   {
-    "title": "How states are following, and resisting, Trump’s lead on election policy",
-    "date": "2026-05-09",
-    "author": "Maya Sterling",
-    "desk": "news-politics",
-    "summary": "How states are following, and resisting, Trump’s lead on election policy&nbsp;&nbsp;Votebeat",
-    "link": "/articles/how-states-are-following-and-resisting-trump-s-lead-on-election-policy/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "id": "2026-05-09-the-ocean-is-fighting-climate-change-and-we-re-trying-to-help-it-here",
     "title": "The ocean is fighting climate change and we’re trying to help it – here’s how",
     "summary": "The ocean is fighting climate change and we’re trying to help it – here’s how&nbsp;&nbsp;The Conversation",
@@ -44,18 +35,6 @@
     "category": "environment",
     "permalink": "/articles/2026-05-09-the-ocean-is-fighting-climate-change-and-we-re-trying-to-help-it-here/",
     "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-09-william-hails-sir-david-attenborough-s-remarkable-milestone-at-100th-birthday-concert",
-    "title": "William hails Sir David Attenborough's 'remarkable milestone' at 100th birthday concert",
-    "summary": "The naturalist's seven-decade career was marked with a special concert at the Royal Albert Hall.",
-    "author": "Camille Vega",
-    "date": "2026-05-09T11:44:46Z",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "permalink": "/articles/2026-05-09-william-hails-sir-david-attenborough-s-remarkable-milestone-at-100th-birthday-concert.html",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/497"
   },
   {
     "id": "2026-05-09-trump-feuds-with-allies-likely-to-outlast-iran-war-reuters",
@@ -84,15 +63,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/495"
   },
   {
-    "title": "Trump says Russia and Ukraine to observe three-day ceasefire",
-    "summary": "It comes as the two countries accused each other of violating separate ceasefires to cover the celebrations of the Soviet Union's victory over Nazi Germany.",
-    "author": "Elias Navarro",
-    "desk": "world",
-    "date": "2026-05-09T08:31:40Z",
-    "link": "/articles/trump-says-russia-and-ukraine-to-observe-three-day-ceasefire/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "id": "2026-05-09-rosal-a-is-bringing-her-2026-lux-tour-to-north-america-shop-tickets-sarasota-her",
     "title": "Rosalía is bringing her 2026 LUX tour to North America, shop tickets - Sarasota Herald-Tribune",
     "permalink": "/articles/2026-05-09-rosal-a-is-bringing-her-2026-lux-tour-to-north-america-shop-tickets-sarasota-her",
@@ -118,41 +88,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/489"
   },
   {
-    "id": "the-need-for-speed-in-mainstream-ai-models-openai-5-5-instant-google-gemini-flash-anthropic-orbit-ard-71",
-    "title": "The 'Need for Speed' in Mainstream AI Models — OpenAI 5.5 Instant, Google Gemini Flash, Anthropic Orbit. ARD-71",
-    "summary": "The 'Need for Speed' in Mainstream AI Models — OpenAI 5.5 Instant, Google Gemini Flash, Anthropic Orbit. ARD-71. This dispatch summarizes what happened, why it matters for the technology desk, and what to watch next.",
-    "author": "Adeline Park",
-    "date": "2026-05-09T04:19:08Z",
-    "subject": "technology",
-    "category": "technology",
-    "permalink": "/articles/the-need-for-speed-in-mainstream-ai-models-openai-5-5-instant-google-gemini-flash-anthropic-orbit-ard-71/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/488"
-  },
-  {
-    "id": "2026-05-09-what-do-the-unfolding-local-election-results-mean-our-panel-responds",
-    "title": "What do the unfolding local election results mean? Our panel responds",
-    "summary": "What do the unfolding local election results mean? Our panel responds — latest verified development for the opinion-editorials desk.",
-    "author": "Simone Hart",
-    "date": "2026-05-09T03:14:02Z",
-    "subject": "opinion-editorials",
-    "category": "opinion-editorials",
-    "permalink": "/articles/2026-05-09-what-do-the-unfolding-local-election-results-mean-our-panel-responds/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/487"
-  },
-  {
-    "id": "global-perceptions-of-us-fall-below-russia-under-trump-survey-finds",
-    "title": "Global perceptions of US fall below Russia under Trump, survey finds",
-    "summary": "Global perceptions of US fall below Russia under Trump, survey finds. This dispatch summarizes what happened, why it matters for the world desk, and what to watch next.",
-    "author": "Elias Navarro",
-    "date": "2026-05-09T02:07:50Z",
-    "subject": "world",
-    "category": "world",
-    "permalink": "/articles/global-perceptions-of-us-fall-below-russia-under-trump-survey-finds/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "id": "2026-05-09-hull-city-0-0-millwall-championship-playoff-semi-final-first-leg-as-it",
     "title": "Hull City 0-0 Millwall: Championship playoff semi-final, first leg – as it happened",
     "summary": "Hull City 0-0 Millwall: Championship playoff semi-final, first leg – as it happened&nbsp;&nbsp;The Guardian",
@@ -162,32 +97,6 @@
     "category": "sports",
     "permalink": "/articles/2026-05-09-hull-city-0-0-millwall-championship-playoff-semi-final-first-leg-as-it/",
     "image": "/images/news-banner.png"
-  },
-  {
-    "id": "tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may",
-    "title": "TSA PreCheck offers $20 discount for first-time applicants 30 and under through May",
-    "summary": "TSA launched a limited-time “$20 Take Off” promotion that cuts the cost of new TSA PreCheck enrollment for travelers 30 and under who complete enrollment during May.",
-    "author": "Nico Laurent",
-    "date": "2026-05-08T21:55:27Z",
-    "subject": "lifestyle",
-    "category": "lifestyle",
-    "permalink": "/articles/tsa-precheck-offers-20-discount-for-first-time-applicants-30-and-under-through-may/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/483"
-  },
-  {
-    "id": "who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk",
-    "title": "WHO says hepatitis progress is real, but 2030 elimination targets are at risk",
-    "summary": "WHO reports declines in new hepatitis B infections and hepatitis C deaths, but says prevention, diagnosis and treatment must accelerate to hit 2030 elimination goals.",
-    "author": "Dr. Lena Okafor",
-    "author_id": "dr-lena-okafor",
-    "author_display_name": "Dr. Lena Okafor",
-    "date": "2026-05-08T20:46:29Z",
-    "subject": "science-health",
-    "category": "science-health",
-    "permalink": "/articles/who-says-hepatitis-progress-is-real-but-2030-targets-are-at-risk/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/482"
   },
   {
     "id": "2026-05-08-governor-stein-announces-nc-film-and-entertainment-grant-program-award",
@@ -210,24 +119,6 @@
     "category": "science-health",
     "permalink": "/articles/update-fda-extends-review-window-for-subcutaneous-leqembi-start-dose/",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/479",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Canvas availability incident highlights resilience risks for schools using cloud edtech",
-    "date": "2026-05-08T17:33:39Z",
-    "author": "Adeline Park",
-    "desk": "technology",
-    "summary": "Instructure’s status page shows an active Canvas availability incident affecting some environments, underscoring how outages in core learning platforms can disrupt coursework, exams and campus operations.",
-    "link": "/articles/canvas-availability-incident-highlights-edtech-resilience-risks/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "How Women Over 50 Actually Style Their Bangs - Vogue",
-    "date": "2026-05-08",
-    "author": "Nico Laurent",
-    "desk": "lifestyle",
-    "summary": "How Women Over 50 Actually Style Their Bangs&nbsp;&nbsp;Vogue",
-    "link": "/articles/how-women-over-50-actually-style-their-bangs-vogue/",
     "image": "/images/news-banner.png"
   },
   {
@@ -259,39 +150,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/473"
   },
   {
-    "title": "Update: 2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
-    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
-    "link": "/articles/2026-05-08-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-p/",
-    "date": "2026-05-08T13:14:01Z",
-    "author": "Camille Vega",
-    "desk": "arts-entertainment",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "europe-inequality-linked-to-higher-temperature-death-risk-study",
-    "title": "Europe inequality linked to higher temperature-death risk, study finds",
-    "summary": "A new Europe-focused health-climate analysis finds socioeconomic inequality is linked to significantly higher temperature-related mortality, with researchers estimating around 100,000 additional heat- and cold-related deaths each year across the continent.",
-    "author": "Rowan Hale",
-    "date": "2026-05-08T12:08:24Z",
-    "subject": "environment",
-    "category": "environment",
-    "permalink": "/articles/europe-inequality-linked-to-higher-temperature-death-risk-study/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/469"
-  },
-  {
-    "id": "alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords",
-    "title": "Alaska megatsunami study raises climate-era risk warnings for glacier fjords",
-    "summary": "New reporting on a massive Alaska fjord wave says glacier retreat and slope instability are increasing the probability of rare but high-impact megatsunami hazards in coastal channels.",
-    "author": "Rowan Hale",
-    "date": "2026-05-08T08:56:37Z",
-    "subject": "environment",
-    "category": "environment",
-    "permalink": "/articles/alaska-megatsunami-study-raises-climate-era-risk-warnings-for-glacier-fjords/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/465"
-  },
-  {
     "id": "update-why-regenerative-farming-is-the-latest-wellness-travel-trend",
     "title": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend",
     "summary": "Update: Why Regenerative Farming Is the Latest Wellness Travel Trend — key verified developments and why they matter for lifestyle readers.",
@@ -311,63 +169,6 @@
     "subject": "business-economy",
     "category": "business-economy",
     "permalink": "/articles/rsm-and-u-s-chamber-survey-middle-market-firms-see-growth-despite-inflation-pres/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Update: US-Iran ceasefire tested by Hormuz exchange, but truce remains in effect",
-    "date": "2026-05-08",
-    "author": "Simone Hart",
-    "desk": "opinion-editorials",
-    "summary": "After reported exchanges of fire in and around the Strait of Hormuz, Washington and Tehran are still publicly treating the ceasefire as active—underscoring how fragile crisis stability becomes when military signaling outruns diplomacy.",
-    "link": "/articles/2026-05-08-update-us-iran-ceasefire-holds-after-hormuz-fire-exchange/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/460"
-  },
-  {
-    "title": "Appeals Court Looks Unlikely to Allow Hegseth to Punish Mark Kelly for Video",
-    "author": "Maya Sterling",
-    "desk": "news-politics",
-    "date": "2026-05-08T04:37:21Z",
-    "summary": "A three-judge panel in Washington heard arguments in the lawsuit aimed at stopping the Pentagon from disciplining Senator Mark Kelly for a video warning about illegal military orders.",
-    "link": "/articles/appeals-court-looks-unlikely-to-allow-hegseth-to-punish-mark-kelly-for-video/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Instagram privacy tech is turned off today- what does this mean for your DMs?",
-    "slug": "instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms",
-    "author": "Adeline Park",
-    "category": "technology",
-    "date": "2026-05-08T03:33:49Z",
-    "excerpt": "The platform said it would remove end-to-end encrypted messages, a major U‑turn by parent company Meta.",
-    "image": "/images/news-banner.png",
-    "path": "/articles/instagram-privacy-tech-is-turned-off-today-what-does-this-mean-for-your-dms/"
-  },
-  {
-    "title": "Oil prices rise after US and Iran exchange fire in Hormuz strait",
-    "date": "2026-05-08",
-    "author": "Priya Desai",
-    "desk": "business-economy",
-    "summary": "The flare-up further endangers the US-Iran ceasefire, which Trump extended indefinitely on 21 April.",
-    "link": "/articles/oil-prices-rise-after-us-and-iran-exchange-fire-in-hormuz-strait/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar",
-    "date": "2026-05-08",
-    "desk": "business-economy",
-    "author": "Priya Desai",
-    "summary": "Market Minute: Earnings deliver, but inflation threat remains - Morningstar — latest verified development for the business-economy desk.",
-    "link": "/articles/2026-05-08-market-minute-earnings-deliver-but-inflation-threat-remains-morningstar/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/456"
-  },
-  {
-    "title": "2025/26 Champions League: All the fixtures and results - UEFA.com",
-    "date": "2026-05-08",
-    "desk": "sports",
-    "author": "Jordan Reeves",
-    "summary": "2025/26 Champions League: All the fixtures and results - UEFA.com — latest verified development for the sports desk.",
-    "link": "/articles/2026-05-08-2025-26-champions-league-all-the-fixtures-and-results-uefa-com/",
     "image": "/images/news-banner.png"
   },
   {
@@ -395,28 +196,6 @@
     "category": "business-economy",
     "permalink": "/articles/update-fed-officials-say-supply-chain-risks-could-fuel-persistent-inflation/",
     "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Halo Effect of GLP-1s Signals New Consumer Lifestyle and Health and Wellness Trends - PR Newswire",
-    "date": "2026-05-07",
-    "author": "Nico Laurent",
-    "category": "lifestyle",
-    "subject": "lifestyle",
-    "path": "/articles/halo-effect-of-glp-1s-signals-new-consumer-lifestyle-and-health-and-wellness-tre",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/451"
-  },
-  {
-    "id": "2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users",
-    "title": "Perplexity opens its Personal Computer app to all Mac users",
-    "summary": "Perplexity has opened its Personal Computer app to all Mac users, expanding desktop access to its AI assistant workflow as competition intensifies in productivity-focused AI tools.",
-    "author": "Adeline Park",
-    "date": "2026-05-07T19:59:49Z",
-    "subject": "technology",
-    "category": "technology",
-    "permalink": "/articles/2026-05-07-perplexity-personal-computer-launches-on-mac-for-all-users/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/449"
   },
   {
     "id": "2026-05-07-a-new-era-for-your-health-and-wellness-blog-google",
@@ -457,18 +236,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/445"
   },
   {
-    "id": "2026-05-07-amazon-deforestation-rainfall-risk-study",
-    "title": "New Research Warns Amazon Deforestation Could Sharply Reduce Regional Rainfall",
-    "summary": "New reporting highlights evidence that continued Amazon deforestation can reduce regional rainfall, with researchers warning climate change may amplify the effect.",
-    "author": "Rowan Hale",
-    "date": "2026-05-07",
-    "subject": "environment",
-    "category": "environment",
-    "permalink": "/articles/2026-05-07-amazon-deforestation-rainfall-risk-study/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/443"
-  },
-  {
     "id": "environment-climate-change-fuels-wildfire-threats-across-appal-2026-05-07",
     "title": "Climate change fuels wildfire threats across Appalachia",
     "summary": "Climate change fuels wildfire threats across Appalachia",
@@ -478,18 +245,6 @@
     "category": "environment",
     "permalink": "/articles/environment-climate-change-fuels-wildfire-threats-across-appal-2026-05-07.html",
     "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation",
-    "title": "Malaysia and India Expand Biodiversity and Sustainability Cooperation",
-    "summary": "Malaysia and India announced expanded cooperation on biodiversity conservation and sustainability, signaling deeper integration of environmental priorities in bilateral policy talks.",
-    "author": "Rowan Hale",
-    "date": "2026-05-07",
-    "subject": "environment",
-    "category": "environment",
-    "permalink": "/articles/2026-05-07-malaysia-and-india-expand-biodiversity-and-sustainability-cooperation/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/441"
   },
   {
     "id": "2026-05-07-f-d-a-blocked-publication-of-research-finding-covid-and-shingles-vaccines-were-safe-the-ne",
@@ -504,34 +259,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/438"
   },
   {
-    "title": "Synflux Wins the 2026 Trailblazer Award",
-    "slug": "synflux-wins-the-2026-trailblazer-award",
-    "date": "2026-05-07",
-    "author": "Nico Laurent",
-    "desk": "lifestyle",
-    "summary": "Vogue reports that Synflux won the 2026 Trailblazer Award, highlighting sustainability-focused innovation in fashion design and production.",
-    "link": "/articles/synflux-wins-the-2026-trailblazer-award/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Sun, Sand, and Spirits in Mexico's Riviera Nayarit",
-    "slug": "sun-sand-and-spirits-in-mexicos-riviera-nayarit",
-    "date": "2026-05-07",
-    "author": "Nico Laurent",
-    "desk": "lifestyle",
-    "summary": "A Bon Appétit report spotlights how Riviera Nayarit’s Rosewood Mandarina is centering local sourcing and agave-led beverage culture in luxury travel experiences.",
-    "link": "/articles/sun-sand-and-spirits-in-mexicos-riviera-nayarit/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Why Google, Microsoft and xAI’s U.S. AI deal matters",
-    "summary": "Why Google, Microsoft and xAI’s U.S. AI deal matters. This is a developing technology story with details still emerging.",
-    "link": "/articles/why-google-microsoft-and-xai-s-u-s-ai-deal-matters/",
-    "image": "/images/news-banner.png",
-    "date": "2026-05-07",
-    "desk": "technology"
-  },
-  {
     "id": "2026-05-07-melissa-barrera-questions-scream-7-box-office-claims",
     "title": "Melissa Barrera Questions ‘Scream 7’ Box-Office Claims After Exit From Franchise",
     "summary": "The actor says she doubts widely cited claims about Scream 7 performance, highlighting ongoing debate over franchise-era box-office narratives.",
@@ -542,18 +269,6 @@
     "permalink": "/articles/2026-05-07-melissa-barrera-questions-scream-7-box-office-claims/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/430"
-  },
-  {
-    "id": "2026-05-07-ai-stocks-riding-major-indices-in-the-new-tech-cycle-kalkine-media",
-    "title": "AI Stocks Riding Major Indices In The New Tech Cycle - Kalkine Media",
-    "summary": "AI Stocks Riding Major Indices In The New Tech Cycle - Kalkine Media",
-    "author": "Adeline Park",
-    "date": "2026-05-07",
-    "subject": "technology",
-    "category": "technology",
-    "permalink": "/articles/2026-05-07-ai-stocks-riding-major-indices-in-the-new-tech-cycle-kalkine-media/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/429"
   },
   {
     "id": "2026-05-07-fitness-focused-travel-retreats-market-emerging-trends-and-long-term-forecast-20",
@@ -567,16 +282,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "TikTok Has Discovered Tae Bo, the Beloved ’90s Workout",
-    "slug": "tiktok-has-discovered-tae-bo-the-beloved-90s-workout",
-    "date": "2026-05-07",
-    "author": "Nico Laurent",
-    "desk": "lifestyle",
-    "summary": "A younger generation is embracing the nostalgic fitness craze.",
-    "link": "/articles/tiktok-has-discovered-tae-bo-the-beloved-90s-workout/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "id": "2026-05-07-nba-stars-playing-in-europe-instead-of-u-s-that-s-what-soccer-giants-want",
     "title": "NBA stars playing in Europe instead of U.S.? That’s what soccer giants want",
     "permalink": "/2026-05-07/nba-stars-playing-in-europe-instead-of-u-s-that-s-what-soccer-giants-want",
@@ -586,48 +291,6 @@
     "subject": "sports",
     "category": "sports",
     "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Millions Across England, Scotland and Wales Vote in High-Stakes Local and Devolved Elections",
-    "slug": "millions-across-england-scotland-and-wales-vote-in-high-stakes-elections",
-    "url": "/articles/millions-across-england-scotland-and-wales-vote-in-high-stakes-elections/",
-    "desk": "news-politics",
-    "author": "Maya Sterling",
-    "date": "2026-05-06",
-    "summary": "Voters across England, Scotland and Wales head to the polls in a major test of party strength and public sentiment ahead of the next national cycle.",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Massive Alaska megatsunami was second largest ever recorded",
-    "slug": "massive-alaska-megatsunami-was-second-largest-ever-recorded",
-    "url": "/articles/massive-alaska-megatsunami-was-second-largest-ever-recorded/",
-    "desk": "environment",
-    "author": "Rowan Hale",
-    "date": "2026-05-06",
-    "summary": "New research suggests glacier melt driven by climate change is increasing the risk of giant waves.",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Does This Feel Like a ‘Catholic Moment’?",
-    "summary": "Readers respond to an Opinion guest essay by Christine Emba about a possible Catholic revival. Also: A woman’s face.",
-    "link": "/articles/2026-05-06-does-this-feel-like-a-catholic-moment/",
-    "date": "2026-05-06",
-    "author": "Simone Hart",
-    "desk": "opinion-editorials",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels",
-    "title": "India's Zee sues Nykaa over alleged copyright misuse of songs on Instagram reels",
-    "slug": "2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels",
-    "summary": "Indian broadcaster Zee Entertainment has sued beauty and lifestyle platform Nykaa over alleged unauthorized use of songs in Instagram reels, according to a Reuters report.",
-    "author": "Camille Vega",
-    "date": "2026-05-06T18:16:19Z",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "permalink": "/articles/2026-05-06-india-s-zee-sues-nykaa-over-alleged-copyright-misuse-of-songs-on-instagram-reels/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/418"
   },
   {
     "title": "Was It Art? Was It Fashion? Was It Good?",
@@ -649,52 +312,6 @@
     "status": "published",
     "permalink": "/articles/2026-05-06-project-glasswing-securing-critical-software-for-the-ai-era",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/415",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-06-remarkable-launches-paper-pure-a-monochrome-e-ink-tablet-focused-on-distraction-free-note-",
-    "title": "reMarkable launches Paper Pure, a monochrome E Ink tablet focused on distraction-free note-taking",
-    "slug": "2026-05-06-remarkable-launches-paper-pure-a-monochrome-e-ink-tablet-focused-on-distraction-free-note-",
-    "summary": "reMarkable introduced Paper Pure, a new black-and-white E Ink tablet that drops color in favor of lower distraction and longer writing-focused use, according to reports from The Verge and TechCrunch.",
-    "author": "Adeline Park",
-    "author_id": "adeline-park",
-    "author_display_name": "Adeline Park",
-    "date": "2026-05-06T12:59:49Z",
-    "subject": "technology",
-    "category": "technology",
-    "permalink": "/articles/2026-05-06-remarkable-launches-paper-pure-a-monochrome-e-ink-tablet-focused-on-distraction-free-note-/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/413"
-  },
-  {
-    "id": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
-    "title": "Darren Aronofsky to receive Locarno Film Festival’s Pardo d’Onore award",
-    "slug": "2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award",
-    "summary": "Locarno Film Festival said filmmaker Darren Aronofsky will receive the Pardo d’Onore award, signaling a high-profile addition to this year’s festival lineup.",
-    "author": "Camille Vega",
-    "date": "2026-05-06T11:56:26Z",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "permalink": "/articles/2026-05-06-darren-aronofsky-to-receive-locarno-film-festival-s-pardo-d-onore-award/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/411"
-  },
-  {
-    "title": "Labour’s nationwide collapse risks making Nigel Farage the face of the UK’s fragile union",
-    "date": "2026-05-06",
-    "author": "Simone Hart",
-    "desk": "opinion-editorials",
-    "summary": "Scottish and Welsh nationalism will be further radicalised if Reform UK sets the tone of debate over inclusion in the British stateKeir Starmer has neither a heartland nor a strong",
-    "link": "/articles/labour-s-nationwide-collapse-risks-making-nigel-farage-the-face-of-the-uk-s-frag/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Google Home&#8217;s Gemini AI can handle more complicated requests",
-    "date": "2026-05-06",
-    "author": "Adeline Park",
-    "desk": "technology",
-    "summary": "Google Home users can now ask Gemini to complete more complex, multi-step tasks and combine multiple tasks in a single command. Google has updated Gemini for Home to Gemini 3.1, which it says will improve the smart home ",
-    "link": "/articles/2026-05-06-google-home-8217-s-gemini-ai-can-handle-more-complicated-requests/",
     "image": "/images/news-banner.png"
   },
   {
@@ -739,21 +356,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "id": "2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial",
-    "title": "Update: OpenAI president testimony adds new detail in Musk v. Altman trial",
-    "slug": "2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial",
-    "summary": "New testimony from OpenAI president Greg Brockman adds material detail to the Musk v. Altman trial record, extending prior reporting on the same case.",
-    "author": "Adeline Park",
-    "author_id": "adeline-park",
-    "author_display_name": "Adeline Park",
-    "date": "2026-05-06T03:28:50Z",
-    "subject": "technology",
-    "category": "technology",
-    "permalink": "/articles/2026-05-06-update-openai-president-testimony-adds-new-detail-in-musk-v-altman-trial/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/402"
-  },
-  {
     "id": "2026-05-06-introducing-the-ibm-granite-4-1-family-of-models",
     "title": "Introducing the IBM Granite 4.1 family of models",
     "slug": "2026-05-06-introducing-the-ibm-granite-4-1-family-of-models",
@@ -764,7 +366,7 @@
     "date": "2026-05-06T02:26:05Z",
     "subject": "technology",
     "category": "technology",
-    "permalink": "/articles/2026-05-06-introducing-the-ibm-granite-4-1-family-of-models/",
+    "permalink": "/articles/2026-05-06-introducing-the-ibm-granite-4-1-family-of-models",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/401"
   },
@@ -816,32 +418,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/395"
   },
   {
-    "id": "2026-05-05-a-democrat-who-makes-me-listen",
-    "title": "Opinion: A Democrat Who Makes Me Listen",
-    "slug": "2026-05-05-a-democrat-who-makes-me-listen",
-    "summary": "A fresh interview spotlighting Rep. Jake Auchincloss revives the debate over whether a pragmatic, center-leaning Democratic lane can broaden coalition politics ahead of the 2026 cycle.",
-    "author": "Simone Hart",
-    "date": "2026-05-05",
-    "subject": "opinion-editorials",
-    "category": "opinion-editorials",
-    "permalink": "/articles/2026-05-05-a-democrat-who-makes-me-listen/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/393"
-  },
-  {
-    "id": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
-    "title": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’",
-    "slug": "2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan",
-    "summary": "2026 Lower East Side Film Festival award winners include ‘Public Access’ and ‘The Plan’&nbsp;&nbsp;Gold Derby",
-    "author": "Camille Vega",
-    "date": "2026-05-05",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "permalink": "/articles/2026-05-05-2026-lower-east-side-film-festival-award-winners-include-public-access-and-the-plan/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/392"
-  },
-  {
     "id": "2026-05-05-extreme-weather-in-2025-drove-record-wildfire-emissions-in-europe-new-scientist",
     "title": "Extreme weather in 2025 drove record wildfire emissions in Europe - New Scientist",
     "slug": "2026-05-05-extreme-weather-in-2025-drove-record-wildfire-emissions-in-europe-new-scientist",
@@ -878,18 +454,6 @@
     "category": "news",
     "permalink": "/articles/wellness-trends-2026-personalization-prevention-amp-real-life-well-being-take-ov/",
     "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts",
-    "title": "Google DeepMind UK staff vote to unionize over military AI contracts",
-    "summary": "Employees at Google DeepMind in the UK have voted to unionize after concerns over the company's defense-related AI work, escalating a labor-rights flashpoint in the AI sector.",
-    "author": "Adeline Park",
-    "date": "2026-05-05",
-    "subject": "technology",
-    "category": "technology",
-    "permalink": "/articles/2026-05-05-google-deepmind-uk-staff-vote-to-unionize-over-military-ai-contracts/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/386"
   },
   {
     "id": "white-house-news-latest-updates-and-video-on-us-politics-and-government",
@@ -965,15 +529,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/374"
   },
   {
-    "title": "Scientists say travel could slow aging and boost your health",
-    "date": "2026-05-05",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "summary": "A new study suggests travel could be a surprisingly powerful anti-aging tool. By viewing tourism through the lens of entropy, researchers found that positive travel experiences may help the body stay balanced and resilie",
-    "link": "/articles/2026-05-05-scientists-say-travel-could-slow-aging-and-boost-your-health/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "id": "2026-05-05-opinion-google-ai-overviews-defamation-duty-of-care",
     "title": "Opinion: Google AI Overviews and the Duty to Prevent Defamation at Scale",
     "summary": "A defamation suit over an AI Overview highlights why high-risk personal allegations need stricter safeguards, transparent provenance, and fast correction workflows.",
@@ -1024,7 +579,7 @@
     "date": "2026-05-04",
     "subject": "business-economy",
     "category": "business-economy",
-    "permalink": "/articles/2026-05-04-williams-says-fed-policy-well-positioned-for-economic-risks-uncertainty-kfgo/",
+    "permalink": "/articles/2026-05-04-williams-says-fed-policy-well-positioned-for-economic-risks-uncertainty-kfgo",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/368"
   },
@@ -1055,37 +610,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/366"
   },
   {
-    "title": "European State of the Climate 2025: record heatwaves from the Mediterranean to the Arctic, while glaciers shrink and snow cover declines",
-    "author": "Rowan Hale",
-    "desk": "environment",
-    "date": "2026-05-04T20:34:49Z",
-    "summary": "European State of the Climate 2025: record heatwaves from the Mediterranean to the Arctic, while glaciers shrink and snow cover declines&nbsp;&nbsp;World Meteorological Organization WMO",
-    "link": "/articles/european-state-of-the-climate-2025-record-heatwaves-from-the-mediterranean-to-th/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "UK joining Ukraine loan scheme would be good for EU ties, Starmer says",
-    "author": "Maya Sterling",
-    "date": "2026-05-04",
-    "summary": "The UK is \"discussing participating\" in a £78bn (€90bn) European Union loan scheme to support Ukraine, the prime minister says.",
-    "link": "/articles/2026-05-04-uk-joining-ukraine-loan-scheme-would-be-good-for-eu-ties-starmer-says/",
-    "image": "/images/news-banner.png",
-    "desk": "news-politics"
-  },
-  {
-    "id": "2026-05-04-what-champions-league-failure-means-for-broken-club-chelsea",
-    "title": "What Champions League failure means for 'broken club' Chelsea",
-    "summary": "After a sixth-straight league loss, Chelsea are almost certain to miss out on Champions League qualification - a bitter blow which is likely to have far‑reaching consequences.",
-    "author": "Jordan Reeves",
-    "author_id": "sports_lead",
-    "author_display_name": "Jordan Reeves",
-    "date": "2026-05-04",
-    "subject": "sports",
-    "category": "sports",
-    "permalink": "/articles/2026-05-04-what-champions-league-failure-means-for-broken-club-chelsea/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "title": "Laufey on making jazz cool again (and the fish that brought out her inner rage)",
     "date": "2026-05-04",
     "author": "Camille Vega",
@@ -1095,37 +619,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "slug": "2026-05-04-a-long-strange-trip-how-the-g-o-p-came-to-embrace-psychedelic-drugs",
-    "title": "A Long, Strange Trip: How the G.O.P. Came to Embrace Psychedelic Drugs",
-    "summary": "U.S. conservatives are increasingly backing psychedelic-therapy research, with ibogaine now central to policy debate over speed, evidence quality, and federal health oversight.",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "date": "2026-05-04",
-    "url": "/articles/2026-05-04-a-long-strange-trip-how-the-g-o-p-came-to-embrace-psychedelic-drugs/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/357"
-  },
-  {
-    "title": "The Met Makes a Statement With 9 New Mannequin Bodies",
-    "date": "2026-05-04",
-    "desk": "lifestyle",
-    "author": "Nico Laurent",
-    "summary": "The latest Costume Institute exhibition expands its ideas of who, exactly, belongs in fashion. Will the gala follow suit?",
-    "link": "/articles/the-met-makes-a-statement-with-9-new-mannequin-bodies/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "slug": "2026-05-04-study-finds-warmer-ai-personas-can-raise-error-rates-and-sycophancy",
-    "title": "Study finds warmer AI personas can raise error rates and sycophancy",
-    "summary": "A new Nature study reports that tuning language models for warmth can reduce factual accuracy and increase sycophantic responses, sharpening debates over safety trade-offs in AI persona design.",
-    "author": "Adeline Park",
-    "desk": "technology",
-    "date": "2026-05-04",
-    "url": "/articles/2026-05-04-study-finds-warmer-ai-personas-can-raise-error-rates-and-sycophancy/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/352"
-  },
-  {
     "slug": "2026-05-04-irish-actor-and-banshees-of-inisherin-star-gary-lydon-dies-aged-61",
     "title": "Irish actor and Banshees of Inisherin star Gary Lydon dies aged 61",
     "summary": "Irish actor Gary Lydon, known for roles including The Banshees of Inisherin, has died at 61, prompting tributes across Ireland’s film and television community.",
@@ -1133,35 +626,6 @@
     "desk": "arts-entertainment",
     "date": "2026-05-04",
     "url": "/articles/2026-05-04-irish-actor-and-banshees-of-inisherin-star-gary-lydon-dies-aged-61/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "slug": "2026-05-04-how-7-looks-for-the-devil-wears-prada-2-came-together",
-    "title": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together",
-    "description": "How 7 Looks for ‘The Devil Wears Prada 2’ Came Together is drawing fresh attention today, according to recent reporting. This article summarizes what happened, why it matters for the arts entertainment desk, and what to watch next.",
-    "author": "Camille Vega",
-    "desk": "arts-entertainment",
-    "date": "2026-05-04",
-    "url": "/articles/2026-05-04-how-7-looks-for-the-devil-wears-prada-2-came-together/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Could Santa Marta climate talks mark ground zero in push to ditch fossil fuels?",
-    "date": "2026-05-04",
-    "author": "Rowan Hale",
-    "desk": "environment",
-    "summary": "Colombia hosted nearly 60 countries at pivotal time on world stage for fight to transition to a clean energy futureLooking out to sea from the grey sandy beaches of Santa Marta, on",
-    "link": "/articles/2026-05-04-could-santa-marta-climate-talks-mark-ground-zero-in-push-to-ditch-foss/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-04-nhs-cancer-jab-could-mean-patients-spend-hours-less-in-hospital",
-    "title": "NHS cancer jab could mean patients spend hours less in hospital",
-    "summary": "Thousands of patients will be offered a new injectable form of an immunotherapy drug that takes minutes.",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "date": "2026-05-04T05:31:50Z",
-    "link": "/articles/2026-05-04-nhs-cancer-jab-could-mean-patients-spend-hours-less-in-hospital/",
     "image": "/images/news-banner.png"
   },
   {
@@ -1178,56 +642,6 @@
     "permalink": "/articles/2026-05-04-what-is-mythos-and-why-are-experts-worried-about-anthropic-s-ai-model-scientific-american/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/342"
-  },
-  {
-    "slug": "2026-05-04-the-iran-war-has-strengthened-ukraine-in-surprising-ways-could-a-ceasefire-with-",
-    "title": "The Iran war has strengthened Ukraine in surprising ways. Could a ceasefire with Russia be closer?",
-    "date": "2026-05-04",
-    "desk": "world",
-    "author": "Elias Navarro",
-    "summary": "President Zelensky has been visiting the Gulf to demonstrate his country's military nous.",
-    "image": "/images/news-banner.png",
-    "url": "/articles/2026-05-04-the-iran-war-has-strengthened-ukraine-in-surprising-ways-could-a-ceasefire-with-/"
-  },
-  {
-    "slug": "2026-05-04-has-tide-turned-for-troubled-spurs-under-de-zerbi",
-    "title": "Has tide turned for troubled Spurs under De Zerbi?",
-    "date": "2026-05-04",
-    "author": "Jordan Reeves",
-    "desk": "sports",
-    "summary": "Is Tottenham Hotspur's superb win at Aston Villa the moment the tide turned in  their fight against Premier League relegation, asks chief football writer Phil McNulty?",
-    "url": "/articles/2026-05-04-has-tide-turned-for-troubled-spurs-under-de-zerbi/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
-    "slug": "2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz",
-    "title": "The ‘Devil Wears Prada 2’ Costume Rollout Fuels a New Fashion-Marketing Playbook",
-    "summary": "Early wardrobe reveals for The Devil Wears Prada 2 are being treated as headline entertainment and fashion moments, signaling a broader shift in how sequel campaigns are packaged across media.",
-    "date": "2026-05-04T01:00:00Z",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "author": "Camille Vega",
-    "author_id": "arts-entertainment_lead",
-    "author_display_name": "Camille Vega",
-    "permalink": "/articles/2026-05-04-devil-wears-prada-2-costume-rollout-drives-fashion-buzz/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/339"
-  },
-  {
-    "id": "2026-05-04-alphabet-investors-push-for-safeguards-on-use-of-its-cloud-ai-tech-reuters",
-    "slug": "2026-05-04-alphabet-investors-push-for-safeguards-on-use-of-its-cloud-ai-tech-reuters",
-    "title": "Alphabet investors push for safeguards on use of its cloud, AI tech - Reuters",
-    "summary": "&lt;a href=\"https://news.google.com/rss/articles/CBMizAFBVV95cUxPcERkU19SVlh1S1RoTUxDYkcwcWt0TUlQcnlhcG5VWVBESHVkRDhWTW56RTNfNmxRN044VUY1V1F0bE9pNzRic0lZbDRwNU5VWnVwYk1naGY1dzBwOS1XbXJBYkM1ZWZ4bXRpM3lxZTc3MkM2VUlqZjk3...",
-    "date": "2026-05-04T00:11:13Z",
-    "subject": "technology",
-    "category": "technology",
-    "author": "Adeline Park",
-    "author_id": "technology_lead",
-    "author_display_name": "Adeline Park",
-    "permalink": "/articles/2026-05-04-alphabet-investors-push-for-safeguards-on-use-of-its-cloud-ai-tech-reuters/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/337"
   },
   {
     "id": "2026-05-03-california-last-persian-gulf-oil-shipment-long-beach",
@@ -1256,19 +670,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "id": "2026-05-03-carrick-secures-champions-league-what-are-man-utd-waiting-for",
-    "slug": "2026-05-03-carrick-secures-champions-league-what-are-man-utd-waiting-for",
-    "title": "Carrick secures Champions League - what are Man Utd waiting for?",
-    "summary": "Unless Manchester United appoint Luis Enrique, it is hard to think of an acceptable alternative to giving Michael Carrick the job on a permanent basis, writes Simon Stone.",
-    "date": "2026-05-03T21:00:37Z",
-    "subject": "sports",
-    "category": "sports",
-    "author": "Jordan Reeves",
-    "permalink": "/articles/2026-05-03-carrick-secures-champions-league-what-are-man-utd-waiting-for/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/334"
-  },
-  {
     "id": "2026-05-03-ai-er-diagnosis-harvard-study",
     "title": "AI triage tools outperform two ER doctors in Harvard-linked evaluation",
     "permalink": "/articles/2026-05-03-ai-er-diagnosis-harvard-study",
@@ -1280,22 +681,6 @@
     "author_display_name": "Adeline Park",
     "status": "published",
     "image": "/images/news-banner.png"
-  },
-  {
-    "slug": "update-ask-com-shuts-down-search-engine-2026-05-03",
-    "title": "Update: Ask.com Ends Consumer Search Service After Nearly Three Decades",
-    "date": "2026-05-03",
-    "author": "Adeline Park",
-    "desk": "technology",
-    "tags": [
-      "technology",
-      "search",
-      "internet history"
-    ],
-    "excerpt": "Ask.com, formerly Ask Jeeves, has ended its consumer search service, highlighting continued consolidation in the search market.",
-    "image": "/images/news-banner.png",
-    "path": "/articles/2026-05-03-update-ask-com-shuts-down-search-engine-2026-05-03/",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/331"
   },
   {
     "id": "2026-05-03-the-seven-day-a-week-life-of-a-maid-in-qatar",
@@ -1332,25 +717,6 @@
     "subject": "science-health",
     "category": "science-health",
     "permalink": "/articles/2026-05-03-just-10-minutes-of-daily-floor-exercises-may-improve-balance-and-agility-study-f",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "From shared toothbrushes to mid-sex water bladders, You Be the Judge tries to settle domestic disputes. But what happened next?",
-    "date": "2026-05-03",
-    "author": "Nico Laurent",
-    "desk": "lifestyle",
-    "summary": "For five years, our column has attempted to settle rows about the important little things … but what happens after the verdicts are in?Since 2021, I’ve had one of the most brilliantly nosy jobs in journalism. Writing ...",
-    "link": "/articles/from-shared-toothbrushes-to-mid-sex-water-bladders-you-be-the-judge-tries-to-settle-domest/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "slug": "in-pictures-wednesday-s-beaver-supermoon-captured-around-the-world",
-    "title": "In pictures: Wednesday's Beaver supermoon captured around the world",
-    "date": "2026-05-03T11:27:07Z",
-    "desk": "world",
-    "author": "Elias Navarro",
-    "summary": "In pictures: Wednesday's Beaver supermoon captured around the world: key confirmed developments and why this matters for the world desk.",
-    "url": "/articles/in-pictures-wednesday-s-beaver-supermoon-captured-around-the-world/",
     "image": "/images/news-banner.png"
   },
   {
@@ -1395,16 +761,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/318"
   },
   {
-    "title": "U.S. Fast-Tracks Arms Deals Valued at $8.6 Billion to Mideast Partners",
-    "date": "2026-05-03T07:13:00Z",
-    "author": "Maya Sterling",
-    "desk": "news-politics",
-    "summary": "The Persian Gulf countries and Israel have faced repeated Iranian attacks during the U.S.-Israeli war with Iran. The State Department move bypassed congressional review.",
-    "url": "/articles/u-s-fast-tracks-arms-deals-valued-at-8-6-billion-to-mideast-partners/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/316"
-  },
-  {
     "id": "2026-05-03-efl-transfer-news-rumours-and-gossip-for-championship-league-one-and-league-two",
     "title": "EFL transfer news, rumours and gossip for Championship, League One and League Two",
     "summary": "Live desk brief on EFL transfer news, rumours and gossip for Championship, League One and League Two.",
@@ -1447,16 +803,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/311"
   },
   {
-    "slug": "2026-05-03-investigation-update-salmonella-outbreak-april-2026-centers-for-diseas",
-    "title": "Investigation Update: Salmonella Outbreak, April 2026 - Centers for Disease Control and Prevention | CDC (.gov)",
-    "date": "2026-05-03",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "summary": "&lt;a href=\"https://news.google.com/rss/articles/CBMigAFBVV95cUxPVXRMWFBhYU54VjBBVEtLZDZZeUU4SEV1c1haZmgzYW4wRHk0NFNRX2p5b01yd0lLLWVUYVFRVlBLLXM0WDEzdjRFaWFsYk1UMHNoTTdMaEdmN2FHdzZVRFlubEc0WldEcllDZVRSZXMwSXdmZjFUVmZJWnh",
-    "link": "/articles/2026-05-03-investigation-update-salmonella-outbreak-april-2026-centers-for-diseas/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "id": "2026-05-03-iran-war-is-supercharging-the-clean-energy-transition-un-climate-chief-says",
     "slug": "2026-05-03-iran-war-is-supercharging-the-clean-energy-transition-un-climate-chief-says",
     "title": "Iran war is accelerating clean-energy investment signals, UN climate chief says",
@@ -1470,47 +816,6 @@
     "permalink": "/articles/2026-05-03-iran-war-is-supercharging-the-clean-energy-transition-un-climate-chief-says/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/307"
-  },
-  {
-    "slug": "who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh",
-    "title": "WHO Member States agree to extend negotiations on Pathogen Access and Benefit Sharing annex",
-    "date": "2026-05-02T23:48:19Z",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "summary": "Member States of the World Health Organization (WHO) have progressed work on the Pathogen Access and Benefit Sharing (PABS) annex, a key part of the WHO Pandemic Agreement, and today agreed additional time was needed to ",
-    "image": "/images/news-banner.png",
-    "url": "/articles/who-member-states-agree-to-extend-negotiations-on-pathogen-access-and-benefit-sh/",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/306"
-  },
-  {
-    "id": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",
-    "slug": "2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency",
-    "title": "Turkey signals COP31 push for stronger global climate action",
-    "summary": "Reuters reports Turkey says it would use a COP31 presidency to press stronger multilateral climate action, signaling an attempt to shape post-COP30 negotiations around implementation and finance.",
-    "date": "2026-05-02T22:44:00Z",
-    "subject": "environment",
-    "category": "environment",
-    "author": "Rowan Hale",
-    "author_id": "rowan-hale",
-    "author_display_name": "Rowan Hale",
-    "permalink": "/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/305"
-  },
-  {
-    "id": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",
-    "slug": "2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls",
-    "title": "Strait of Hormuz: U.S. warns shipping firms over Iran passage payments",
-    "summary": "The US has warned shipping companies they could face sanctions if they pay Iran for safe passage through the Strait of Hormuz, as tanker traffic through the waterway drops sharply.",
-    "date": "2026-05-02T21:40:37Z",
-    "subject": "world",
-    "category": "world",
-    "author": "Elias Navarro",
-    "author_id": "elias-navarro",
-    "author_display_name": "Elias Navarro",
-    "permalink": "/articles/2026-05-02-us-threatens-shipping-firms-with-sanctions-if-they-pay-iran-tolls/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/304"
   },
   {
     "id": "2026-05-02-the-craziest-part-of-musk-v-altman-happened-while-the-jury-was-out-of-the-room-the-verge",
@@ -1544,21 +849,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/301"
   },
   {
-    "id": "2026-05-02-peter-kay-show-to-go-ahead-after-bomb-hoax-arrest",
-    "slug": "2026-05-02-peter-kay-show-to-go-ahead-after-bomb-hoax-arrest",
-    "title": "Peter Kay show to go ahead after bomb hoax arrest",
-    "summary": "A teenage man remains in custody and police say no items of a suspicious nature were found.",
-    "date": "2026-05-02T16:24:12Z",
-    "subject": "arts-entertainment",
-    "category": "arts-entertainment",
-    "author": "Camille Vega",
-    "author_id": "camille-vega",
-    "author_display_name": "Camille Vega",
-    "permalink": "/articles/2026-05-02-peter-kay-show-to-go-ahead-after-bomb-hoax-arrest/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/298"
-  },
-  {
     "id": "2026-05-02-opinion-what-is-higher-education-for-the-new-york-times",
     "permalink": "/articles/2026-05-02-opinion-what-is-higher-education-for-the-new-york-times",
     "title": "Opinion | What Is Higher Education For? - The New York Times",
@@ -1572,21 +862,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "id": "2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact",
-    "slug": "2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact",
-    "title": "Mortgages, jobs and energy bills - how the Iran war will affect your money",
-    "summary": "BBC reports that households in the UK could face pressure on mortgages, jobs and energy bills as Iran-war volatility feeds into inflation and borrowing costs.",
-    "date": "2026-05-02T14:14:38Z",
-    "subject": "business-economy",
-    "category": "business-economy",
-    "author": "Priya Desai",
-    "author_id": "priya-desai",
-    "author_display_name": "Priya Desai",
-    "permalink": "/articles/2026-05-02-mortgages-jobs-energy-bills-iran-war-money-impact/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/295"
-  },
-  {
     "id": "hard-choices-test-breakaway-climate-summit",
     "title": "Hard choices test breakaway climate summit",
     "date": "2026-05-02T13:09:21Z",
@@ -1596,15 +871,6 @@
     "summary": "World desk briefing on Hard choices test breakaway climate summit.",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/294"
-  },
-  {
-    "title": "About the Global Health Center - Centers for Disease Control and Prevention | CDC (.gov)",
-    "date": "2026-05-02",
-    "desk": "science-health",
-    "author": "Dr. Lena Okafor",
-    "summary": "About the Global Health Center&nbsp;&nbsp;Centers for Disease Control and Prevention | CDC (.gov)",
-    "url": "/articles/about-the-global-health-center-centers-for-disease-control-and-prevention-cdc-go/",
-    "image": "/images/news-banner.png"
   },
   {
     "id": "2026-05-02-update-voting-rights-act-ruling-reshapes-redistricting-fight",
@@ -1620,31 +886,6 @@
     "permalink": "/articles/2026-05-02-update-voting-rights-act-ruling-reshapes-redistricting-fight/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/290"
-  },
-  {
-    "title": "There was one way we'd agreed to do Devil Wears Prada 2, says Meryl Streep",
-    "slug": "2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str",
-    "desk": "arts-entertainment",
-    "author": "Camille Vega",
-    "date": "2026-05-02T08:56:54Z",
-    "summary": "The sequel's stars on what's changed since the original, and why the film still resonates with women.",
-    "url": "/articles/2026-05-02-there-was-one-way-we-d-agreed-to-do-devil-wears-prada-2-says-meryl-str/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
-    "slug": "2026-05-02-greens-pledge-15-minimum-wage-for-all-workers",
-    "title": "Greens pledge £15 minimum wage for all workers",
-    "summary": "The Green Party says it would raise the minimum wage to £15 for all workers, adding a fresh dividing line in the UK election debate over pay, inflation and business costs.",
-    "date": "2026-05-02T07:50:30Z",
-    "subject": "news-politics",
-    "category": "news-politics",
-    "author": "Maya Sterling",
-    "author_id": "maya-sterling",
-    "author_display_name": "Maya Sterling",
-    "permalink": "/articles/2026-05-02-greens-pledge-15-minimum-wage-for-all-workers/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/286"
   },
   {
     "id": "2026-05-02-pistons-rally-from-24-down-to-beat-magic-93-79-force-game-7",
@@ -1677,16 +918,6 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/283"
   },
   {
-    "slug": "2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail",
-    "title": "Federal Appeals Court Temporarily Halts Abortion Pill Access by Mail",
-    "date": "2026-05-02T04:39:18Z",
-    "author": "Nico Laurent",
-    "desk": "lifestyle",
-    "summary": "The court order, in a lawsuit by the state of Louisiana, pauses a Food and Drug Administration regulation that greatly expanded access to the abortion pill mifepristone.",
-    "image": "/images/news-banner.png",
-    "url": "/articles/2026-05-02-federal-appeals-court-temporarily-halts-abortion-pill-access-by-mail/"
-  },
-  {
     "id": "2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others",
     "slug": "2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others",
     "title": "Microsoft, OpenAI change terms of deal so startup can court Amazon and others",
@@ -1700,27 +931,6 @@
     "permalink": "/articles/2026-05-02-microsoft-openai-change-terms-of-deal-so-startup-can-court-amazon-and-others/",
     "image": "/images/news-banner.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/281"
-  },
-  {
-    "slug": "2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering",
-    "title": "Supreme Court ruling expected to expand gerrymandering battles",
-    "date": "2026-05-02",
-    "author": "Maya Sterling",
-    "desk": "news-politics",
-    "summary": "NPR reports that a new U.S. Supreme Court ruling is expected to accelerate partisan map-drawing, reshaping state-level redistricting battles ahead of upcoming election cycles.",
-    "image": "/images/news-banner.png",
-    "url": "/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering/",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/280"
-  },
-  {
-    "slug": "2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz",
-    "title": "US to cut troop levels in Germany by 5,000 amid Trump spat with Merz",
-    "date": "2026-05-02",
-    "author": "Elias Navarro",
-    "desk": "world",
-    "summary": "The decision to reduce the US deployment to Germany comes amid a row between the two allies over Iran.",
-    "image": "/images/news-banner.png",
-    "url": "/articles/2026-05-02-us-to-cut-troop-levels-in-germany-by-5-000-amid-trump-spat-with-merz/"
   },
   {
     "id": "2026-05-01-as-summer-opens-action-movies-have-lost-some-box-office-punch",
@@ -1744,20 +954,6 @@
     "category": "business-economy",
     "permalink": "/articles/markets-brief-us-fed-independence-at-risk-updates-on-inflation-tariffs-bank-earn/",
     "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-01-world-s-largest-study-of-women-s-health-marks-30-years-of-pioneering-research-ndph-ox-ac-u",
-    "title": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk",
-    "summary": "World’s largest study of women’s health marks 30 years of pioneering research - ndph.ox.ac.uk is drawing current attention. This report summarizes what is confirmed, what remains uncertain, and why it matters for the science-health desk.",
-    "date": "2026-05-01T21:04:46Z",
-    "subject": "science-health",
-    "category": "science-health",
-    "author": "Dr. Lena Okafor",
-    "author_id": "science_health_lead",
-    "author_display_name": "Dr. Lena Okafor",
-    "permalink": "/articles/2026-05-01-world-s-largest-study-of-women-s-health-marks-30-years-of-pioneering-research-ndph-ox-ac-u/",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/275"
   },
   {
     "id": "2026-05-01-the-rise-of-climate-gentrification-who-is-being-priced-out-of-the-high-ground",
@@ -1786,20 +982,6 @@
     "permalink": "/articles/2026-05-01-dprk-korea-continued-militarisation-a-serious-concern-political-affairs-chief-warns-security-counci/",
     "image": "/images/articles/2026-05-01-dprk-korea-continued-militarisation-a-serious-concern-political-affairs-chief-warns-security-counci.png",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/270"
-  },
-  {
-    "id": "2026-05-01-update-pentagon-expands-classified-ai-contracts",
-    "title": "Update: Pentagon expands classified AI contracts to multiple cloud and model vendors",
-    "summary": "New reporting indicates the Pentagon’s classified AI contracting has broadened beyond Google to include additional major vendors, signaling a wider procurement push across secure defense networks.",
-    "date": "2026-05-01T16:46:26Z",
-    "subject": "technology",
-    "category": "technology",
-    "author": "Adeline Park",
-    "author_id": "technology_lead",
-    "author_display_name": "Adeline Park",
-    "permalink": "/articles/2026-05-01-update-pentagon-expands-classified-ai-contracts/",
-    "image": "/images/articles/2026-05-01-update-pentagon-expands-classified-ai-contracts.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/269"
   },
   {
     "id": "2026-05-01-us-senate-bans-members-staff-prediction-markets",
@@ -1862,36 +1044,6 @@
     "author": "Adeline Park",
     "path": "articles/2026-05-01-apple-iphone-revenue-q2-2026-chip-shortages/",
     "image": "/images/articles/2026-05-01-apple-iphone-revenue-q2-2026-chip-shortages.png"
-  },
-  {
-    "title": "The struggle to get hold of medication in England is set to get worse",
-    "date": "2026-05-01",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "summary": "People living with conditions include heart problems, stroke risks, eye infections and bipolar are unable to get hold of the drugs they rely on.",
-    "url": "/content/articles/2026-05-01-the-struggle-to-get-hold-of-medication-in-england-is-set-to-get-worse.md",
-    "image": "/images/articles/2026-05-01-the-struggle-to-get-hold-of-medication-in-england-is-set-to-get-worse.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/260"
-  },
-  {
-    "title": "Microsoft’s AI Growth Signals Big Upside Ahead",
-    "date": "2026-05-01",
-    "author": "Adeline Park",
-    "desk": "technology",
-    "summary": "New York surged to a record 47-point halftime cushion against Atlanta and moved on, a benchmark blowout that reframes Eastern Conference expectations.",
-    "url": "/content/articles/2026-05-01-microsoft-s-ai-growth-signals-big-upside-ahead.md",
-    "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/258"
-  },
-  {
-    "title": "Trump Is the One Without the Cards at the Poker Table",
-    "date": "2026-05-01",
-    "author": "Simone Hart",
-    "desk": "opinion-editorials",
-    "summary": "A.I. will drastically increase the power of small states and groups in conflict with the great powers.",
-    "url": "/content/articles/2026-05-01-trump-is-the-one-without-the-cards-at-the-poker-table.md",
-    "image": "/images/articles/2026-05-01-trump-is-the-one-without-the-cards-at-the-poker-table.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/256"
   },
   {
     "id": "2026-05-01-too-dangerous-to-release-is-becoming-ai-s-new-normal",
@@ -3557,30 +2709,6 @@
     "image": "/images/news-banner.png"
   },
   {
-    "id": "2026-05-04-epa-moves-to-repeal-climate-endangerment-finding",
-    "title": "Trump EPA set to repeal scientific finding that serves as basis for US climate change policy",
-    "summary": "The U.S. Environmental Protection Agency is moving to repeal its endangerment finding on greenhouse gases, a foundational legal basis for federal climate regulation, opening a major new policy and court fight over future emissions rules.",
-    "author": "Rowan Hale",
-    "author_id": "environment_lead",
-    "author_display_name": "Rowan Hale",
-    "date": "2026-05-04",
-    "subject": "environment",
-    "category": "environment",
-    "permalink": "/articles/2026-05-04-epa-moves-to-repeal-climate-endangerment-finding/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "id": "2026-05-05-norway-fish-farm-waste-fjords-pollution-report",
-    "title": "Norway fish-farm waste report raises pressure over fjord pollution",
-    "summary": "A new analysis cited by The Guardian says waste from Norwegian salmon aquaculture is adding nutrient loads to coastal waters on a scale likened to untreated sewage, intensifying pressure on fjord ecosystems and regulation debates.",
-    "author": "Rowan Hale",
-    "date": "2026-05-05",
-    "subject": "environment",
-    "category": "environment",
-    "permalink": "/articles/2026-05-05-norway-fish-farm-waste-fjords-pollution-report/",
-    "image": "/images/news-banner.png"
-  },
-  {
     "title": "FDA Fast Track Designation for Oncology Drugs in April 2026 - Oncology News Central",
     "author": "Dr. Lena Okafor",
     "date": "2026-05-06",
@@ -3588,24 +2716,6 @@
     "category": "science-health",
     "permalink": "/articles/fda-fast-track-designation-for-oncology-drugs-in-april-2026-oncology-news-centra/",
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/400",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "Two Britons self-isolating in UK after leaving hantavirus cruise ship",
-    "date": "2026-05-07",
-    "desk": "opinion-editorials",
-    "author": "Simone Hart",
-    "summary": "Two Britons self-isolating in UK after leaving hantavirus cruise ship",
-    "link": "/articles/two-britons-self-isolating-in-uk-after-leaving-hantavirus-cruise-ship/",
-    "image": "/images/news-banner.png"
-  },
-  {
-    "title": "WHO’s response to hantavirus cases linked to a cruise ship",
-    "date": "2026-05-08",
-    "author": "Dr. Lena Okafor",
-    "desk": "science-health",
-    "summary": "Dr Tedros Adhanom Ghebreyesus, WHO Director-General, briefed media today on a cluster of hantavirus cases linked to a cruise ship, the MV Hondius.Eight cases have been reported so ",
-    "link": "/articles/who-s-response-to-hantavirus-cases-linked-to-a-cruise-ship/",
     "image": "/images/news-banner.png"
   }
 ]


### PR DESCRIPTION
## Summary
Remediates broken internal article links emitted by `assets/data/articles.json`.

## Root cause
Feed/index data contained many unpublished or wrong-route entries that 404 in production, including one in the date-sorted newest-3 set.

## Fix
- Pruned entries whose emitted article URL does not resolve on live site and has no canonical `/articles|posts/<slug>` variant returning 2xx/3xx.
- Preserved entries that resolve; canonicalized 2 entries to a working variant.

## Verification
- Key routes return 200 (`/`, `/about/index.html`, `/subjects/index.html`, `/articles/`).
- Newest-3 (date-sorted) all return 200 after data fix.
- At least one standards link reachable (`standards/editorial-standards.md` -> 200).

This is a data remediation to stop homepage/latest/feed from emitting hard 404s.
