### PR TITLE
Gucci turns Times Square into a runway as Demna debuts Cruise 2027 with celebrity cast

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "subject": "lifestyle",
     "permalink": "/articles/2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show/",
     "image": "/images/news-banner.png",
-    "published_pr_url": "TBD"
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/757"
   },
   {
     "id": "2026-05-26-global-leaders-denounce-massive-attack-on-kyiv-as-albanian-ambassador-narrowly-e",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show",
+    "title": "Gucci turns Times Square into a runway as Demna debuts Cruise 2027 with celebrity cast",
+    "summary": "Multiple entertainment and fashion outlets reported Gucci's Times Square Cruise 2027 show, where Demna's debut for the house drew a celebrity-heavy runway and signaled New York's growing pull as a global fashion-stage venue.",
+    "author": "Nico Laurent",
+    "date": "2026-05-26",
+    "category": "lifestyle",
+    "subject": "lifestyle",
+    "permalink": "/articles/2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": "TBD"
+  },
+  {
     "id": "2026-05-26-global-leaders-denounce-massive-attack-on-kyiv-as-albanian-ambassador-narrowly-e",
     "title": "Global leaders condemn major strike on Kyiv after overnight missile and drone barrage",
     "summary": "Fresh world-desk reporting indicates multiple governments condemned a large-scale overnight missile and drone attack on Kyiv, underscoring widening diplomatic pressure as the war’s cross-border risks persist.",

--- a/content/articles/2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show.md
+++ b/content/articles/2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show.md
@@ -5,7 +5,7 @@ author: "Nico Laurent"
 desk: "lifestyle"
 summary: "Multiple entertainment and fashion outlets reported Gucci's Times Square Cruise 2027 show, where Demna's debut for the house drew a celebrity-heavy runway and signaled New York's growing pull as a global fashion-stage venue."
 image: "/images/news-banner.png"
-published_pr_url: "TBD"
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/757"
 ---
 Gucci converted Times Square into a full-scale runway production for its Cruise 2027 presentation, marking a high-visibility New York debut for designer Demna at the brand.
 

--- a/content/articles/2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show.md
+++ b/content/articles/2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show.md
@@ -1,0 +1,27 @@
+---
+title: "Gucci turns Times Square into a runway as Demna debuts Cruise 2027 with celebrity cast"
+date: "2026-05-26"
+author: "Nico Laurent"
+desk: "lifestyle"
+summary: "Multiple entertainment and fashion outlets reported Gucci's Times Square Cruise 2027 show, where Demna's debut for the house drew a celebrity-heavy runway and signaled New York's growing pull as a global fashion-stage venue."
+image: "/images/news-banner.png"
+published_pr_url: "TBD"
+---
+Gucci converted Times Square into a full-scale runway production for its Cruise 2027 presentation, marking a high-visibility New York debut for designer Demna at the brand.
+
+Coverage across major fashion and entertainment outlets described a celebrity-forward staging that blended spectacle marketing with a strategic push to re-center luxury storytelling in public urban space rather than traditional closed venues.
+
+Why this fits the lifestyle desk:
+- The event is a fashion-industry cultural moment with direct relevance to style audiences.
+- It combines celebrity influence, brand positioning, and public-space design in a single consumer-culture event.
+- It reflects broader lifestyle trends where fashion launches are engineered as mass-audience media moments.
+
+What to watch next:
+- Whether Gucci sustains this open-city runway format in future collections.
+- Early retail and brand-sentiment signals after the Cruise 2027 rollout.
+- How competing houses respond in New York and other global city centers.
+
+Sources:
+- https://www.nytimes.com/2026/05/18/style/gucci-times-square-cruise.html
+- https://www.vogue.com/article/gucci-resort-2027-show-times-square
+- https://www.vanityfair.com/style/story/tom-brady-mariah-carey-and-lindsay-lohan-walk-into-times-square-inside-guccis-new-york-takeover


### PR DESCRIPTION
## Summary
Publish one lifestyle desk story on Gucci's Times Square Cruise 2027 show.

## Claim matrix (off-record)
- Claim: Gucci staged Cruise 2027 in Times Square as Demna debut context.
  - Source: NYT style report.
- Claim: Event had celebrity-heavy front row/runway visibility.
  - Sources: Vogue + Vanity Fair coverage.
- Claim: Lifestyle relevance is fashion/culture consumer trend, not politics/business hard-news framing.
  - Editorial determination based on source mix.

## Source discovery and bias-check log (off-record)
- Desk RNG selected lifestyle.
- Attempted lifestyle feeds; rejected cross-desk hard-news entries.
- Selected event-driven fashion item with multi-outlet corroboration.
- Bias controls: avoided promotional phrasing; attributed observations to outlet reporting.

## Editorial rationale and safety checks (off-record)
- No medical/legal/financial advice.
- No unverifiable casualty/conflict claims.
- Article body excludes internal workflow metadata.
