### PR TITLE
Arts & Entertainment: AMA 2026 performer lineup update

### DIFF
--- a/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands.md
+++ b/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands.md
@@ -1,0 +1,24 @@
+---
+title: "2026 American Music Awards Performer Lineup Expands Ahead of Memorial Day Broadcast"
+author: "Camille Vega"
+author_id: "arts-entertainment_lead"
+author_display_name: "Camille Vega"
+date: "2026-05-11"
+subject: "arts-entertainment"
+category: "arts-entertainment"
+status: "published"
+permalink: "/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+Entertainment outlets are reporting an expanded performer slate for the 2026 American Music Awards as the show approaches its Memorial Day broadcast window.
+
+Billboard reported a growing list of announced acts, while Variety separately highlighted additional names tied to the telecast. Together, those updates indicate the program is still adding talent in the final pre-show stretch.
+
+For labels and artist teams, late-cycle performer additions can materially change audience reach, social-media share of voice, and post-show streaming lift. For viewers, the key watch item is whether producers continue to add collaborative or cross-genre sets in the final week.
+
+### Sources
+- Billboard (via Google News): https://news.google.com/rss/articles/CBMiekFVX3lxTE5vTDk4QkhGLXpqTEl1X2lRUkZVd21wSW00VXJ0TElTbkVRRzVIcUxTZXhCalpMWkRGSEprbWRldkpxbGF2V2c0SjM1TGlnbUVrU1VGZlRPZ2ZsOXFyelNYZGFxOVd5aVJ5VXNfRWE4VkZma1R1bFhHNXZn?oc=5
+- Variety (via Google News): https://news.google.com/rss/articles/CBMioAFBVV95cUxQQWpzSXR6U2o0WUdaSzlTdzZJa2Rra1cwcnpnLTZ2NjhIdVF2anNPRmx5bnNLVGVzaGtBMHN5eXBpRlM0VjFnMFVoVzJvNzhtUmc5UnBURjM3N2psdlJFNXZVVTlkVXRVaXpKTDVOVW1waGxTYUlUN2tpbVVKSUxhOWZjT0lSazhqdFN0WmFVOG50bGx4ODhmT1JWel9uWUtU?oc=5
+- American Music Awards updates hub (Google News): https://news.google.com/search?q=2026+American+Music+Awards+performers

--- a/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands.md
+++ b/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands.md
@@ -8,7 +8,7 @@ subject: "arts-entertainment"
 category: "arts-entertainment"
 status: "published"
 permalink: "/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/562"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,6 +1,20 @@
 [
   {
-    "title": "EDITORIAL: Japan joining growing global trend of declining democracy - \u671d\u65e5\u65b0\u805e",
+    "id": "2026-05-11-2026-american-music-awards-performers-lineup-expands",
+    "title": "2026 American Music Awards Performer Lineup Expands Ahead of Memorial Day Broadcast",
+    "summary": "Billboard and Variety report an expanding 2026 American Music Awards performer slate as producers continue final-week additions ahead of the Memorial Day broadcast.",
+    "author": "Camille Vega",
+    "author_id": "arts-entertainment_lead",
+    "author_display_name": "Camille Vega",
+    "date": "2026-05-11",
+    "category": "arts-entertainment",
+    "subject": "arts-entertainment",
+    "permalink": "/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
+    "title": "EDITORIAL: Japan joining growing global trend of declining democracy - 朝日新聞",
     "date": "2026-05-11",
     "author": "Simone Hart",
     "desk": "opinion-editorials",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "subject": "arts-entertainment",
     "permalink": "/articles/2026-05-11-2026-american-music-awards-performers-lineup-expands/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/562"
   },
   {
     "title": "EDITORIAL: Japan joining growing global trend of declining democracy - 朝日新聞",


### PR DESCRIPTION
## Summary
Publishes one arts-entertainment desk article on the 2026 American Music Awards performer-lineup expansion.

## Duplicate/Update Gate
Decision: **New article** (no materially identical AMA performer-lineup story found in current repo corpus).
Canonical topic link: https://news.google.com/search?q=2026+American+Music+Awards+performers

## Claim Matrix (off-record)
1) Claim: Billboard reported additional announced performers for 2026 AMAs.
- Source: https://news.google.com/rss/articles/CBMiekFVX3lxTE5vTDk4QkhGLXpqTEl1X2lRUkZVd21wSW00VXJ0TElTbkVRRzVIcUxTZXhCalpMWkRGSEprbWRldkpxbGF2V2c0SjM1TGlnbUVrU1VGZlRPZ2ZsOXFyelNYZGFxOVd5aVJ5VXNfRWE4VkZma1R1bFhHNXZn?oc=5
2) Claim: Variety separately reported related performer additions.
- Source: https://news.google.com/rss/articles/CBMioAFBVV95cUxQQWpzSXR6U2o0WUdaSzlTdzZJa2Rra1cwcnpnLTZ2NjhIdVF2anNPRmx5bnNLVGVzaGtBMHN5eXBpRlM0VjFnMFVoVzJvNzhtUmc5UnBURjM3N2psdlJFNXZVVTlkVXRVaXpKTDVOVW1waGxTYUlUN2tpbVVKSUxhOWZjT0lSazhqdFN0WmFVOG50bGx4ODhmT1JWel9uWUtU?oc=5

## Source Discovery and Bias-Check Log (off-record)
- Discovery channel: Google News RSS query for 2026 AMAs performers.
- Desk-fit check: arts-entertainment (music awards programming + performer slate updates).
- Bias mitigation: used two independent entertainment trade publications (Billboard and Variety), avoided speculation beyond reported lineup expansion.

## Editorial Rationale and Safety Checks (off-record)
- Kept copy bounded to confirmed reporting and implications (audience reach and streaming impact) without fabricating performer names.
- Excluded internal workflow text from article body.
- Image generation fallback applied due unavailable image provider credentials.
