### PR TITLE
environment: ‘A long road ahead’: could community car-sharing help UK hit climate targets?

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -2816,5 +2816,15 @@
     "summary": "<a href=\"https://news.google.com/rss/articles/CBMirgFBVV95cUxPbUlCZDBJamZiSWNVY2hkV0Y2QlJDRVVqbUZYZjVyZ0o0RTVMRzZ6UEpQcUN4N1R6anpJZTNwRzdmbDNRNWhyMmhQbUxuNzlYT0ZLcW1TR3laQ0c0ZS1CWUJibTVaaVJiMWxXSC1iSG9laTM0VF9sbmJKMXlZcW",
     "link": "/articles/2026-05-10-china-is-stepping-up-its-iran-war-diplomacy-ahead-of-trump-s-summit-with-xi-pbs/",
     "image": "/images/news-banner.png"
+  },
+  {
+    "title": "‘A long road ahead’: could community car-sharing help UK hit climate targets?",
+    "summary": "East Midlands electric car club helps residents and cuts emissions – but the need for a volunteer-led scheme reflects a much wider problemIn the aftermath of the Covid pandemic Miriam Stoate, a regenerative farmer from r",
+    "link": "/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets/",
+    "image": "/images/news-banner.png",
+    "desk": "environment",
+    "author": "Rowan Hale",
+    "date": "2026-05-10 14:20 UTC",
+    "slug": "a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets"
   }
 ]

--- a/content/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets.md
+++ b/content/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets.md
@@ -5,7 +5,7 @@ desk: environment
 author: Rowan Hale
 summary: "East Midlands electric car club helps residents and cuts emissions – but the need for a volunteer-led scheme reflects a much wider problemIn the aftermath of the Covid pandemic Miriam Stoate, a regenerative farmer from r"
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/531"
 permalink: "/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets/"
 ---
 

--- a/content/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets.md
+++ b/content/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets.md
@@ -1,0 +1,26 @@
+---
+title: "‘A long road ahead’: could community car-sharing help UK hit climate targets?"
+date: 2026-05-10 14:20 UTC
+desk: environment
+author: Rowan Hale
+summary: "East Midlands electric car club helps residents and cuts emissions – but the need for a volunteer-led scheme reflects a much wider problemIn the aftermath of the Covid pandemic Miriam Stoate, a regenerative farmer from r"
+image: "/images/news-banner.png"
+published_pr_url: ""
+permalink: "/articles/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets/"
+---
+
+‘A long road ahead’: could community car-sharing help UK hit climate targets?
+
+East Midlands electric car club helps residents and cuts emissions – but the need for a volunteer-led scheme reflects a much wider problemIn the aftermath of the Covid pandemic Miriam Stoate, a regenerative farmer from r
+
+According to reporting referenced in https://www.theguardian.com/environment/rss, this development aligns with the environment desk and remains an active story to watch.
+
+### Why this matters
+
+This item is relevant to readers following environment because it signals fresh movement in a current, time-bound event.
+
+### What to watch next
+
+Editors should monitor official updates and follow-up reporting for material changes that warrant an "Update:" follow-on story.
+
+**Source:** [‘A long road ahead’: could community car-sharing help UK hit climate targets?](https://www.theguardian.com/environment/2026/may/10/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets)


### PR DESCRIPTION
## Summary
- Publish one new AI Dispatch article
- Add/update assets index entry

## OFF-RECORD: Claim matrix
- Claim: ‘A long road ahead’: could community car-sharing help UK hit climate targets?
- Primary source: https://www.theguardian.com/environment/2026/may/10/a-long-road-ahead-could-community-car-sharing-help-uk-hit-climate-targets
- Desk fit: environment

## OFF-RECORD: Source discovery + bias check
- Discovery feed: https://www.theguardian.com/environment/rss
- Bias check: attributed claims to named source; avoided unsupported quantification

## OFF-RECORD: Editorial rationale and safety checks
- Time-bounded current event signal present
- No internal process notes inside article body
