### PR TITLE
Science-Health: Stoltzfus Family Dairy recalls Sour Cream and Onion Cheese Curds over salmonella risk

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,14 @@
 [
   {
+    "title": "Stoltzfus Family Dairy recalls Sour Cream and Onion Cheese Curds over salmonella risk",
+    "date": "2026-05-11",
+    "author": "Dr. Lena Okafor",
+    "desk": "science-health",
+    "summary": "Stoltzfus Family Dairy says it is recalling Sour Cream and Onion cheese curds after potential salmonella contamination, with FDA and CDC syndication pages carrying the notice.",
+    "link": "/articles/2026-05-11-stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-over-salmonella-risk/",
+    "image": "/images/news-banner.png"
+  },
+  {
     "id": "2026-05-11-top-5-ai-stocks-for-beginners-to-buy-in-2026",
     "title": "Top 5 AI Stocks for Beginners to Buy in 2026",
     "date": "2026-05-11",

--- a/content/articles/2026-05-11-stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-over-salmonella-risk.md
+++ b/content/articles/2026-05-11-stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-over-salmonella-risk.md
@@ -1,0 +1,27 @@
+---
+title: "Stoltzfus Family Dairy recalls Sour Cream and Onion Cheese Curds over salmonella risk"
+slug: "2026-05-11-stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-over-salmonella-risk"
+date: "2026-05-11"
+author: "Dr. Lena Okafor"
+desk: "science-health"
+summary: "Stoltzfus Family Dairy says it is recalling Sour Cream and Onion cheese curds after potential salmonella contamination, with FDA and CDC syndication pages carrying the notice."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+
+# Stoltzfus Family Dairy recalls Sour Cream and Onion Cheese Curds over salmonella risk
+
+Stoltzfus Family Dairy said it is recalling Sour Cream and Onion cheese curds after identifying potential contamination with *Salmonella*, according to an FDA recall notice syndicated through CDC's media feed.
+
+The notice says the product was produced in Vernon Center, New York, and warns that salmonella exposure can cause serious illness in young children, older adults, and people with weakened immune systems.
+
+As of publication, the recall communication describes the action as a voluntary company recall and advises consumers to follow the disposal and refund guidance listed in the official notice.
+
+## Why this matters
+
+Food-recall alerts are a frontline public-health tool: they are designed to reduce preventable illness by quickly warning consumers, retailers, and local health departments when contamination risk is identified.
+
+## Sources
+
+- CDC media API entry (published 2026-05-07): https://tools.cdc.gov/api/v2/resources/media/765407
+- FDA recall notice: https://www.fda.gov/safety/recalls-market-withdrawals-safety-alerts/stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-because-possible-health-risk

--- a/content/articles/2026-05-11-stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-over-salmonella-risk.md
+++ b/content/articles/2026-05-11-stoltzfus-family-dairy-recalls-sour-cream-and-onion-cheese-curds-over-salmonella-risk.md
@@ -6,7 +6,7 @@ author: "Dr. Lena Okafor"
 desk: "science-health"
 summary: "Stoltzfus Family Dairy says it is recalling Sour Cream and Onion cheese curds after potential salmonella contamination, with FDA and CDC syndication pages carrying the notice."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/551"
 ---
 
 # Stoltzfus Family Dairy recalls Sour Cream and Onion Cheese Curds over salmonella risk


### PR DESCRIPTION
## Summary
- New science-health desk article on Stoltzfus Family Dairy cheese-curd recall notice
- Added article metadata entry in `assets/data/articles.json`
- Generated/assigned article image path

## Off-record: claim matrix
1. Claim: Company recalled Sour Cream and Onion cheese curds over potential salmonella risk.
   - Source A: CDC media API item 765407
   - Source B: FDA recall notice page
2. Claim: Notice identifies Vernon Center, NY and elevated risk groups.
   - Source A: FDA recall page text
   - Source B: CDC-syndicated description

## Off-record: source discovery + bias-check log
- Discovery pass used CDC syndicated recall feed for current health-alert candidates.
- Corroborated with the FDA canonical recall page to avoid single-source dependency.
- Bias check: copy avoids speculation on case counts or confirmed illnesses not stated by sources.

## Off-record: editorial rationale and safety checks
- Desk fit: science-health (consumer food-safety/public-health recall).
- Safety: limited claims to what recall notices explicitly state.
- No unverifiable impact estimates included.
