### PR TITLE
Environment | Indonesia forest loss rose sharply in 2025, report says

### DIFF
--- a/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive.md
+++ b/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive.md
@@ -8,7 +8,7 @@ subject: "environment"
 category: "breaking-news"
 status: "published"
 permalink: "/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive/"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/554"
 image: "/images/news-banner.png"
 ---
 
@@ -36,4 +36,4 @@ Why this matters: Indonesia is central to global rainforest conservation and emi
 
 ## Publishing PR
 
-Published via PR: (pending)
+Published via PR: [#554](https://github.com/thestamp/Static-ai-articles/pull/554)

--- a/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive.md
+++ b/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive.md
@@ -1,0 +1,39 @@
+---
+title: "Indonesia's forest loss surged in 2025, driven by expansion for food and energy goals, report says"
+author: "Rowan Hale"
+author_id: "environment_lead"
+author_display_name: "Rowan Hale"
+date: "2026-05-11"
+subject: "environment"
+category: "breaking-news"
+status: "published"
+permalink: "/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive/"
+published_pr_url: "TBD"
+image: "/images/news-banner.png"
+---
+
+# Indonesia's forest loss surged in 2025, driven by expansion for food and energy goals, report says
+
+Indonesia lost substantially more primary forest in 2025 than in 2024, according to new forest-monitoring analysis, with observers linking much of the increase to land conversion pressures tied to domestic food and energy priorities.
+
+Reuters reported that the year-over-year increase reached 66%, citing analysis that connected the shift to policy and market incentives around expansion. The latest figures sharpen concern that climate and biodiversity goals will be harder to meet if large-scale clearing accelerates in high-carbon tropical landscapes.
+
+Officials and analysts continue to debate how much of the increase reflects temporary commodity and policy cycles versus a longer structural trend. But the direction of change in 2025 is clear: loss moved higher, not lower, after prior years of improvement.
+
+Why this matters: Indonesia is central to global rainforest conservation and emissions reduction. A sustained reversal in forest outcomes could affect regional haze risk, biodiversity integrity, and the pace of progress toward international climate commitments.
+
+## What we know
+
+- Confirmed: Reuters reported a 66% surge in Indonesian forest loss in 2025 versus 2024.
+- Confirmed: Reporting tied the increase to land-use expansion pressures associated with national self-sufficiency priorities.
+- Uncertain: Whether this is a one-year spike or the start of a multi-year trend will depend on enforcement, permitting, and commodity dynamics through 2026.
+
+## Sources
+
+- Reuters: https://www.reuters.com/world/asia-pacific/indonesian-forest-loss-surges-by-66-2025-driven-by-prabowos-self-sufficiency-drive-report-shows-2026-03-31/
+- Global Forest Watch (context/data platform): https://www.globalforestwatch.org/
+- World Resources Institute (forest monitoring context): https://www.wri.org/insights/global-tree-cover-loss-data-2024
+
+## Publishing PR
+
+Published via PR: (pending)

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive",
+    "title": "Indonesia's forest loss surged in 2025, driven by expansion for food and energy goals, report says",
+    "summary": "New reporting says Indonesian forest loss jumped sharply in 2025, raising concern over climate and biodiversity progress if land clearing remains elevated.",
+    "author": "Rowan Hale",
+    "author_id": "environment_lead",
+    "author_display_name": "Rowan Hale",
+    "date": "2026-05-11",
+    "category": "environment",
+    "subject": "environment",
+    "permalink": "/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-11-the-biggest-wellness-trends-of-2026-vogue",
     "title": "The Biggest Wellness Trends of 2026",
     "summary": "The Biggest Wellness Trends of 2026. Early coverage indicates developing details; this brief summarizes confirmed facts and what to watch next.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "subject": "environment",
     "permalink": "/articles/2026-05-11-indonesia-forest-loss-surges-2025-prabowo-drive/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/554"
   },
   {
     "id": "2026-05-11-the-biggest-wellness-trends-of-2026-vogue",


### PR DESCRIPTION
## Summary
Publishes one environment desk article on reported 2025 surge in Indonesian forest loss.

## Claim matrix (off-record)
1) Claim: Indonesian forest loss increased 66% in 2025 vs 2024.
   - Source: Reuters report (2026-03-31).
   - Confidence: High.
2) Claim: Increase linked to land expansion pressures associated with self-sufficiency policy push.
   - Source: Reuters framing and attributed analysis.
   - Confidence: Medium-High.
3) Claim: Trend durability into 2026 remains uncertain.
   - Source: Editorial caution based on known policy and commodity variability.
   - Confidence: Medium.

## Source discovery and bias-check log (off-record)
- Discovery path: Google News RSS for environment desk, then Reuters-targeted candidate shortlist.
- Reachability check: Selected Reuters canonical URL reachable in runner context.
- Bias check: Avoided causal overstatement beyond attributed reporting; clearly separated confirmed figures from forward-looking uncertainty.

## Editorial rationale and safety checks (off-record)
- Desk fit: Environment (deforestation and climate implications).
- Harm minimization: No speculation on unverified actors or motives.
- Scope control: Single-event brief, one article only.

## Internal process notes (off-record)
- Image generation via gpt-image-1 unavailable due to missing OPENAI_API_KEY in runner; fallback image used per runbook.
