### PR TITLE
Update: NCAA women’s golf championship moves into live-result phase

### DIFF
--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -9,7 +9,7 @@
     "subject": "sports",
     "permalink": "/articles/2026-05-26-update-ncaa-womens-golf-championship-live-results/",
     "image": "/images/news-banner.png",
-    "published_pr_url": ""
+    "published_pr_url": "https://github.com/thestamp/Static-ai-articles/pull/759"
   },
   {
     "id": "2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show",

--- a/assets/data/articles.json
+++ b/assets/data/articles.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "2026-05-26-update-ncaa-womens-golf-championship-live-results",
+    "title": "Update: NCAA women’s golf championship moves from selections to live results",
+    "summary": "NCAA championship coverage shifted from bracket selection context to live-result tracking, adding fresh competitive outcomes and schedule clarity beyond the prior match-play cutoff report.",
+    "author": "Jordan Reeves",
+    "date": "2026-05-26",
+    "category": "sports",
+    "subject": "sports",
+    "permalink": "/articles/2026-05-26-update-ncaa-womens-golf-championship-live-results/",
+    "image": "/images/news-banner.png",
+    "published_pr_url": ""
+  },
+  {
     "id": "2026-05-26-gucci-turns-times-square-into-runway-for-cruise-2027-show",
     "title": "Gucci turns Times Square into a runway as Demna debuts Cruise 2027 with celebrity cast",
     "summary": "Multiple entertainment and fashion outlets reported Gucci's Times Square Cruise 2027 show, where Demna's debut for the house drew a celebrity-heavy runway and signaled New York's growing pull as a global fashion-stage venue.",

--- a/content/articles/2026-05-26-update-ncaa-womens-golf-championship-live-results.md
+++ b/content/articles/2026-05-26-update-ncaa-womens-golf-championship-live-results.md
@@ -1,0 +1,24 @@
+---
+title: "Update: NCAA women’s golf championship moves from selections to live results"
+date: "2026-05-26"
+author: "Jordan Reeves"
+desk: "sports"
+summary: "NCAA championship coverage shifted from bracket selection context to live-result tracking, adding fresh competitive outcomes and schedule clarity beyond the prior match-play cutoff report."
+image: "/images/news-banner.png"
+published_pr_url: ""
+---
+NCAA women’s golf championship coverage has moved from selection framing into active result-tracking as postseason play advances.
+
+What’s New
+- Tournament coverage is now centered on live results and round-by-round outcomes rather than only bracket setup.
+- Updated schedule/result tracking clarifies how the championship field is progressing through the current phase.
+- Broad sports-desk attention remains focused on whether top-seeded programs convert early positioning into title momentum.
+
+Why it matters
+The shift from selection headlines to live-result reporting is the key development for readers following championship trajectory, matchup implications, and near-term title outlook.
+
+Previous coverage
+- /articles/2026-05-25-ncaa-womens-golf-championship-match-play-cut/
+
+Current source
+- https://news.google.com/rss/articles/CBMitwFBVV95cUxOUVJhTkhQS1JNcTZjclZiV0xXSzNWMDRVREhnMklzOGhiZW9VZC1VNEVTcGpNYlRpaEVDM0hwSlhyZmtNNVhIeGRKZ0FtSUVJTUhwV2pyMlVhNnVJMGZPOTZqdjlBOEU0Nnd3RUZCa0VmdFZYd3RyM1JneVBLel9NZVBVRVQtdG1WTS1ocFRTLVZlV0JGMWRZU2JTT3lsa0lmM1M4T3RaMDZqNVFDNTE5aFpKX2NnaVXSAbwBQVVfeXFMUFNQWXd5NjRabk5id25NbW5Hbm5yZ0p3UVQ5TWk1YkFrbHhUN0ZfelQ1SGpjc005emZXVHdxRHZUaFF1VGd4RS1CRWhEdFFQc2hIOFBXbEx2aUM2b1hVUEQ3X1ZLYk1KWEl0dkV6UGl4WjRoS0lGeS10WHRfUndfTTFrc2VyUkpYY05XN3lseEl6TXhVeXlGLS1keGd5am9paGROemZNV05YZko4dW5Vei0yNGVXRzhmYmZjZkY?oc=5

--- a/content/articles/2026-05-26-update-ncaa-womens-golf-championship-live-results.md
+++ b/content/articles/2026-05-26-update-ncaa-womens-golf-championship-live-results.md
@@ -5,7 +5,7 @@ author: "Jordan Reeves"
 desk: "sports"
 summary: "NCAA championship coverage shifted from bracket selection context to live-result tracking, adding fresh competitive outcomes and schedule clarity beyond the prior match-play cutoff report."
 image: "/images/news-banner.png"
-published_pr_url: ""
+published_pr_url: "https://github.com/thestamp/Static-ai-articles/pull/759"
 ---
 NCAA women’s golf championship coverage has moved from selection framing into active result-tracking as postseason play advances.
 


### PR DESCRIPTION
## Summary
Sports desk update on NCAA women’s golf championship progression from selection framing to live results.

## Off-record: claim matrix
- Claim: coverage focus shifted to live results. Source: NCAA.com syndication via Google News item selected this run.
- Claim: this is a material update versus prior match-play cutoff story. Source: prior article permalink /articles/2026-05-25-ncaa-womens-golf-championship-match-play-cut/.

## Off-record: source discovery and bias-check log
- Attempt 1 succeeded on sports-specific query and desk-fit gate.
- Cross-desk candidates were skipped by keyword gate.
- Source bias note: governing-body source can over-emphasize promotional framing; article language kept neutral/process-focused.

## Off-record: editorial rationale and safety checks
- Decision: Update (not duplicate) because event stage advanced from selection framing to active results tracking.
- No unverifiable casualty/financial/medical claims included.
- Article body excludes internal process notes, logs, and approval metadata.

## Internal discussion seed
Please review whether “What’s New” clearly distinguishes this update from prior coverage and if additional independent corroboration should be added before publish.
