### PR TITLE
Arts & Entertainment: BAFTA Television Awards 2026 winners announced

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -8,7 +8,7 @@
     "date": "2026-05-10",
     "link": "/articles/2026-05-10-bafta-television-awards-2026-winners-announced/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/538"
   },
   {
     "slug": "tiktok-scales-back-ai-generated-video-descriptions-after-absurd-errors-20260510",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,16 @@
 [
   {
+    "slug": "2026-05-10-bafta-television-awards-2026-winners-announced",
+    "title": "BAFTA Television Awards 2026: Winners announced in London",
+    "summary": "The 2026 BAFTA Television Awards handed out top UK TV honors in London, with major drama and performance categories drawing the most attention.",
+    "desk": "arts-entertainment",
+    "author": "Camille Vega",
+    "date": "2026-05-10",
+    "link": "/articles/2026-05-10-bafta-television-awards-2026-winners-announced/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "slug": "tiktok-scales-back-ai-generated-video-descriptions-after-absurd-errors-20260510",
     "title": "TikTok scales back AI-generated video descriptions after absurd errors",
     "summary": "While only rolled out to some users, the feature's bizarre AI-generated descriptions were shared widely.",

--- a/content/articles/2026-05-10-bafta-television-awards-2026-winners-announced.md
+++ b/content/articles/2026-05-10-bafta-television-awards-2026-winners-announced.md
@@ -1,0 +1,23 @@
+---
+title: "BAFTA Television Awards 2026: Winners announced in London"
+date: "2026-05-10"
+author: "Camille Vega"
+desk: "arts-entertainment"
+summary: "The 2026 BAFTA Television Awards handed out top UK TV honors in London, with major drama and performance categories drawing the most attention."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+The 2026 BAFTA Television Awards were presented in London on Sunday, with winners announced across drama, performance, and entertainment categories.
+
+According to the BBC's published winners list, this year's ceremony recognized a broad mix of public-service broadcasters and streaming platforms, underscoring continued competition across UK television formats.
+
+The awards are closely watched by commissioners, distributors, and talent agencies because they can influence renewal momentum, international sales positioning, and audience discovery for nominated shows.
+
+What to watch next:
+- Post-awards audience lift for headline-winning titles.
+- Whether award momentum translates into commissioning and international licensing activity.
+- Follow-on campaign positioning ahead of the next major TV and film awards cycle.
+
+Sources:
+- https://www.bbc.com/news/articles/cy52ep161z2o
+- https://www.bbc.com/news/articles/c1d2exkg7z5o

--- a/content/articles/2026-05-10-bafta-television-awards-2026-winners-announced.md
+++ b/content/articles/2026-05-10-bafta-television-awards-2026-winners-announced.md
@@ -5,7 +5,7 @@ author: "Camille Vega"
 desk: "arts-entertainment"
 summary: "The 2026 BAFTA Television Awards handed out top UK TV honors in London, with major drama and performance categories drawing the most attention."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/538"
 ---
 The 2026 BAFTA Television Awards were presented in London on Sunday, with winners announced across drama, performance, and entertainment categories.
 


### PR DESCRIPTION
## Summary
Publish one arts-entertainment desk article on the 2026 BAFTA Television Awards winners.

## Claim matrix (off-record)
1. Ceremony held in London and winners announced across TV categories.
   - Source: https://www.bbc.com/news/articles/cy52ep161z2o
2. Awards span broadcast and streaming titles, signaling cross-platform competition.
   - Source: https://www.bbc.com/news/articles/cy52ep161z2o

## Source discovery + bias-check log (off-record)
- Discovery method: desk-targeted RSS scan (BBC entertainment and arts).
- Corroboration: BBC winners list plus BBC red-carpet/event context page.
- Bias check: phrasing kept descriptive and non-promotional; no speculative ratings/financial claims.

## Editorial rationale and safety checks (off-record)
- Desk fit validated as arts-entertainment (television industry awards coverage).
- Removed internal workflow notes from article body; only publishable reader content included.
- No sensitive personal data; no medical/legal/financial advice content.
