### PR TITLE
Fix metadata for PR #686 article card author fields

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,9 @@
     "subject": "environment",
     "permalink": "/articles/2026-05-23-climate-change-accountability-works-best-through-congress-not-courtrooms/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/686"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/686",
+    "author_id": "environment_lead",
+    "author_display_name": "Rowan Hale"
   },
   {
     "id": "2026-05-12-france-seeks-reset-with-african-partners-at-kenya-summit",


### PR DESCRIPTION
Post-merge integrity correction: add missing `author_id` and `author_display_name` to latest environment article entry.