### PR TITLE
Update: Russia threatens more Kyiv strikes and tells foreign nationals to leave

### DIFF
--- a/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned.md
+++ b/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned.md
@@ -1,0 +1,35 @@
+---
+title: "Update: Russia threatens more Kyiv strikes and tells foreign nationals to leave"
+author: "Elias Navarro"
+author_id: "world_lead"
+author_display_name: "Elias Navarro"
+date: "2026-05-25"
+subject: "world"
+category: "world"
+status: "published"
+permalink: "/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+Russia signaled it could intensify strikes on Kyiv and urged foreign nationals to leave, after one of the heaviest recent waves of attacks on the Ukrainian capital. The warning marks an escalation in official rhetoric around the same conflict cycle covered earlier in the day.
+
+## What’s New
+
+- Russian officials publicly warned of additional strikes targeting Kyiv.
+- Moscow also told foreign nationals to leave the city, adding a civilian-risk signal beyond prior battlefield updates.
+- The development shifts the story from strike aftermath to explicit forward-looking threat messaging.
+
+## Why It Matters
+
+The warning could affect diplomatic calculations, embassy operations, and civilian movement planning in and around Kyiv. It also raises the risk of renewed volatility in the broader regional security picture.
+
+## Related Coverage
+
+- Earlier report: [/articles/2026-05-25-russian-strikes-hit-kyiv-dead-injured/](/articles/2026-05-25-russian-strikes-hit-kyiv-dead-injured/)
+- This update: [/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned/](/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned/)
+
+## Sources
+
+- BBC: https://www.bbc.com/news/articles/c1e22n55zn4o
+- Google News (discovery context): https://news.google.com/rss/headlines/section/topic/WORLD?hl=en-US&gl=US&ceid=US:en

--- a/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned.md
+++ b/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned.md
@@ -8,7 +8,7 @@ subject: "world"
 category: "world"
 status: "published"
 permalink: "/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/736"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned",
+    "title": "Update: Russia threatens more Kyiv strikes and tells foreign nationals to leave",
+    "summary": "BBC reports Russia warned of further Kyiv strikes and advised foreign nationals to leave, adding a forward-looking escalation signal after earlier attack reporting.",
+    "author": "Elias Navarro",
+    "date": "2026-05-25",
+    "category": "world",
+    "subject": "world",
+    "permalink": "/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-25-007-first-light-james-bond-origin-game-reveal",
     "title": "007 First Light reveals a younger Bond as IO Interactive sets May 27 showcase",
     "summary": "BBC reporting and the game’s official site show IO Interactive’s upcoming James Bond title, 007 First Light, positioning the character as a younger MI6 recruit ahead of a May 27 reveal window.",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "subject": "world",
     "permalink": "/articles/2026-05-25-update-russia-threatens-more-kyiv-strikes-foreign-nationals-warned/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/736"
   },
   {
     "id": "2026-05-25-007-first-light-james-bond-origin-game-reveal",


### PR DESCRIPTION
## Summary
Publishes a **world desk update** on renewed Russian strike warnings on Kyiv and guidance for foreign nationals to leave.

## Duplicate/Update Gate Decision
- Canonical prior story: /articles/2026-05-25-russian-strikes-hit-kyiv-dead-injured/
- Decision: **Update (material new facts)**
- Material delta: explicit forward-looking warning of more strikes and foreign-national departure guidance.

## Claim Matrix
1) Russia warned of additional Kyiv strikes.  
   - Source: BBC https://www.bbc.com/news/articles/c1e22n55zn4o
2) Foreign nationals were told to leave.  
   - Source: BBC https://www.bbc.com/news/articles/c1e22n55zn4o
3) This follows earlier same-day strike reporting in repo.  
   - Source: prior article permalink above.

## Source Discovery and Bias-Check Log
- Discovery channels attempted: Google News WORLD RSS, BBC World RSS.
- Reachability checks: BBC article accessible from runner.
- Bias check: relied on outlet with transparent attribution and constrained claims to directly reported facts.
- Excluded unverified social media claims and casualty-count inflation beyond source text.

## Editorial Rationale and Safety Checks
- Desk fit: geopolitical conflict escalation and cross-border risk signaling => **world** desk.
- Safety: no operational targeting details, no graphic content, no speculative military assertions.
- Scope control: one-article cap respected for this run.

## Internal Process Notes
- Image generation via OpenAI Images API `gpt-image-1` attempted but `OPENAI_API_KEY` unavailable in runner.
- Applied required fallback image: `/images/news-banner.png`.
