### PR TITLE
fix: repair broken in-article cross-links

### DIFF
--- a/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
+++ b/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze.md
@@ -41,7 +41,7 @@ This development directly affects personal travel planning decisions — when to
 
 ## Update
 
-For the latest regional-angle follow-up, see: [Update: Europe Summer Travel Plans Face Wider Risk as Jet-Fuel Squeeze Spreads Across Airlines](/articles/2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands/).
+For the latest regional-angle follow-up, see: [Update: Europe Summer Travel Plans Face Wider Risk as Jet-Fuel Squeeze Spreads Across Airlines](../2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands/).
 
 ## Publishing PR
 

--- a/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal.md
+++ b/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal.md
@@ -31,4 +31,4 @@ Published via PR: [#25](https://github.com/thestamp/Static-ai-articles/pull/25)
 
 ## Update
 
-For the latest update on this deal, see: [Update: Warner Bros. Discovery Shareholders Approve Paramount Takeover, Reject CEO Payout Proposal](/articles/2026-04-24-update-warner-bros-shareholders-approve-paramount-takeover-reject-ceo-payout/)
+For the latest update on this deal, see: [Update: Warner Bros. Discovery Shareholders Approve Paramount Takeover, Reject CEO Payout Proposal](../2026-04-24-update-warner-bros-shareholders-approve-paramount-takeover-reject-ceo-payout/)

--- a/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
+++ b/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update.md
@@ -20,7 +20,7 @@ The U.S.-UK trade dispute widened after President Donald Trump said he would "pr
 ## Why This Is an Update
 AI Dispatch previously covered the diplomatic-repair framing around a possible royal visit in U.S.-UK relations. This update adds a **specific tariff threat linked to a named policy lever (digital services tax)**.
 
-Prior coverage: [/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations/](/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations/)
+Prior coverage: [/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations/](../2026-04-24-trump-king-charles-visit-repair-uk-us-relations/)
 
 ## What We Still Don’t Know
 - Whether Washington will formalize a tariff schedule, timeline, or legal mechanism.

--- a/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations.md
+++ b/articles/2026-04-24-trump-king-charles-visit-repair-uk-us-relations.md
@@ -38,4 +38,4 @@ This is a political-signaling story, not just protocol. Public comments from hea
 Published via PR: [#75](https://github.com/thestamp/Static-ai-articles/pull/75)
 
 
-> **Update (2026-04-24):** Follow-on coverage: [Trump Signals Possible UK Tariffs if Digital Services Tax Remains](/articles/2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update/)
+> **Update (2026-04-24):** Follow-on coverage: [Trump Signals Possible UK Tariffs if Digital Services Tax Remains](../2026-04-24-trump-big-tariff-threat-uk-digital-services-tax-update/)

--- a/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview.md
+++ b/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview.md
@@ -21,8 +21,8 @@ DeepSeek has previewed a new AI model version reported to be adapted for Huawei 
 
 ## Update Linkage (old ↔ new)
 
-- Previous coverage: [/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/](/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/)
-- This update: [/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/](/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/)
+- Previous coverage: [/articles/2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/](../2026-04-24-china-s-deepseek-says-releases-long-awaited-new-ai-model/)
+- This update: [/articles/2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/](../2026-04-24-update-deepseek-huawei-chip-optimized-ai-model-preview/)
 
 ## Why this matters for the technology desk
 

--- a/articles/2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands.md
+++ b/articles/2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands.md
@@ -23,13 +23,13 @@ This is a direct **consumer travel and lifestyle planning** story: it affects ho
 
 Compared with our prior coverage focused on Lufthansa-specific cuts, the latest reports frame the issue as a **multi-airline, region-wide summer travel constraint** with knock-on effects for fares and schedule reliability.
 
-- Prior coverage: [/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/](/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/)
+- Prior coverage: [/articles/2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/](../2026-04-23-lufthansa-cuts-20000-summer-flights-jet-fuel-squeeze/)
 - This update adds broader cross-outlet evidence of regional impact and watchpoints for travelers.
 
 ## What changed in the reporting
 
 
-- Newer update: [/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/](/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/)
+- Newer update: [/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/](../2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/)
 
 - Outlets now describe Europe-wide summer travel exposure rather than only one carrier’s operational adjustment.
 - Coverage ties disruption risk to both fuel availability and elevated input costs, not just standard seasonal schedule optimization.

--- a/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch.md
+++ b/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch.md
@@ -26,8 +26,8 @@ Compared with our earlier update, current reporting adds two material facts:
 1. **Carrier-specific UK cancellation detail** (not just region-wide disruption framing).
 2. **Stronger passenger-action guidance** on refund/rebooking expectations under disruption scenarios.
 
-- Prior update: [/articles/2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands/](/articles/2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands/)
-- This update: [/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/](/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/)
+- Prior update: [/articles/2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands/](../2026-04-24-update-europe-summer-travel-jet-fuel-squeeze-expands/)
+- This update: [/articles/2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/](../2026-04-24-update-uk-flight-cancellations-passenger-rights-jet-fuel-crunch/)
 
 ## Verified now vs still uncertain
 

--- a/articles/2026-04-24-update-warner-bros-shareholders-approve-paramount-takeover-reject-ceo-payout.md
+++ b/articles/2026-04-24-update-warner-bros-shareholders-approve-paramount-takeover-reject-ceo-payout.md
@@ -23,7 +23,7 @@ Warner Bros. Discovery shareholders have now approved Paramount’s proposed tak
 
 ## Context
 
-This report updates our earlier piece on the same event: [Warner Bros. Discovery Shareholders Vote on Paramount Deal](/articles/2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal/).
+This report updates our earlier piece on the same event: [Warner Bros. Discovery Shareholders Vote on Paramount Deal](../2026-04-23-warner-bros-discovery-shareholders-vote-paramount-deal/).
 
 ## Why this fits arts-entertainment
 

--- a/articles/2026-05-02-update-voting-rights-act-ruling-reshapes-redistricting-fight.md
+++ b/articles/2026-05-02-update-voting-rights-act-ruling-reshapes-redistricting-fight.md
@@ -30,8 +30,8 @@ In the long run, the ruling may deepen a broader legitimacy problem: voters incr
 If courts narrow federal remedies, legislatures inherit more responsibility for legitimacy. States that want durable public trust should pursue transparent criteria, independent map review mechanisms, and clearer disclosure around proposed district changes. Absent that, the default future is prolonged litigation, intensified polarization, and lower confidence in electoral fairness.
 
 ## Related coverage
-- Previous: [/articles/2026-04-29-supreme-court-limits-key-provision-of-the-landmark-voting-rights-act/](/articles/2026-04-29-supreme-court-limits-key-provision-of-the-landmark-voting-rights-act/)
-- News baseline: [/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering/](/articles/2026-05-02-supreme-court-ruling-expected-to-expand-gerrymandering/)
+- Previous: [/articles/2026-04-29-supreme-court-limits-key-provision-of-the-landmark-voting-rights-act/](../2026-04-29-supreme-court-limits-key-provision-of-the-landmark-voting-rights-act/)
+- News baseline: Supreme Court ruling expected to expand gerrymandering (link removed pending republish of source article).
 
 ## Sources
 - [SCOTUSblog: Court decides major Voting Rights Act case](https://www.scotusblog.com/)

--- a/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance.md
+++ b/articles/2026-05-03-update-cop31-hosting-deal-tests-climate-diplomacy-s-energy-security-balance.md
@@ -32,8 +32,8 @@ Governments keep promising faster decarbonization while simultaneously prioritiz
 Without that shift, COP31 risks producing familiar language and fragile consensus. With it, the summit could become a template for integrating climate ambition with security-era constraints.
 
 ## Related coverage
-- Previous: [/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/](/articles/2026-05-02-turkey-says-cop31-will-push-for-more-global-action-under-its-presidency/)
-- News baseline: [/articles/hard-choices-test-breakaway-climate-summit/](/articles/hard-choices-test-breakaway-climate-summit/)
+- Previous: Turkey says COP31 will push for more global action under its presidency (link removed pending republish of source article).
+- News baseline: [/articles/hard-choices-test-breakaway-climate-summit/](../hard-choices-test-breakaway-climate-summit/)
 
 ## Sources
 - [Reuters: Turkey set to host COP31 climate summit, Australia to lead government talks](https://www.reuters.com/)

--- a/articles/wellness-trends-2026-personalization-prevention-amp-real-life-well-being-take-ov.md
+++ b/articles/wellness-trends-2026-personalization-prevention-amp-real-life-well-being-take-ov.md
@@ -17,8 +17,8 @@ image: "/images/news-banner.png"
 
 ## What’s New
 - New verified developments since our earlier coverage.
-- Prior coverage: [Wellness Trends 2026: Personalization, Prevention & Real-Life Well-Being Take Over](/articles/2026-04-30-wellness-trends-2026-personalization-prevention-real-life-well-being-t/).
-- This update: [Wellness Trends 2026: Personalization, Prevention &amp; Real-Life Well-Being Take Over](/articles/wellness-trends-2026-personalization-prevention-amp-real-life-well-being-take-ov/).
+- Prior coverage: [Wellness Trends 2026: Personalization, Prevention & Real-Life Well-Being Take Over](../2026-04-30-wellness-trends-2026-personalization-prevention-real-life-well-being-t/).
+- This update: [Wellness Trends 2026: Personalization, Prevention &amp; Real-Life Well-Being Take Over](../wellness-trends-2026-personalization-prevention-amp-real-life-well-being-take-ov/).
 
 ## Why It Matters
 This development is significant for the lifestyle desk because it can affect policy, markets, institutions, or public behavior beyond the immediate headline cycle.


### PR DESCRIPTION
## Summary
- Replaced root-relative in-article links like `/articles/<slug>/` with sibling-relative links `../<slug>/` so links resolve correctly on GitHub Pages project site paths (`/Static-ai-articles/`).
- Removed two links that pointed to unpublished/missing article routes to prevent hard 404s.

## Verification
- Confirmed all remaining in-article cross-links resolve to 2xx on live site.
- Confirmed no remaining root-relative `/articles/...` links in `articles/*.md`.

## Root cause
Root-relative links in markdown resolved to `https://thestamp.github.io/articles/...` (missing `/Static-ai-articles/`), producing widespread 404s on cross-story links.