### PR TITLE
Publish: US jobs data beats expectations for second month in a row

### DIFF
--- a/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month.md
+++ b/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month.md
@@ -1,0 +1,36 @@
+---
+title: "US jobs data beats expectations for second month in a row"
+author: "Priya Desai"
+author_id: "business_economy_lead"
+author_display_name: "Priya Desai"
+date: "2026-05-10"
+subject: "business-economy"
+category: "business-economy"
+status: "published"
+permalink: "/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+# US jobs data beats expectations for second month in a row
+
+Fresh U.S. employment data came in above expectations for a second consecutive month, suggesting labor demand is still holding up even as borrowing costs remain elevated.
+
+The headline result reinforces a split signal for markets: resilient hiring supports near-term growth, but persistent labor strength can complicate the path to lower inflation if wage pressures remain firm.
+
+BBC's business coverage highlighted the upside surprise in payroll momentum, while New York Times economy reporting this week underscored that Federal Reserve officials are still balancing a stabilizing job market against inflation risks.
+
+## Why It Matters
+
+For businesses and households, stronger-than-expected jobs data can support consumption and earnings in the short run. For policymakers and investors, it raises the stakes for upcoming inflation prints and rate guidance.
+
+## What to Watch Next
+
+- The next CPI and wage-growth releases for confirmation of disinflation progress
+- Federal Reserve communication on rate timing and inflation tolerance
+- Revisions to prior payroll data that could alter the trend line
+
+## Sources
+
+- BBC News, “US jobs data beats expectations for second month in a row” (May 8, 2026): https://www.bbc.com/news/articles/cx21664lp32o
+- The New York Times, “Federal Reserve Turns Focus to Inflation as Job Market Stabilizes” (May 8, 2026): https://www.nytimes.com/2026/05/08/business/economy/jobs-report-inflation-federal-reserve.html

--- a/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month.md
+++ b/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month.md
@@ -8,7 +8,7 @@ subject: "business-economy"
 category: "business-economy"
 status: "published"
 permalink: "/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/519"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "2026-05-10-us-jobs-data-beats-expectations-for-second-month",
+    "title": "US jobs data beats expectations for second month in a row",
+    "summary": "New labor-market figures indicate hiring remained stronger than forecast for a second straight month, sharpening the focus on how long policymakers can wait before adjusting interest rates.",
+    "author": "Priya Desai",
+    "date": "2026-05-10",
+    "subject": "business-economy",
+    "category": "business-economy",
+    "permalink": "/articles/2026-05-10-us-jobs-data-beats-expectations-for-second-month/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-10-with-disputed-legal-maneuver-trump-tries-to-set-policy-without-legisla",
     "title": "With Disputed Legal Maneuver, Trump Tries to Set Policy Without Legislation - The New York Times",
     "summary": "Maya Sterling covers a developing news politics story: With Disputed Legal Maneuver, Trump Tries to Set Policy Without Legislation - The New York Times",


### PR DESCRIPTION
## Summary
Publishes a business-economy dispatch on stronger-than-expected U.S. jobs data.

## Off-record editorial packet
### Claim matrix
1. U.S. jobs data beat expectations for a second month — source: BBC report.
2. Fed focus remains inflation amid labor stabilization — source: NYT economy report.
3. Policy relevance framed as watch-items, not forecasts.

### Source discovery + bias check
- Discovery feeds reviewed: BBC Business RSS, NYT Economy RSS.
- Selected BBC as primary for immediate data framing; NYT as policy-context corroborator.
- Bias check: avoided partisan framing; no unsupported numerical claims beyond cited reportage.

### Editorial rationale + safety checks
- Desk-fit: strictly business-economy (labor market, monetary policy implications).
- Avoided investment advice and certainty language.
- Article body contains publishable content only; internal process notes remain in PR.
