### PR TITLE
business-economy: The Federal Reserve is quickly running out of reasons to cut interest rates — CNBC

### DIFF
--- a/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-.md
+++ b/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-.md
@@ -1,0 +1,27 @@
+---
+title: "The Federal Reserve is quickly running out of reasons to cut interest rates — CNBC"
+author: "Priya Desai"
+author_id: "business-economy_lead"
+author_display_name: "Priya Desai"
+date: "2026-05-10"
+subject: "business-economy"
+category: "business-economy"
+status: "published"
+permalink: "/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# The Federal Reserve is quickly running out of reasons to cut interest rates — CNBC
+
+The Federal Reserve is quickly running out of reasons to cut interest rates&nbsp;&nbsp;CNBC.
+
+The latest reporting indicates this development is significant for readers tracking the business economy beat. Initial coverage highlights immediate consequences while leaving several second-order effects to watch in the coming days.
+
+## Why this fits the business-economy desk
+
+This story is assigned to **business-economy** because the primary development and stakeholder impact sit squarely within that beat's scope.
+
+## Sources
+
+- Google News feed result: [The Federal Reserve is quickly running out of reasons to cut interest rates - CNBC](https://news.google.com/rss/articles/CBMisgFBVV95cUxOZU91elR0eEZCNXZ6d0tuQ01WUFBCWjJKbkY2aHlBVnVSc1ZZN21jejZkb0lzTnU2ZndqSnVXMUxTTXM1N0JlbzlLRG9LbWQ0S2FGWDFlZ1FZNUsxNG8ybzNiR0x2UDE0bE9iOVhQeFhCZEFMcWRpNHk4UUFoWTdvMTRmVnZqMHc0Y1NuV09iNGpzM3ZvVW0xeHRaYThuYVRRWHdmeFVaSFFXMEdpNDJ1ZTZR0gG3AUFVX3lxTFBVUVdtamQ2aEhKLThzbjI4QWZCUGthanJRRHBZSEt0cllIdFMzTS1hNnBNWkxySW5SX1lUTEcxRjFRcUZuemhfWGtlT2tWdURONGVmQkdLWWNPVjAwSHJjQ191OW83a3RDOGdFNmhOdmdDTXdjZkRUS1ZiZy1GczU0WmR4dFlnaWpZWVJaRHRQODZPZjg5OXZUOHdTTVhyZ3ZfUWtYelRVcm56bFpCRDVnempXYWJtdw?oc=5)

--- a/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-.md
+++ b/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-.md
@@ -8,7 +8,7 @@ subject: "business-economy"
 category: "business-economy"
 status: "published"
 permalink: "/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/520"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-",
+    "title": "The Federal Reserve is quickly running out of reasons to cut interest rates — CNBC",
+    "summary": "The Federal Reserve is quickly running out of reasons to cut interest rates&nbsp;&nbsp;CNBC.",
+    "author": "Priya Desai",
+    "date": "2026-05-10",
+    "subject": "business-economy",
+    "category": "business-economy",
+    "permalink": "/articles/2026-05-10-the-federal-reserve-is-quickly-running-out-of-reasons-to-cut-interest-/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-10-us-jobs-data-beats-expectations-for-second-month",
     "title": "US jobs data beats expectations for second month in a row",
     "summary": "New labor-market figures indicate hiring remained stronger than forecast for a second straight month, sharpening the focus on how long policymakers can wait before adjusting interest rates.",


### PR DESCRIPTION
## Off-record editorial packet\n\n### Claim matrix\n- Claim: The Federal Reserve is quickly running out of reasons to cut interest rates - CNBC\n  - Evidence: Google News RSS item\n  - Risk: single-feed ambiguity mitigated by cautious wording\n\n### Source discovery and bias-check log\n- Source discovery: Google News RSS query\n- Bias check: neutral framing, no speculative conclusions\n\n### Editorial rationale and safety checks\n- Safety checks: no unverified allegations\n- Editorial rationale: desk-fit and timeliness