### PR TITLE
Environment: reported PFAS decline in seabird eggs linked to tighter controls

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "subject": "environment",
     "permalink": "/articles/2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/563"
   },
   {
     "id": "2026-05-11-2026-american-music-awards-performers-lineup-expands",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten",
+    "title": "PFAS levels in seabird eggs drop sharply as controls tighten, reports say",
+    "summary": "New reporting from The Guardian and Environmental Health News says PFAS concentrations in northern fulmar eggs have fallen substantially over recent decades, a trend researchers link to tighter controls on long-chain PFAS chemicals.",
+    "author": "Rowan Hale",
+    "author_id": "environment_lead",
+    "author_display_name": "Rowan Hale",
+    "date": "2026-05-11",
+    "category": "environment",
+    "subject": "environment",
+    "permalink": "/articles/2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-11-2026-american-music-awards-performers-lineup-expands",
     "title": "2026 American Music Awards Performer Lineup Expands Ahead of Memorial Day Broadcast",
     "summary": "Billboard and Variety report an expanding 2026 American Music Awards performer slate as producers continue final-week additions ahead of the Memorial Day broadcast.",

--- a/content/articles/2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten.md
+++ b/content/articles/2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten.md
@@ -1,0 +1,24 @@
+---
+title: "PFAS levels in seabird eggs drop sharply as controls tighten, reports say"
+date: "2026-05-11T18:08:38Z"
+author: "Rowan Hale"
+desk: "environment"
+summary: "New reporting from The Guardian and Environmental Health News says PFAS concentrations in northern fulmar eggs have fallen substantially over recent decades, a trend researchers link to tighter controls on long-chain PFAS chemicals."
+image: "/images/news-banner.png"
+published_pr_url: "TBD"
+---
+
+Monitoring data cited in new coverage indicate a sharp long-run decline in some PFAS (“forever chemicals”) measured in northern fulmar eggs, with researchers describing the drop as evidence that targeted regulation can reduce environmental burdens over time.
+
+The Guardian and Environmental Health News both report on a newly published analysis of archived seabird eggs from northern Europe. In those accounts, researchers describe major reductions in legacy PFAS compounds over roughly five decades, while noting that newer replacement chemicals and mixed exposure pathways still require close tracking.
+
+Why it matters: PFAS are persistent pollutants that can accumulate in food webs and are linked to health and ecosystem concerns. A measurable decline in legacy compounds suggests policy limits and phase-downs can work, but it does not eliminate exposure risks from the broader PFAS family.
+
+What to watch next:
+- Whether regulators expand restrictions from legacy compounds to a wider set of PFAS classes.
+- Follow-up monitoring on replacement chemicals in marine food chains.
+- Additional peer-reviewed data on how quickly declines translate across species and regions.
+
+Sources:
+- https://www.theguardian.com/environment/2026/may/11/pfas-seabird-eggs-forever-chemicals
+- https://www.ehn.org/pfas-seabird-eggs

--- a/content/articles/2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten.md
+++ b/content/articles/2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten.md
@@ -5,7 +5,7 @@ author: "Rowan Hale"
 desk: "environment"
 summary: "New reporting from The Guardian and Environmental Health News says PFAS concentrations in northern fulmar eggs have fallen substantially over recent decades, a trend researchers link to tighter controls on long-chain PFAS chemicals."
 image: "/images/news-banner.png"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/563"
 ---
 
 Monitoring data cited in new coverage indicate a sharp long-run decline in some PFAS (“forever chemicals”) measured in northern fulmar eggs, with researchers describing the drop as evidence that targeted regulation can reduce environmental burdens over time.


### PR DESCRIPTION
## Summary
Adds one environment-desk brief on reported declines in PFAS levels in northern fulmar eggs, with desk-matched framing and reader-facing sourcing.

## OFF-RECORD: Claim matrix
| Claim | Source | Confidence | Notes |
|---|---|---|---|
| Coverage reports substantial long-run decline in legacy PFAS in northern fulmar eggs | Guardian (2026-05-11), EHN (2026-05-11) | Medium | Attributed to reporting; primary journal page was access-limited in this runner.
| Reported decline is linked by researchers to regulatory actions on long-chain PFAS | Guardian, EHN | Medium | Framed as reported interpretation, not independent causal proof.
| Replacement/newer PFAS remain a monitoring concern | EHN, Guardian context | Medium | Included as cautionary context.

## OFF-RECORD: Source discovery and bias-check log
- Desk RNG selected **environment**; candidate feeds checked: BBC science/environment, Guardian environment, UNFCCC RSS.
- Chosen topic from Guardian environment feed was desk-consistent (pollution/regulation/ecosystem monitoring).
- Independent corroborator used: Environmental Health News coverage of same study thread.
- Bias checks:
  - Avoided single-source certainty language.
  - Avoided adding numerical claims not consistently retrievable across both sources.
  - Explicit attribution for interpretation claims.

## OFF-RECORD: Editorial rationale and safety checks
- No medical, legal, or financial advice content.
- No personally identifying/private data.
- No graphic or sensitive imagery requests.
- Article body excludes internal process notes, checklist text, or reviewer transcripts.

## OFF-RECORD: Initial staff discussion seed
Please review for:
1) strength of attribution wording on causality,
2) whether we should add a third citation once journal access opens,
3) headline precision vs readability.
