### PR TITLE
news-politics: UK April borrowing hits highest level since pandemic

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-24-uk-april-borrowing-highest-since-pandemic",
+    "title": "UK April borrowing hits highest level since pandemic as debt-interest costs climb",
+    "summary": "UK public sector borrowing in April reached £24.3bn, the highest April total since 2020, as higher benefit and debt-interest costs offset stronger tax receipts.",
+    "author": "Maya Sterling",
+    "date": "2026-05-24",
+    "subject": "news-politics",
+    "category": "news-politics",
+    "permalink": "/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING_PR_URL"
+  },
+  {
     "id": "2026-05-24-opinion-who-should-write-america-s-ai-rules",
     "title": "Opinion: Who should write America’s AI rules?",
     "summary": "A new wave of commentary around federal review of advanced AI models is sharpening the core policy question: should Washington set one national framework, or should states keep moving first?",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "category": "news-politics",
     "permalink": "/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING_PR_URL"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/698"
   },
   {
     "id": "2026-05-24-opinion-who-should-write-america-s-ai-rules",

--- a/content/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic.md
+++ b/content/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic.md
@@ -1,0 +1,32 @@
+---
+id: "2026-05-24-uk-april-borrowing-highest-since-pandemic"
+title: "UK April borrowing hits highest level since pandemic as debt-interest costs climb"
+summary: "UK public sector borrowing in April reached £24.3bn, the highest April total since 2020, as higher benefit and debt-interest costs offset stronger tax receipts."
+author: "Maya Sterling"
+date: "2026-05-24"
+subject: "news-politics"
+category: "news-politics"
+permalink: "/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic/"
+image: "/images/news-banner.png"
+published_pr_url: "PENDING_PR_URL"
+---
+
+What happened
+- UK public sector borrowing in April was £24.3bn, up £4.9bn from a year earlier and the highest April figure since 2020, according to the Office for National Statistics (ONS).
+- ONS said higher tax receipts were more than offset by spending pressures, including inflation-linked benefit increases and higher debt-interest costs.
+
+Why it matters
+- The April borrowing print sets a difficult opening pace for the fiscal year and narrows room for discretionary spending moves later in 2026.
+- Debt-interest costs are becoming a larger budget constraint as gilt yields stay elevated.
+
+The latest figures
+- Net social benefits rose by £2.7bn year over year in April, while debt-interest payments reached a record £10.3bn for the month.
+- The data point to persistent cost pressure even as headline inflation has cooled from prior peaks.
+
+What to watch
+- Upcoming monthly borrowing releases for signs that April was a one-off volatility spike or the start of a higher borrowing trend.
+- Any fiscal-policy adjustments in response to debt-interest sensitivity and weaker growth assumptions.
+
+Sources
+- https://www.bbc.com/news/articles/ce9py7nx8j4o
+- https://www.ons.gov.uk/economy/governmentpublicsectorandtaxes/publicsectorfinance/bulletins/publicsectorfinances/april2026

--- a/content/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic.md
+++ b/content/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic.md
@@ -8,7 +8,7 @@ subject: "news-politics"
 category: "news-politics"
 permalink: "/articles/2026-05-24-uk-april-borrowing-highest-since-pandemic/"
 image: "/images/news-banner.png"
-published_pr_url: "PENDING_PR_URL"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/698"
 ---
 
 What happened


### PR DESCRIPTION
## Summary
Adds a new news-politics article on UK April public borrowing and updates article index.

## Claim matrix (off-record)
1. Claim: UK April borrowing was £24.3bn, highest April since 2020.
   - Source: BBC report citing ONS and ONS April 2026 bulletin.
2. Claim: Borrowing was up £4.9bn year-over-year.
   - Source: BBC report.
3. Claim: Net social benefits +£2.7bn YoY; debt-interest payments £10.3bn (record for April).
   - Source: BBC report with ONS attribution.

## Source discovery and bias-check log (off-record)
- Desk feed selection: BBC Politics RSS item from 2026-05-22/23 window.
- Corroboration: direct ONS bulletin used as primary official data source.
- Bias check: outlet framing minimized; article language keeps attribution to ONS/BBC and avoids partisan conclusions.

## Editorial rationale and safety checks (off-record)
- Desk fit: domestic fiscal/policy coverage aligns to news-politics desk.
- Recency: sources are within 48 hours.
- Safety: no sensitive personal data; no unverifiable casualty/security claims.

## Internal process notes (off-record)
- Image generation via gpt-image-1 unavailable (missing OPENAI_API_KEY), fallback image used: /images/news-banner.png
- published_pr_url to be backfilled after PR creation.
