### PR TITLE
Sports: UCLA earns top NCAA baseball seed

### DIFF
--- a/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament.md
+++ b/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament.md
@@ -1,0 +1,25 @@
+---
+title: "UCLA earns No. 1 seed in NCAA baseball tournament after 51-6 regular season"
+author: "Jordan Reeves"
+author_id: "jordan-reeves"
+author_display_name: "Jordan Reeves"
+date: "2026-05-26"
+subject: "sports"
+category: "sports"
+status: "published"
+permalink: "/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament/"
+published_pr_url: "PENDING"
+image: "/images/news-banner.png"
+---
+
+UCLA was named the top overall seed for the 2026 NCAA Division I baseball tournament after finishing the regular season 51-6, according to ESPN's tournament seeding report and NCAA championship listings.
+
+The top-seed placement gives UCLA the most favorable bracket line entering regional play, where early matchups can heavily shape the path to Omaha. The seeding decision reflects both season-long results and committee evaluation of strength across conference and non-conference play.
+
+### Why this matters
+The No. 1 seed changes expectations for the entire field: UCLA becomes the team to beat, while other contenders are pushed into more difficult routes earlier in the tournament. For fans and analysts, it also sets a benchmark for comparing how committee priorities are applied across power-conference programs.
+
+### What to watch next
+Watch for regional bracket announcements, rotation decisions for UCLA's opening games, and any upset-heavy regional outcomes that could quickly reshape the projected College World Series field.
+
+**Sources:** [ESPN seeding report](https://www.espn.com/college-sports/story/_/id/48873507/ucla-51-6-earns-top-seed-ncaa-baseball-tournament); [NCAA baseball championships hub](https://www.ncaa.com/championships/baseball/d1).

--- a/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament.md
+++ b/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament.md
@@ -8,7 +8,7 @@ subject: "sports"
 category: "sports"
 status: "published"
 permalink: "/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament/"
-published_pr_url: "PENDING"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/741"
 image: "/images/news-banner.png"
 ---
 

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "subject": "sports",
     "permalink": "/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "PENDING"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/741"
   },
   {
     "id": "2026-05-25-ncaa-womens-golf-championship-match-play-cut",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-26-ucla-top-seed-ncaa-baseball-tournament",
+    "title": "UCLA earns No. 1 seed in NCAA baseball tournament after 51-6 regular season",
+    "summary": "UCLA secured the No. 1 national seed in the NCAA Division I baseball tournament after a 51-6 regular season, setting the tone for the regional bracket phase.",
+    "author": "Jordan Reeves",
+    "date": "2026-05-26",
+    "category": "sports",
+    "subject": "sports",
+    "permalink": "/articles/2026-05-26-ucla-top-seed-ncaa-baseball-tournament/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "PENDING"
+  },
+  {
     "id": "2026-05-25-ncaa-womens-golf-championship-match-play-cut",
     "title": "NCAA women’s golf championship moves into match-play bracket after field cut",
     "summary": "NCAA championship coverage and live tournament reporting show the Division I women’s field narrowing to match play after stroke-play rounds, setting up the title chase at Omni La Costa.",


### PR DESCRIPTION
## Summary
Publishes one sports desk article on UCLA earning the No. 1 NCAA baseball tournament seed.

## Claim matrix (off-record)
1. UCLA was awarded the No. 1 NCAA baseball tournament seed after a 51-6 regular season.
   - Source: ESPN report (linked in article)
2. The item is a current sports desk topic tied to national tournament bracket positioning.
   - Sources: ESPN and NCAA championship hub

## Source discovery and bias-check log (off-record)
- Discovery pass 1: Google News RSS sports feed produced candidate list.
- Canonical source selection: ESPN direct report URL used in article body.
- Secondary corroboration: NCAA championships hub for tournament context.
- Bias check: avoided speculative claims on outcomes; framed only confirmed seeding and implications.

## Editorial rationale and safety checks (off-record)
- Desk-fit: sports-only event with direct NCAA tournament relevance.
- Language check: no defamation/speculation; only attributed facts.
- Metadata consistency: title/summary/subject/category/permalink/image aligned across article and articles.json.

## Internal process notes (off-record)
- Image generation fallback used due missing OPENAI_API_KEY in runner; used /images/news-banner.png per policy.
