### PR TITLE
[AI Dispatch] 007 First Light introduces younger Bond ahead of May 27 reveal

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "subject": "arts-entertainment",
     "permalink": "/articles/2026-05-25-007-first-light-james-bond-origin-game-reveal/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/734"
   },
   {
     "id": "can-ai-help-combat-the-climate-crisis-university-of-pennsylvania",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-25-007-first-light-james-bond-origin-game-reveal",
+    "title": "007 First Light reveals a younger Bond as IO Interactive sets May 27 showcase",
+    "summary": "BBC reporting and the game’s official site show IO Interactive’s upcoming James Bond title, 007 First Light, positioning the character as a younger MI6 recruit ahead of a May 27 reveal window.",
+    "author": "Camille Vega",
+    "date": "2026-05-25",
+    "category": "arts-entertainment",
+    "subject": "arts-entertainment",
+    "permalink": "/articles/2026-05-25-007-first-light-james-bond-origin-game-reveal/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "can-ai-help-combat-the-climate-crisis-university-of-pennsylvania",
     "title": "Can AI Help Combat the Climate Crisis? - University of Pennsylvania",
     "summary": "Latest developments: Can AI Help Combat the Climate Crisis? - University of Pennsylvania",
@@ -118,7 +130,7 @@
   {
     "id": "2026-05-24-us-week-ahead-key-economic-data",
     "title": "U.S. Week Ahead: Key Economic Reports Could Reframe Rate-Cut Bets",
-    "summary": "A dense run of U.S. releases in the coming week \u2014 including growth revisions, inflation signals and confidence gauges \u2014 could shift market expectations for when the Federal Reserve begins cutting rates.",
+    "summary": "A dense run of U.S. releases in the coming week — including growth revisions, inflation signals and confidence gauges — could shift market expectations for when the Federal Reserve begins cutting rates.",
     "author": "Priya Desai",
     "date": "2026-05-24",
     "category": "business-economy",
@@ -177,7 +189,7 @@
   },
   {
     "id": "2026-05-24-flavored-vapes-led-to-a-major-shake-up-at-the-fda-here-s-the-sci",
-    "title": "Flavored vapes led to a major shake\u2011up at the FDA \u2013 here's the science behind the controversial products",
+    "title": "Flavored vapes led to a major shake‑up at the FDA – here's the science behind the controversial products",
     "permalink": "/articles/2026-05-24-flavored-vapes-led-to-a-major-shake-up-at-the-fda-here-s-the-sci",
     "date": "2026-05-24",
     "author_id": "science_health_lead",
@@ -188,8 +200,8 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "Cannes Film Festival Winners List: Palme d\u2019Or Goes to \u2018Fjord,\u2019 Neon\u2019s Seventh in a Row - IndieWire",
-    "summary": "Cannes Film Festival Winners List: Palme d\u2019Or Goes to \u2018Fjord,\u2019 Neon\u2019s Seventh in a Row &nbsp;&nbsp; IndieWire",
+    "title": "Cannes Film Festival Winners List: Palme d’Or Goes to ‘Fjord,’ Neon’s Seventh in a Row - IndieWire",
+    "summary": "Cannes Film Festival Winners List: Palme d’Or Goes to ‘Fjord,’ Neon’s Seventh in a Row &nbsp;&nbsp; IndieWire",
     "link": "/articles/2026-05-24-cannes-film-festival-winners-list-palme-d-or-goes-to-fjord-neon-s-seve/",
     "date": "2026-05-24",
     "desk": "arts-entertainment",
@@ -211,7 +223,7 @@
   {
     "id": "2026-05-24-uk-april-borrowing-highest-since-pandemic",
     "title": "UK April borrowing hits highest level since pandemic as debt-interest costs climb",
-    "summary": "UK public sector borrowing in April reached \u00a324.3bn, the highest April total since 2020, as higher benefit and debt-interest costs offset stronger tax receipts.",
+    "summary": "UK public sector borrowing in April reached £24.3bn, the highest April total since 2020, as higher benefit and debt-interest costs offset stronger tax receipts.",
     "author": "Maya Sterling",
     "date": "2026-05-24",
     "subject": "news-politics",
@@ -222,7 +234,7 @@
   },
   {
     "id": "2026-05-24-opinion-who-should-write-america-s-ai-rules",
-    "title": "Opinion: Who should write America\u2019s AI rules?",
+    "title": "Opinion: Who should write America’s AI rules?",
     "summary": "A new wave of commentary around federal review of advanced AI models is sharpening the core policy question: should Washington set one national framework, or should states keep moving first?",
     "author": "Simone Hart",
     "date": "2026-05-24",
@@ -268,8 +280,8 @@
   },
   {
     "id": "2026-05-23-russia-s-war-against-ukraine-diplomatic-talks-and-u-s-policy-analysis",
-    "title": "Russia\u2019s War Against Ukraine: Diplomatic Talks And U.S. Policy \u2013 Analysis",
-    "summary": "Russia\u2019s War Against Ukraine: Diplomatic Talks And U.S. Policy \u2013 Analysis is a developing opinion-editorials story. Early verified details are still emerging.",
+    "title": "Russia’s War Against Ukraine: Diplomatic Talks And U.S. Policy – Analysis",
+    "summary": "Russia’s War Against Ukraine: Diplomatic Talks And U.S. Policy – Analysis is a developing opinion-editorials story. Early verified details are still emerging.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -354,7 +366,7 @@
   {
     "id": "2026-05-12-29-summer-salad-recipes-for-peak-produce-season",
     "title": "29 Summer Salad Recipes for Peak Produce Season",
-    "summary": "Juicy tomatoes, stone fruit, crunchy slaws\u2014these salads were made for hot days.",
+    "summary": "Juicy tomatoes, stone fruit, crunchy slaws—these salads were made for hot days.",
     "author": "Nico Laurent",
     "date": "2026-05-12",
     "category": "lifestyle",
@@ -413,13 +425,13 @@
     "author": "Nico Laurent",
     "date": "2026-05-11 22:36:29 UTC",
     "desk": "lifestyle",
-    "summary": "The Vogue Business TikTok Trend Tracker \u2014 key facts, context, and what to watch next.",
+    "summary": "The Vogue Business TikTok Trend Tracker — key facts, context, and what to watch next.",
     "link": "/articles/the-vogue-business-tiktok-trend-tracker-20260511/",
     "image": "/images/articles/the-vogue-business-tiktok-trend-tracker-20260511.png"
   },
   {
     "id": "2026-05-11-mortal-kombat-ii-opening-weekend-box-office-hits-40-million-in-the-uni",
-    "title": "\u2018Mortal Kombat II\u2019 Opening Weekend Box Office Hits $40 Million in the United States - Bloody Disgusting",
+    "title": "‘Mortal Kombat II’ Opening Weekend Box Office Hits $40 Million in the United States - Bloody Disgusting",
     "permalink": "/2026-05-11-mortal-kombat-ii-opening-weekend-box-office-hits-40-million-in-the-uni/",
     "date": "2026-05-11",
     "subject": "arts-entertainment",
@@ -486,7 +498,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/562"
   },
   {
-    "title": "EDITORIAL: Japan joining growing global trend of declining democracy - \u671d\u65e5\u65b0\u805e",
+    "title": "EDITORIAL: Japan joining growing global trend of declining democracy - 朝日新聞",
     "date": "2026-05-11",
     "author": "Simone Hart",
     "desk": "opinion-editorials",

--- a/content/articles/2026-05-25-007-first-light-james-bond-origin-game-reveal.md
+++ b/content/articles/2026-05-25-007-first-light-james-bond-origin-game-reveal.md
@@ -1,0 +1,23 @@
+---
+title: "007 First Light reveals a younger Bond as IO Interactive sets May 27 showcase"
+date: "2026-05-25"
+author: "Camille Vega"
+desk: "arts-entertainment"
+summary: "BBC reporting and the game’s official site show IO Interactive’s upcoming James Bond title, 007 First Light, positioning the character as a younger MI6 recruit ahead of a May 27 reveal window."
+image: "/images/news-banner.png"
+published_pr_url: "PENDING"
+---
+IO Interactive’s upcoming Bond game, **007 First Light**, is being positioned as a younger-origin take on James Bond rather than a direct adaptation of a film storyline.
+
+BBC coverage describes the project as a re-framing of the iconic spy with a more vulnerable early-career profile, while the official game site calls it a standalone origin story following Bond as an MI6 recruit.
+
+The timing matters for the entertainment industry because major franchise game launches now serve as both publishing events and cross-media brand resets. If successful, this title could broaden the Bond audience in gaming the way the films historically refreshed the character for new generations.
+
+What to watch next:
+- Details released around the announced **May 27** reveal window on official channels.
+- How much of the game leans into narrative origin-story structure versus open-ended spy sandbox design.
+- Whether early reception strengthens confidence in premium single-player franchise games tied to long-running film IP.
+
+Sources:
+- https://www.bbc.com/news/articles/cvgzdr177mvo
+- https://007firstlight.com/

--- a/content/articles/2026-05-25-007-first-light-james-bond-origin-game-reveal.md
+++ b/content/articles/2026-05-25-007-first-light-james-bond-origin-game-reveal.md
@@ -5,7 +5,7 @@ author: "Camille Vega"
 desk: "arts-entertainment"
 summary: "BBC reporting and the game’s official site show IO Interactive’s upcoming James Bond title, 007 First Light, positioning the character as a younger MI6 recruit ahead of a May 27 reveal window."
 image: "/images/news-banner.png"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/734"
 ---
 IO Interactive’s upcoming Bond game, **007 First Light**, is being positioned as a younger-origin take on James Bond rather than a direct adaptation of a film storyline.
 


### PR DESCRIPTION
## Summary
This PR adds one arts-entertainment article on IO Interactive's 007 First Light reveal positioning.

## Claim matrix (off-record)
1. Claim: 007 First Light is an origin-story framing for a younger Bond.
   - Source: BBC feature (2026-05-24)
   - Source: Official 007 First Light site copy
2. Claim: May 27 is the announced showcase window reference.
   - Source: Official 007 First Light site header copy
3. Claim: Game is developed/published by IO Interactive.
   - Source: Official site game description

## Source discovery + bias-check log (off-record)
- Desk route: arts-entertainment (RNG-assigned).
- Considered alternatives: festival-recap items and review pieces; rejected for weaker event signal.
- Selected because topic is a current franchise-gaming reveal with direct primary source and independent media framing.
- Bias check: official site has promotional framing; article attributes framing and avoids unverified commercial performance claims.

## Editorial rationale and safety checks (off-record)
- No sensitive personal data.
- No allegations of wrongdoing.
- Kept claims bounded to directly visible source statements.
- Avoided speculative sales/impact numbers.
