### PR TITLE
Update: Anthony Edwards rallies Timberwolves past Spurs after Wembanyama ejection, series level at 2-2

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Update: Anthony Edwards rallies Timberwolves past Spurs after Wembanyama ejection, series level at 2-2",
+    "date": "2026-05-11",
+    "author": "Jordan Reeves",
+    "desk": "sports",
+    "summary": "Minnesota tied its Western Conference semifinal at 2-2 after a 114-109 Game 4 win over San Antonio, in a game that included Victor Wembanyama's first career ejection.",
+    "link": "/articles/2026-05-11-update-anthony-edwards-rallies-timberwolves-after-wembanyama-ejection/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "title": "Gov. Kotek issues executive order placing climate lens on farms, forests, waterways",
     "date": "2026-05-11T04:14:06Z",
     "author": "Rowan Hale",

--- a/content/articles/2026-05-11-update-anthony-edwards-rallies-timberwolves-after-wembanyama-ejection.md
+++ b/content/articles/2026-05-11-update-anthony-edwards-rallies-timberwolves-after-wembanyama-ejection.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "Update: Anthony Edwards rallies Timberwolves past Spurs after Wembanyama ejection, series level at 2-2"
+date: 2026-05-11 05:14:00 +0000
+author: "Jordan Reeves"
+desk: "sports"
+summary: "Minnesota tied its Western Conference semifinal at 2-2 after a 114-109 Game 4 win over San Antonio, in a game that included Victor Wembanyama's first career ejection."
+image: "/images/news-banner.png"
+source_url: "https://www.espn.com/nba/story/_/id/48737913/anthony-edwards-rallies-timberwolves-even-series-spurs"
+published_pr_url: ""
+---
+
+The Minnesota Timberwolves beat the San Antonio Spurs 114-109 in Game 4 on Sunday night, leveling their Western Conference semifinal series at 2-2.
+
+According to ESPN's game report, Anthony Edwards scored 36 points, including a decisive fourth-quarter stretch, and said afterward he dedicated the performance to his late mother. The same report said San Antonio played the closing stretch without Victor Wembanyama after his first career ejection.
+
+A separate Sportsnet match report also described Minnesota's comeback and confirmed the series is now tied.
+
+### What's New
+- Minnesota closed Game 4 with a late run to even the series.
+- The series status changed from Spurs leading to a 2-2 deadlock.
+- Wembanyama's ejection became a central turning point in this game update.
+
+### Why it matters
+With the series reset to best-of-three, home-court and late-game execution become the defining factors for who advances to the conference finals.
+
+### Sources
+- ESPN: https://www.espn.com/nba/story/_/id/48737913/anthony-edwards-rallies-timberwolves-even-series-spurs
+- Sportsnet: https://www.sportsnet.ca/nba/article/edwards-propels-timberwolves-to-series-tie-after-wembanyamas-ejection/

--- a/content/articles/2026-05-11-update-anthony-edwards-rallies-timberwolves-after-wembanyama-ejection.md
+++ b/content/articles/2026-05-11-update-anthony-edwards-rallies-timberwolves-after-wembanyama-ejection.md
@@ -7,7 +7,7 @@ desk: "sports"
 summary: "Minnesota tied its Western Conference semifinal at 2-2 after a 114-109 Game 4 win over San Antonio, in a game that included Victor Wembanyama's first career ejection."
 image: "/images/news-banner.png"
 source_url: "https://www.espn.com/nba/story/_/id/48737913/anthony-edwards-rallies-timberwolves-even-series-spurs"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/548"
 ---
 
 The Minnesota Timberwolves beat the San Antonio Spurs 114-109 in Game 4 on Sunday night, leveling their Western Conference semifinal series at 2-2.


### PR DESCRIPTION
## Summary
Sports desk update on Timberwolves vs Spurs semifinal after Game 4.

## Claim matrix (off-record)
1. Score and series state now 2-2 after Game 4 — ESPN game report and Sportsnet report.
2. Anthony Edwards led late comeback with 36 points — ESPN game report.
3. Victor Wembanyama ejection was a game inflection point — ESPN report; corroborated by Sportsnet framing.

## Source discovery and bias-check log (off-record)
- Candidate feeds checked: BBC Sport RSS, ESPN RSS, Google News sports query.
- Selected topic due to same-event corroboration across ESPN and Sportsnet.
- Bias checks: avoided betting/fan blogs; used two newsroom sports outlets; attributed sensitive details to named sources.

## Editorial rationale and safety checks (off-record)
- Desk fit: pure playoff game development (sports desk only).
- Excluded speculative injury/discipline details not established in cited reports.
- No private or non-publishable process text included in article body.

## Old↔New links
- Prior sports desk article (different Spurs context): /articles/2026-05-04-has-tide-turned-for-troubled-spurs-under-de-zerbi/
- New update article: /articles/2026-05-11-update-anthony-edwards-rallies-timberwolves-after-wembanyama-ejection/
