### PR TITLE
Update: U.S. revised U.N. Hormuz draft faces veto risk

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -11,7 +11,7 @@
     "subject": "world",
     "permalink": "/articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/565"
   },
   {
     "id": "2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat",
+    "title": "Update: U.S. push for U.N. Hormuz resolution faces China-Russia veto threat",
+    "summary": "Reuters reports the United States revised a Security Council resolution on Iran-related actions in the Strait of Hormuz, but China and Russia are still expected to oppose it, raising the odds of another diplomatic impasse at the U.N.",
+    "author": "Elias Navarro",
+    "author_id": "world_lead",
+    "author_display_name": "Elias Navarro",
+    "date": "2026-05-11",
+    "category": "world",
+    "subject": "world",
+    "permalink": "/articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-11-pfas-levels-in-seabird-eggs-drop-sharply-as-controls-tighten",
     "title": "PFAS levels in seabird eggs drop sharply as controls tighten, reports say",
     "summary": "New reporting from The Guardian and Environmental Health News says PFAS concentrations in northern fulmar eggs have fallen substantially over recent decades, a trend researchers link to tighter controls on long-chain PFAS chemicals.",

--- a/content/articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat.md
+++ b/content/articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat.md
@@ -5,7 +5,7 @@ author: "Elias Navarro"
 desk: "world"
 summary: "Reuters reports the United States revised a Security Council resolution on Iran-related actions in the Strait of Hormuz, but China and Russia are still expected to oppose it, raising the odds of another diplomatic impasse at the U.N."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/565"
 ---
 Update: U.S. push for U.N. Hormuz resolution faces China-Russia veto threat
 

--- a/content/articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat.md
+++ b/content/articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat.md
@@ -1,0 +1,31 @@
+---
+title: "Update: U.S. push for U.N. Hormuz resolution faces China-Russia veto threat"
+date: "2026-05-11"
+author: "Elias Navarro"
+desk: "world"
+summary: "Reuters reports the United States revised a Security Council resolution on Iran-related actions in the Strait of Hormuz, but China and Russia are still expected to oppose it, raising the odds of another diplomatic impasse at the U.N."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+Update: U.S. push for U.N. Hormuz resolution faces China-Russia veto threat
+
+The U.S. effort to move a new U.N. Security Council resolution tied to the Strait of Hormuz has entered a difficult phase, with Reuters reporting that China and Russia are still expected to oppose the measure despite revisions.
+
+### What’s New
+- Reuters reports U.S. diplomats revised draft language before bringing the proposal forward.
+- China and Russia are still seen as likely vetoes, indicating limited immediate consensus at the Security Council.
+- A U.N. item confirms Bahrain and the U.S. tabled a Security Council text tied to Hormuz, reinforcing that the dispute has moved into formal U.N. channels.
+
+### Why this is an update
+Earlier coverage tracked live U.S.-Iran war-and-ceasefire rhetoric. This update adds a distinct diplomatic development: a revised draft resolution at the U.N. and explicit veto risk from two permanent members.
+
+- Previous report: /articles/2026-05-11-iran-war-live-trump-calls-iran-s-response-to-latest-us-ceasefire-proposal-totally-unaccept/
+- This update permalink: /articles/2026-05-11-update-us-push-un-hormuz-resolution-faces-china-russia-veto-threat/
+
+### Why it matters
+If vetoes hold, the U.S. and partners may need to shift from Security Council action toward alternative diplomatic or sanctions pathways, potentially reshaping near-term maritime security coordination.
+
+### Sources
+- Reuters (via Google News syndication): https://news.google.com/rss/articles/CBMisAFBVV95cUxOb2xLRlZudF9PNnJLel9xSmtuT3Rma2hmV0U2cmZqN1JrajNzNElCMmRzOGJGVWpWZTFGZUFuSzVyd0t4LVhod3FxdUNoNGV6bDg4UTFHbDUtbWlGZnNTWlNsTU94aDBPd1JtUm5pazZzdUZpVVZIT2VlcDB0MTluNlNSdUtxTWZ6eFV5UWtMTjltVUhQWjM2NHVqdzJ5XzhrWXc4NkhDQjBvbHdhYTA1eg?oc=5
+- Reuters follow-up headline (via Google News syndication): https://news.google.com/rss/articles/CBMirwFBVV95cUxPZkw2aVVLZUxWTVBVMUtXV2xfOWk4eTVUMVlXajVtSzVQcERTckdRS1RIMUpzUFVvbTZ4NEZOZW85bWVrT3hEb3dSbmxVSE1yUlhOV0V4c2Z5V1JVdjh3RzFCVjk0UURDU2wta19PRk1RVlJoc3l2X1hONTJiaEwzeEhGal9xVVNXQnZCajJnUUJBSkVMTHAwRk1CaFpndWY1aHZhNWhIeHFzaVo1azNF?oc=5
+- United Nations item (via Google News syndication): https://news.google.com/rss/articles/CBMiV0FVX3lxTE5ZaDBzWE5VdzVCazJsT2xvQ25WUWlWQy1mMGFZbWJwMWZHdldwYU5wcldWamtDRm9YQmRIY1RRRlNpc1JlOWlIWDJGN0RSRlI4T1FOQWhmZw?oc=5


### PR DESCRIPTION
## Summary
World desk update on U.S. revised U.N. resolution and expected China/Russia veto risk.

## Off-record editorial package
### Claim matrix
1) U.S. revised Security Council draft language on Hormuz (Reuters syndication headlines).
2) China and Russia are still expected to veto (Reuters).
3) U.N. listing shows Bahrain and the U.S. floated Security Council text on Hormuz (UN listing).

### Source discovery + bias-check log
- Discovery query focused on world desk: UN Security Council + Hormuz.
- Prioritized wire + primary institutional listing.
- Excluded liveblog/opinion leads for hard-news writeup.

### Editorial rationale and safety checks
- Classified as Update due to material diplomatic-process change versus prior live-rhetoric piece.
- Attribution remains explicit; no unverified tactical/casualty claims.

### Internal process notes
- published_pr_url backfilled after PR creation.