### PR TITLE
Update: U.S. launches new strikes on southern Iran as talks resume in Qatar

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "subject": "world",
     "permalink": "/articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/745"
   },
   {
     "id": "2026-05-26-google-io-2026-ai-announcements-roundup",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,8 +1,20 @@
 [
   {
+    "id": "2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks",
+    "title": "Update: U.S. launches new strikes on southern Iran as talks resume in Qatar",
+    "summary": "Fresh reporting indicates U.S. military strikes in southern Iran coincided with renewed Qatar talks, marking a new escalation point in the broader Iran conflict tracked earlier this month.",
+    "author": "Elias Navarro",
+    "date": "2026-05-26",
+    "category": "world",
+    "subject": "world",
+    "permalink": "/articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-26-google-io-2026-ai-announcements-roundup",
     "title": "Google I/O 2026 spotlights Gemini upgrades and developer-focused AI rollout",
-    "summary": "Google\u2019s I/O 2026 announcements emphasize Gemini model improvements and new developer integrations, signaling a deeper push to turn flagship AI capabilities into production-ready tools across products and APIs.",
+    "summary": "Google’s I/O 2026 announcements emphasize Gemini model improvements and new developer integrations, signaling a deeper push to turn flagship AI capabilities into production-ready tools across products and APIs.",
     "author": "Adeline Park",
     "date": "2026-05-26",
     "category": "technology",
@@ -25,8 +37,8 @@
   },
   {
     "id": "2026-05-25-ncaa-womens-golf-championship-match-play-cut",
-    "title": "NCAA women\u2019s golf championship moves into match-play bracket after field cut",
-    "summary": "NCAA championship coverage and live tournament reporting show the Division I women\u2019s field narrowing to match play after stroke-play rounds, setting up the title chase at Omni La Costa.",
+    "title": "NCAA women’s golf championship moves into match-play bracket after field cut",
+    "summary": "NCAA championship coverage and live tournament reporting show the Division I women’s field narrowing to match play after stroke-play rounds, setting up the title chase at Omni La Costa.",
     "author": "Jordan Reeves",
     "date": "2026-05-25",
     "category": "sports",
@@ -71,7 +83,7 @@
   {
     "id": "2026-05-25-007-first-light-james-bond-origin-game-reveal",
     "title": "007 First Light reveals a younger Bond as IO Interactive sets May 27 showcase",
-    "summary": "BBC reporting and the game\u2019s official site show IO Interactive\u2019s upcoming James Bond title, 007 First Light, positioning the character as a younger MI6 recruit ahead of a May 27 reveal window.",
+    "summary": "BBC reporting and the game’s official site show IO Interactive’s upcoming James Bond title, 007 First Light, positioning the character as a younger MI6 recruit ahead of a May 27 reveal window.",
     "author": "Camille Vega",
     "date": "2026-05-25",
     "category": "arts-entertainment",
@@ -199,7 +211,7 @@
   {
     "id": "2026-05-24-us-week-ahead-key-economic-data",
     "title": "U.S. Week Ahead: Key Economic Reports Could Reframe Rate-Cut Bets",
-    "summary": "A dense run of U.S. releases in the coming week \u2014 including growth revisions, inflation signals and confidence gauges \u2014 could shift market expectations for when the Federal Reserve begins cutting rates.",
+    "summary": "A dense run of U.S. releases in the coming week — including growth revisions, inflation signals and confidence gauges — could shift market expectations for when the Federal Reserve begins cutting rates.",
     "author": "Priya Desai",
     "date": "2026-05-24",
     "category": "business-economy",
@@ -258,7 +270,7 @@
   },
   {
     "id": "2026-05-24-flavored-vapes-led-to-a-major-shake-up-at-the-fda-here-s-the-sci",
-    "title": "Flavored vapes led to a major shake\u2011up at the FDA \u2013 here's the science behind the controversial products",
+    "title": "Flavored vapes led to a major shake‑up at the FDA – here's the science behind the controversial products",
     "permalink": "/articles/2026-05-24-flavored-vapes-led-to-a-major-shake-up-at-the-fda-here-s-the-sci",
     "date": "2026-05-24",
     "author_id": "science_health_lead",
@@ -269,8 +281,8 @@
     "image": "/images/news-banner.png"
   },
   {
-    "title": "Cannes Film Festival Winners List: Palme d\u2019Or Goes to \u2018Fjord,\u2019 Neon\u2019s Seventh in a Row - IndieWire",
-    "summary": "Cannes Film Festival Winners List: Palme d\u2019Or Goes to \u2018Fjord,\u2019 Neon\u2019s Seventh in a Row &nbsp;&nbsp; IndieWire",
+    "title": "Cannes Film Festival Winners List: Palme d’Or Goes to ‘Fjord,’ Neon’s Seventh in a Row - IndieWire",
+    "summary": "Cannes Film Festival Winners List: Palme d’Or Goes to ‘Fjord,’ Neon’s Seventh in a Row &nbsp;&nbsp; IndieWire",
     "link": "/articles/2026-05-24-cannes-film-festival-winners-list-palme-d-or-goes-to-fjord-neon-s-seve/",
     "date": "2026-05-24",
     "desk": "arts-entertainment",
@@ -292,7 +304,7 @@
   {
     "id": "2026-05-24-uk-april-borrowing-highest-since-pandemic",
     "title": "UK April borrowing hits highest level since pandemic as debt-interest costs climb",
-    "summary": "UK public sector borrowing in April reached \u00a324.3bn, the highest April total since 2020, as higher benefit and debt-interest costs offset stronger tax receipts.",
+    "summary": "UK public sector borrowing in April reached £24.3bn, the highest April total since 2020, as higher benefit and debt-interest costs offset stronger tax receipts.",
     "author": "Maya Sterling",
     "date": "2026-05-24",
     "subject": "news-politics",
@@ -303,7 +315,7 @@
   },
   {
     "id": "2026-05-24-opinion-who-should-write-america-s-ai-rules",
-    "title": "Opinion: Who should write America\u2019s AI rules?",
+    "title": "Opinion: Who should write America’s AI rules?",
     "summary": "A new wave of commentary around federal review of advanced AI models is sharpening the core policy question: should Washington set one national framework, or should states keep moving first?",
     "author": "Simone Hart",
     "date": "2026-05-24",
@@ -349,8 +361,8 @@
   },
   {
     "id": "2026-05-23-russia-s-war-against-ukraine-diplomatic-talks-and-u-s-policy-analysis",
-    "title": "Russia\u2019s War Against Ukraine: Diplomatic Talks And U.S. Policy \u2013 Analysis",
-    "summary": "Russia\u2019s War Against Ukraine: Diplomatic Talks And U.S. Policy \u2013 Analysis is a developing opinion-editorials story. Early verified details are still emerging.",
+    "title": "Russia’s War Against Ukraine: Diplomatic Talks And U.S. Policy – Analysis",
+    "summary": "Russia’s War Against Ukraine: Diplomatic Talks And U.S. Policy – Analysis is a developing opinion-editorials story. Early verified details are still emerging.",
     "author": "Simone Hart",
     "author_id": "opinion_editorials_lead",
     "author_display_name": "Simone Hart",
@@ -435,7 +447,7 @@
   {
     "id": "2026-05-12-29-summer-salad-recipes-for-peak-produce-season",
     "title": "29 Summer Salad Recipes for Peak Produce Season",
-    "summary": "Juicy tomatoes, stone fruit, crunchy slaws\u2014these salads were made for hot days.",
+    "summary": "Juicy tomatoes, stone fruit, crunchy slaws—these salads were made for hot days.",
     "author": "Nico Laurent",
     "date": "2026-05-12",
     "category": "lifestyle",
@@ -494,13 +506,13 @@
     "author": "Nico Laurent",
     "date": "2026-05-11 22:36:29 UTC",
     "desk": "lifestyle",
-    "summary": "The Vogue Business TikTok Trend Tracker \u2014 key facts, context, and what to watch next.",
+    "summary": "The Vogue Business TikTok Trend Tracker — key facts, context, and what to watch next.",
     "link": "/articles/the-vogue-business-tiktok-trend-tracker-20260511/",
     "image": "/images/articles/the-vogue-business-tiktok-trend-tracker-20260511.png"
   },
   {
     "id": "2026-05-11-mortal-kombat-ii-opening-weekend-box-office-hits-40-million-in-the-uni",
-    "title": "\u2018Mortal Kombat II\u2019 Opening Weekend Box Office Hits $40 Million in the United States - Bloody Disgusting",
+    "title": "‘Mortal Kombat II’ Opening Weekend Box Office Hits $40 Million in the United States - Bloody Disgusting",
     "permalink": "/2026-05-11-mortal-kombat-ii-opening-weekend-box-office-hits-40-million-in-the-uni/",
     "date": "2026-05-11",
     "subject": "arts-entertainment",
@@ -567,7 +579,7 @@
     "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/562"
   },
   {
-    "title": "EDITORIAL: Japan joining growing global trend of declining democracy - \u671d\u65e5\u65b0\u805e",
+    "title": "EDITORIAL: Japan joining growing global trend of declining democracy - 朝日新聞",
     "date": "2026-05-11",
     "author": "Simone Hart",
     "desk": "opinion-editorials",

--- a/content/articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks.md
+++ b/content/articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks.md
@@ -5,7 +5,7 @@ author: "Elias Navarro"
 desk: "world"
 summary: "Fresh reporting indicates U.S. military strikes in southern Iran coincided with renewed Qatar talks, marking a new escalation point in the broader Iran conflict tracked earlier this month."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/745"
 ---
 New reporting from multiple world desks indicates U.S. forces carried out additional strikes in southern Iran while diplomatic contacts resumed in Qatar, introducing a sharper military-diplomatic split into the same news cycle.
 

--- a/content/articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks.md
+++ b/content/articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks.md
@@ -1,0 +1,35 @@
+---
+title: "Update: U.S. launches new strikes on southern Iran as talks resume in Qatar"
+date: "2026-05-26"
+author: "Elias Navarro"
+desk: "world"
+summary: "Fresh reporting indicates U.S. military strikes in southern Iran coincided with renewed Qatar talks, marking a new escalation point in the broader Iran conflict tracked earlier this month."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+New reporting from multiple world desks indicates U.S. forces carried out additional strikes in southern Iran while diplomatic contacts resumed in Qatar, introducing a sharper military-diplomatic split into the same news cycle.
+
+### What’s New
+- BBC and Al Jazeera both report fresh U.S. military strikes in southern Iran.
+- The strikes were reported alongside resumed talks in Qatar, signaling parallel escalation and diplomacy.
+- The timing creates new uncertainty over whether talks can contain near-term regional spillover.
+
+### Why this is an update
+This story advances our prior conflict coverage with a specific new military development and a simultaneous diplomatic track.
+
+- Previous coverage: /articles/2026-05-11-iran-war-live-trump-calls-iran-s-response-to-latest-us-ceasefire-proposal-totally-unaccept/
+- This update: /articles/2026-05-26-update-us-launches-new-strikes-on-southern-iran-amid-qatar-talks/
+
+Why this matters for the world desk:
+- It affects cross-border security dynamics in the Gulf and wider Middle East.
+- It changes the risk picture for diplomacy, shipping, and regional actors.
+- It adds immediate context for government and multilateral responses.
+
+What to watch next:
+- Whether Qatar-hosted talks produce a formal de-escalation framework.
+- Any confirmed casualty, targeting, or retaliation details from official statements.
+- Reactions from regional governments and UN channels.
+
+Sources:
+- https://www.bbc.com/news/articles/cvgzzn4y1n8o
+- https://www.aljazeera.com/news/2026/5/26/us-military-launches-strikes-on-southern-iran-amid-talks-in-qatar


### PR DESCRIPTION
## Summary
This PR adds a **world desk update** article on newly reported U.S. strikes in southern Iran occurring alongside resumed Qatar talks.

## Off-record editorial/meta notes (not included in article)
### Claim matrix
1. **Claim:** New U.S. strikes were launched in southern Iran.  
   - Source A: BBC world RSS-linked report  
   - Source B: Al Jazeera world report  
   - Status: Reported by multiple outlets; framed as developing.
2. **Claim:** Talks resumed in Qatar in the same cycle.  
   - Source A: NYT world live headline context  
   - Source B: Al Jazeera report framing  
   - Status: Treated as concurrent diplomatic context.
3. **Claim:** This is a material update relative to prior site coverage.  
   - Prior: /articles/2026-05-11-iran-war-live-trump-calls-iran-s-response-to-latest-us-ceasefire-proposal-totally-unaccept/  
   - New: Adds fresh strike timing + diplomacy concurrency.

### Source discovery + bias-check log
- Desk-constrained topic scan performed from world feeds (BBC, NYT, Al Jazeera).
- Chosen item prioritized for timeliness and clear world-desk fit.
- Bias check: paired US/Western outlet headline context (BBC/NYT) with non-Western international outlet (Al Jazeera).
- Language in article avoids unverified casualty/attribution specifics.

### Editorial rationale and safety checks
- Marked as **Update:** due to prior event coverage and newly reported developments.
- Kept claims narrow and attributed.
- No graphic content, no operational targeting details, and no unverifiable intelligence assertions.
